### PR TITLE
Until Element Updates for Vibe and Parsing

### DIFF
--- a/src/Parsing/Registry/TagRegistry.php
+++ b/src/Parsing/Registry/TagRegistry.php
@@ -229,6 +229,14 @@ class TagRegistry {
         ));
 
         self::register(new TagDefinition(
+            name: 'until',
+            pattern: '{open}\#until(.*?)?{close}(.*?){open}\/until{close}',
+            attributes: ['validator', 'max', 'limit', 'attempts'],
+            interface: Contracts\ILoopElement::class,
+            class: Elements\UntilElement::class
+        ));
+
+        self::register(new TagDefinition(
             name: 'await',
             pattern: '{open}\#await(.*?)?{close}(.*?){open}\/await{close}',
             attributes: ['event'],

--- a/tests/Parsing/AdditionalTagsTest.php
+++ b/tests/Parsing/AdditionalTagsTest.php
@@ -29,6 +29,15 @@ class AdditionalTagsTest extends ParsingTestCase
         $this->assertSame('AB', $output);
     }
 
+    public function testUntilStopsWhenValidatorPasses()
+    {
+        $template = '{#until validator=notEmpty}Hello{/until}';
+        $parser = new Parser($template);
+        $output = $parser->render();
+
+        $this->assertSame('Hello', $output);
+    }
+
     public function testMacroTagIsRegistered()
     {
         $definition = TagRegistry::get('macro');


### PR DESCRIPTION
Intent Summary
  Fix {#until} loop behavior so validator-driven regeneration works as expected and matches the ILoopElement contract.

  User Stories / Acceptance Criteria

  - As a Vibe/Vibrato author, I can define {#until validator=...} blocks that re-render until a validator passes.
  - {#until validator=notEmpty}Hello{/until} renders Hello without errors.
  - UntilElement::run matches ILoopElement::run(array).

  Key Files Changed

  - src/Parsing/Elements/UntilElement.php
  - src/Parsing/Registry/TagRegistry.php
  - tests/Parsing/AdditionalTagsTest.php

  How to Test

  1. vendor/bin/phpunit --do-not-cache-result tests/Parsing

  QA Checklist

  - [ ] {#until} tag is registered and parsed
  - [ ] Validator loop stops on success or max attempts
  - [ ] No signature mismatch with ILoopElement
  - [ ] Parsing tests green

  Approval Conditions

  - Parsing tests pass and {#until} works with validators (e.g., notEmpty).