### PR TITLE
MySQL::tables() returns indexed array or throws exception

### DIFF
--- a/src/Data/Storage/MySQL.php
+++ b/src/Data/Storage/MySQL.php
@@ -771,8 +771,10 @@ class MySQL extends Storage implements IData
 			$tables[] = $table;
 		}
 
-		if (empty($tables) && $this->config(self::NAME_FIELD)) {
-			$tables = Arr::toArray( $this->config(self::NAME_FIELD) ) );
+		if (!empty($tables)) {
+			return $tables;
+		} elseif ($this->config(self::NAME_FIELD)) {
+			$tables = Arr::toArray($this->config(self::NAME_FIELD));
 		} else {
 			throw new \Exception("No tables found in the database or configuration.");
 		}


### PR DESCRIPTION
Avoids MySQL errors when table is not found in database or mis-configured, throws and exception