### PR TITLE
Fixes val calls in network classes

### DIFF
--- a/src/Net/HTTPClient.php
+++ b/src/Net/HTTPClient.php
@@ -3,6 +3,9 @@
 namespace BlueFission\Net;
 
 use BlueFission\Connections\Curl;
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -51,13 +54,38 @@ class HTTPClient implements ClientInterface
     {
         $headerSize = curl_getinfo($this->_curl->connection(), CURLINFO_HEADER_SIZE);
         $headerString = Str::sub($this->_curl->result(), 0, $headerSize);
+        $lines = $this->normalizeHeaderLines($headerString);
         $headers = [];
-        foreach (explode("\r\n", $headerString) as $line) {
+        foreach ($lines as $line) {
             if (Str::pos($line, ':') !== false) {
                 list($key, $value) = explode(':', Str::use(), 2);
                 $headers[trim($key)] = trim($value);
             }
         }
         return $headers;
+    }
+
+    protected function normalizeHeaderLines($headerString): array
+    {
+        if (Val::isEmpty($headerString)) {
+            return [];
+        }
+
+        $headerString = Val::grab();
+
+        if (Str::is($headerString)) {
+            $headerString = Str::replace(Str::grab(), "\r", '');
+            $lines = Str::split($headerString, "\n");
+        } elseif (Arr::is($headerString)) {
+            $lines = Arr::grab();
+        } else {
+            return [];
+        }
+
+        if (!Arr::isNotEmpty($lines)) {
+            return [];
+        }
+
+        return Arr::grab();
     }
 }


### PR DESCRIPTION
Intent summary
  - normalize header handling using Val/Str/Arr so Curl and HTTPClient accept string/array headers consistently

  User stories / acceptance criteria
  - As a developer, I can pass headers as a string or array and Curl sends them correctly.
  - As a developer, HTTPClient parses response headers reliably from the raw header string.
  - Curl tests pass with network tests enabled.

  Key files changed
  - src/Connections/Curl.php
  - src/Net/HTTPClient.php

  How to test
  - DEV_ELATION_NETWORK_TESTS=1 vendor/bin/phpunit --do-not-cache-result tests/Connections/CurlTest.php

  QA checklist
  - [ ] Header normalization works for string input with CRLF
  - [ ] Header normalization works for array input
  - [ ] Curl requests still include Content-Type for JSON posts
  - [ ] HTTPClient parses response headers into key/value pairs
  - [ ] No regressions in existing Curl flow

  Approval conditions
  - Approve if curl tests pass with network enabled and header normalization behaves the same for strings and arrays.