### PR TITLE
add cli example and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Beginnings of an application framework, offering service and routing management 
 - [Application Framework Documentation](app_framework.md)
 
 ### System Tools
-A suite of tools for interacting with the operating system, managing command-line interfaces, machine-specific details, statistics, processes, and asynchronous operations.
+A suite of tools for interacting with the operating system, including CLI utilities, process control, machine details, statistics, and asynchronous operations.
 
 - [System Tools Documentation](system_tools.md)
 
@@ -96,6 +96,56 @@ Sample applications that demonstrate DevElation’s flexibility:
 - Session-backed todo list using `Arr`, `Date`, `Session` storage, HTML helpers, and Vibe templates: `examples/todo/index.php`
 - Simple comment thread with voting using `Arr`, `Str`, `Session` storage, HTML helpers, and Vibe templates: `examples/comments/index.php`
 - CLI territory game using the behavioral engine (`Behaves`) and an `Arr`-backed log: `examples/game/gangs.php`
+- CLI status report using args, tables, and progress bars: `examples/cli/report.php`
+- Additional walkthroughs live in `examples/README.md`
+
+## Quick Start Examples
+
+### CLI utilities: args, tables, and progress
+
+```php
+use BlueFission\Cli\Args;
+use BlueFission\Cli\Args\OptionDefinition;
+use BlueFission\Cli\Console;
+
+$args = (new Args())
+    ->addOption(new OptionDefinition('limit', [
+        'short' => 'l',
+        'type' => 'int',
+        'default' => 5,
+        'description' => 'Number of rows to show.',
+    ]))
+    ->parse($argv);
+
+$options = $args->options();
+$limit = $options['limit'] ?? 5;
+
+$console = new Console();
+$console->writeln($console->color('Report', 'cyan', ['bold']));
+$console->writeln($console->table(['Item', 'Count'], [
+    ['alpha', $limit],
+]));
+
+for ($i = 1; $i <= $limit; $i++) {
+    $console->rewriteLine($console->progress($limit, $i));
+}
+$console->writeln('');
+```
+
+### Storage pipeline: session-backed data
+
+```php
+use BlueFission\Data\Storage\Session;
+
+$store = new Session(['name' => 'todos']);
+$store->activate()->read();
+
+$todos = (array)($store->contents() ?? []);
+$todos[] = ['task' => 'Ship docs', 'due' => '2026-01-10'];
+
+$store->assign($todos);
+$store->write();
+```
 
 ## Usage
 

--- a/app_framework.md
+++ b/app_framework.md
@@ -1,0 +1,50 @@
+# Application Framework
+
+DevElation's `Services` namespace provides a lightweight application shell for routing, service dispatch, and behavior-driven workflows. It is not a full MVC framework, but it gives you consistent primitives for routing and messaging.
+
+## Key Classes
+
+- `Application`: entry point for routing, behavior dispatch, and service registry.
+- `Service`: base service wrapper for behavior-based handlers.
+- `Mapping`: route definition with method, path, and callable.
+- `Gateway`: optional request preprocessing before service execution.
+- `Uri`: URI parsing and matching helper.
+- `Request` and `Response`: service request/response containers.
+
+## Quick Start: Map and Run
+
+```php
+use BlueFission\Services\Application;
+
+$app = new Application(['name' => 'Demo']);
+
+$app->map('get', '/health', function() {
+    return 'ok';
+});
+
+$app->args()->process()->run();
+```
+
+## Service Dispatch Pattern
+
+```php
+use BlueFission\Services\Application;
+use BlueFission\Services\Service;
+
+class UserService extends Service {
+    public function list() {
+        return json_encode(['users' => []]);
+    }
+}
+
+$app = new Application(['name' => 'Api']);
+$app->delegate('users', UserService::class);
+$app->map('get', '/users', [UserService::class, 'list']);
+
+$app->args()->process()->run();
+```
+
+## Related
+
+For data access, see `data_management.md`.
+For networking utilities, see `network_services.md`.

--- a/behavior.md
+++ b/behavior.md
@@ -24,6 +24,30 @@ $this->perform(State::PERFORMING_ACTION, new Meta(when: Action::READ, info: 'Ope
 
 In this example, `Meta` holds information about the action being performed, additional context (info), and relevant data (file path).
 
+### Quick Start (Behaves)
+
+```php
+use BlueFission\Behavioral\Behaves;
+use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\Behavioral\Behaviors\Meta;
+
+class Worker {
+    use Behaves;
+
+    public function __construct() {
+        $this->when(Event::PROCESSED, function($behavior, Meta $meta) {
+            echo "Processed: " . json_encode($meta->data) . PHP_EOL;
+        });
+    }
+
+    public function run(array $payload) {
+        $this->dispatch(Event::PROCESSED, new Meta(data: $payload));
+    }
+}
+
+(new Worker())->run(['id' => 42]);
+```
+
 ### Event-Driven Architecture
 
 #### Triggering Events
@@ -72,8 +96,8 @@ $object->when(Event::LOAD, function() {
 $object->dispatch(Event::LOAD);
 ```
 
-#### Example Usage
-Here’s an example of how an eCommerce checkout process might define and trigger behaviors within an application:
+#### Extended Example
+Here is an example of how an eCommerce checkout process might define and trigger behaviors within an application:
 
 ```php
 $order->behavior(new Event(Event::CHECKOUT_STARTED));
@@ -108,13 +132,10 @@ $order->when(Action::SEND_EMAIL, function($behavior, $meta) {
 
 ```
 
-### What’s Happening:
- CHECKOUT_STARTED event is dispatched.
+### What's Happening
 
- The system enters PROCESSING_PAYMENT state.
-
- It performs CHARGE_CARD action using card info.
-
- Once the card is charged, it triggers ORDER_CONFIRMED event.
-
- Then it performs SEND_EMAIL action to email the customer.
+- CHECKOUT_STARTED event is dispatched.
+- The system enters PROCESSING_PAYMENT state.
+- It performs CHARGE_CARD action using card info.
+- Once the card is charged, it triggers ORDER_CONFIRMED event.
+- Then it performs SEND_EMAIL action to email the customer.

--- a/collections.md
+++ b/collections.md
@@ -18,6 +18,20 @@ The `Collection` class provides a flexible way to manage an array of items. It i
 - **first()**: Returns the first item in the collection.
 - **last()**: Returns the last item in the collection.
 
+### Quick Start
+
+```php
+use BlueFission\Collections\Collection;
+use BlueFission\Str;
+
+$collection = new Collection();
+$collection->add(Str::make('alpha'), 'first');
+$collection->add(Str::make('beta'), 'second');
+
+echo $collection->count(); // 2
+echo $collection->first()->val(); // alpha
+```
+
 ### Usage Scenario
 
 `Collection` is ideal for scenarios where you need to maintain a list of objects or values, such as managing a list of subscribers in an application or storing a set of configurations.

--- a/connections.md
+++ b/connections.md
@@ -57,6 +57,26 @@ Implements `Connection` to handle stream-based communications. Uses PHP's stream
 
 To utilize these classes, ensure your application configuration includes parameters suited for each type of connection. For instance, when using `Curl`, configure endpoints and authentication details. For `Socket` or `Stream`, specify the target and parameters like port numbers or stream contexts.
 
+### Quick Start (Curl)
+
+```php
+use BlueFission\Connections\Curl;
+use BlueFission\Behavioral\Behaviors\Event;
+
+$curl = new Curl([
+    'target' => 'https://api.example.com/users',
+    'method' => 'GET',
+]);
+
+$curl->when(Event::SUCCESS, function() {
+    echo "Request completed.";
+});
+
+$curl->open();
+$response = $curl->query(null)->result();
+$curl->close();
+```
+
 ### Example
 
 ```php

--- a/datatypes.md
+++ b/datatypes.md
@@ -6,6 +6,22 @@ The BlueFission Data Type Wrapper Classes provide a powerful and flexible way to
 
 The BlueFission Data Type Wrapper Classes aim to enhance PHP's native data types by encapsulating them in objects that offer additional functionality. These enhancements include event handling, constraints for data integrity, dynamic method slotting for runtime extensibility, and utility methods that augment or replace PHP's native functions for more intuitive and object-oriented data manipulation.
 
+## Quick Start
+
+```php
+use BlueFission\Arr;
+use BlueFission\Num;
+use BlueFission\Str;
+
+$title = Str::make('  hello world  ')->trim()->capitalize();
+$items = Arr::make(['alpha', 'beta'])->push('gamma');
+$count = Num::make(3)->val(4);
+
+echo $title(); // Hello world
+echo $items->count(); // 3
+echo $count(); // 4
+```
+
 ## Purpose
 
 The core purpose of these wrapper classes is to provide a structured, object-oriented approach to handling common data types in PHP. By wrapping data types in classes, it becomes possible to:
@@ -29,6 +45,8 @@ The core purpose of these wrapper classes is to provide a structured, object-ori
 - `Num`: Specialized class for numeric values.
 - `Str`: Specialized class for string values.
 - `Arr`: Specialized class for array values.
+
+Typed fields in `Obj` use the `DataTypes` enum to determine how values are cast and exposed. That means you can declare a field as `DataTypes::STRING` and the field behaves like a `Str` value object when `_exposeValueObject` is enabled.
 
 ## Key Methods
 

--- a/date.md
+++ b/date.md
@@ -94,6 +94,7 @@ echo $date->time(14, 30, 0); // Sets the time to 2:30 PM and outputs the result
 // Get the difference in days
 $anotherDate = new BlueFission\Date('2023-04-05');
 echo $date->difference($anotherDate->val(), 'days'); // Outputs the difference in days
+```
 
 # E-Commerce Example with BlueFission Date Wrapper
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,17 @@ This directory contains small, self-contained example apps that are meant to dou
 - **How to run**:
   - From the project root: `php examples/game/gangs.php` in a terminal.
 
+### 4. CLI Status Report – `examples/cli/report.php`
+
+- **Purpose**: Compact CLI demo for argument parsing, output formatting, and progress updates.
+- **Key DevElation concepts**:
+  - `Cli\Args` + `OptionDefinition`: parse short/long flags and generate usage text.
+  - `Cli\Console`: colorized output, tables, progress bars, and prompts.
+  - `Cli\Util\StatusBar`: quick status line composed from labeled values.
+- **How to run**:
+  - From the project root: `php examples/cli/report.php --limit 3 --delay 50`
+  - Add `--ask` to prompt for a custom title.
+
 ### Additional Ideas to Explore
 
 These examples intentionally stay small, but there are several DevElation features that could be layered in when you want to go deeper:

--- a/examples/cli/report.php
+++ b/examples/cli/report.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use BlueFission\Cli\Args;
+use BlueFission\Cli\Args\OptionDefinition;
+use BlueFission\Cli\Console;
+use BlueFission\Cli\Util\StatusBar;
+
+$args = (new Args())
+    ->addOptions([
+        new OptionDefinition('limit', [
+            'short' => 'l',
+            'type' => 'int',
+            'default' => 5,
+            'description' => 'Number of rows to render.',
+        ]),
+        new OptionDefinition('delay', [
+            'short' => 'd',
+            'type' => 'int',
+            'default' => 0,
+            'description' => 'Delay per step (ms).',
+        ]),
+        new OptionDefinition('title', [
+            'short' => 't',
+            'type' => 'string',
+            'default' => 'CLI Report',
+            'description' => 'Title for the output.',
+        ]),
+        new OptionDefinition('ask', [
+            'short' => 'a',
+            'type' => 'bool',
+            'default' => false,
+            'description' => 'Prompt for a custom title.',
+        ]),
+    ])
+    ->parse($argv);
+
+$options = $args->options();
+
+$console = new Console();
+
+if (!empty($options['help'])) {
+    $console->writeln($args->usage());
+    exit(0);
+}
+
+$limit = max(1, (int)($options['limit'] ?? 5));
+$delay = max(0, (int)($options['delay'] ?? 0));
+$title = (string)($options['title'] ?? 'CLI Report');
+
+if (!empty($options['ask'])) {
+    $title = $console->prompt('Report title: ', $title);
+}
+
+$console->writeln($console->color($title, 'cyan', ['bold']));
+
+$rows = [];
+for ($i = 1; $i <= $limit; $i++) {
+    $rows[] = ['Item ' . $i, 'ready'];
+}
+$console->writeln($console->table(['Item', 'Status'], $rows, [
+    'align' => ['left', 'right'],
+]));
+
+$status = new StatusBar();
+$status->set('total', (string)$limit)->set('mode', 'demo');
+$console->writeln($status->render());
+
+for ($i = 1; $i <= $limit; $i++) {
+    $console->rewriteLine($console->progress($limit, $i));
+    if ($delay > 0) {
+        usleep($delay * 1000);
+    }
+}
+$console->writeln('');

--- a/html_tools.md
+++ b/html_tools.md
@@ -1,0 +1,46 @@
+# HTML Tools
+
+The HTML helpers in DevElation focus on quick, server-side markup generation for forms, tables, templates, and XML. They pair well with Vibe templates and the parsing pipeline documented in `parsing.md`.
+
+## Key Classes
+
+- `HTML`: low-level helpers for formatting text, links, images, and tags.
+- `Form`: form and input builders (text, select, checkbox, date, and more).
+- `Table`: HTML table generator with optional headers and styling.
+- `Template`: Vibe-based template rendering.
+- `XML`: lightweight XML helpers.
+
+## Quick Start: Form Fields
+
+```php
+use BlueFission\HTML\Form;
+
+$form = Form::open('/submit', 'signup');
+$form .= Form::field('text', 'email', 'Email');
+$form .= Form::field('password', 'password', 'Password');
+$form .= Form::field('submit', 'save', '', 'Create Account');
+$form .= Form::close();
+
+echo $form;
+```
+
+## Quick Start: Table Rendering
+
+```php
+use BlueFission\HTML\Table;
+
+$table = new Table([
+    'headers' => ['Name', 'Value'],
+]);
+
+$table->content([
+    ['Framework', 'DevElation'],
+    ['License', 'MIT'],
+]);
+
+echo $table->render();
+```
+
+## Templates
+
+For file-based templates, use `HTML\Template` and the Vibe syntax documented in `parsing.md`.

--- a/network_services.md
+++ b/network_services.md
@@ -1,0 +1,41 @@
+# Network Services
+
+The `BlueFission\Net` namespace provides common HTTP, email, and IP utilities. These classes are lightweight and are meant to be composed with `Connections` or `Services` when you need richer behavior.
+
+## Key Classes
+
+- `HTTP`: helpers for queries, sessions, cookies, redirects, and URL inspection.
+- `HTTPClient` and `HTTPClientFactory`: PSR-18 compatible HTTP client support.
+- `Request` and `Response`: PSR-7 request/response implementations.
+- `Email`: mail composition and delivery helpers.
+- `IP`: IP address helpers and checks.
+
+## Quick Start: HTTP Helpers
+
+```php
+use BlueFission\Net\HTTP;
+
+$query = HTTP::query(['q' => 'search', 'page' => 2]);
+$url = 'https://example.com/?' . $query;
+
+if (HTTP::urlExists($url)) {
+    echo "URL is reachable";
+}
+```
+
+## Quick Start: Email
+
+```php
+use BlueFission\Net\Email;
+
+Email::sendMail(
+    'ops@example.com',
+    'no-reply@example.com',
+    'Job finished',
+    'The nightly sync completed successfully.'
+);
+```
+
+## Related
+
+If you need connection lifecycle events and state handling, see `connections.md`.

--- a/object.md
+++ b/object.md
@@ -13,7 +13,7 @@ The `Obj` class is part of the BlueFission framework, designed to encapsulate co
 ## Features
 
 - **Dynamic Fields**: Fields can be dynamically added, accessed, and modified using object attributes.
-- **Event Dispatching**: Leverages the `Dispatches` trait for event handling, allowing objects to react to and broadcast events on data changes.
+- **Event Dispatching**: Leverages the `Behaves` trait for event handling, allowing objects to react to and broadcast events on data changes.
 - **Data Type Flexibility**: Supports flexible data types for fields, with the capability to lock data types if needed.
 - **Serialization Support**: Provides methods for serializing object data to arrays or JSON strings.
 
@@ -110,7 +110,7 @@ echo $obj->field('name');
 
 ### Event Dispatching
 
-The `Obj` class can dispatch and respond to events, thanks to the `Dispatches` trait. This feature allows for complex interactions within and between objects, based on changes to their state or other triggers.
+The `Obj` class can dispatch and respond to events, thanks to the `Behaves` trait. This feature allows for complex interactions within and between objects, based on changes to their state or other triggers.
 
 ```php
 $obj->behavior('customEvent', function($args) {
@@ -162,9 +162,9 @@ class CustomObj extends BlueFission\Obj {
     ];
 
     protected $_types = [
-        'customField1' => BlueFission\DataTypes::STRING
-        'customField2' => BlueFission\DataTypes::INTEGER
-        'customField3' => BlueFission\DataTypes::STRING
+        'customField1' => BlueFission\DataTypes::STRING,
+        'customField2' => BlueFission\DataTypes::INTEGER,
+        'customField3' => BlueFission\DataTypes::STRING,
     
     ];
 
@@ -223,7 +223,7 @@ $obj->age = 'thirty'; // Throws exception
 
 ### Using Events
 
-Events can be used to trigger actions based on changes to the object's state. The `Dispatches` trait provides a simple way to manage event-driven programming within the object.
+Events can be used to trigger actions based on changes to the object's state. The `Behaves` trait provides a simple way to manage event-driven programming within the object.
 
 ```php
 use BlueFission\Behavioral\Behaviors\Meta;
@@ -268,7 +268,6 @@ class Person extends \BlueFission\Obj {
     public function __construct() {
         parent::__construct();
         $this->when(Event::CHANGE, function() {
-            if
             echo "My values have changed";
         });
     }

--- a/parsing.md
+++ b/parsing.md
@@ -42,6 +42,8 @@ $template->assign(['name' => 'World']);
 echo $template->render();
 ```
 
+Register defaults once per process (for example, during bootstrap) so custom tags and renderers are available everywhere.
+
 A simple Vibe layout pattern:
 
 ```vibe

--- a/system_tools.md
+++ b/system_tools.md
@@ -1,0 +1,41 @@
+# System Tools
+
+System tools cover CLI interactions, OS-level process control, machine inspection, and async helpers. Most components are behavior-aware so you can listen for state changes or events.
+
+## Key Areas
+
+- `Cli`: terminal utilities (Console, Args, Ansi, Table, ProgressBar, Prompt, Cursor).
+- `System`: process control and machine details (`Process`, `System`, `Machine`).
+- `Async`: promises, forks, sockets, and basic async helpers.
+- `IPC`: lightweight inter-process communication helper.
+
+## Quick Start: CLI Output
+
+```php
+use BlueFission\Cli\Console;
+
+$console = new Console();
+$console->writeln($console->color('Starting up', 'green'));
+$console->writeln($console->table(['Key', 'Value'], [
+    ['mode', 'cli'],
+    ['status', 'ready'],
+]));
+```
+
+## Quick Start: Process Execution
+
+```php
+use BlueFission\System\Process;
+
+$process = new Process('php -v');
+$process->start();
+$output = $process->output();
+$process->stop();
+
+echo $output;
+```
+
+## Related
+
+CLI utilities are documented in `src/Cli` and integrate with `Behavioral` events.
+Async helpers live in `src/Async`.

--- a/tests.md
+++ b/tests.md
@@ -7,7 +7,8 @@ This project uses PHPUnit. The suite is split by feature area and includes optio
 1. Install dependencies: `composer install`
 2. Run all tests: `vendor/bin/phpunit --do-not-cache-result`
 3. Run a subset: `vendor/bin/phpunit --do-not-cache-result tests/Parsing`
-4. Run all tests inside Docker (php container only, lib mode):
+4. Run CLI suite: `vendor/bin/phpunit --do-not-cache-result tests/Cli`
+5. Run all tests inside Docker (php container only, lib mode):
 
 ```powershell
 $env:BF_MODE = 'lib'

--- a/utilities.md
+++ b/utilities.md
@@ -1,0 +1,45 @@
+# Utilities
+
+Utilities provide small, reusable helpers that do not fit neatly into the other modules. They are intended for glue code, safety checks, and convenience features.
+
+## Key Classes
+
+- `Utils\Util`: alerts, storage helpers, and guardrails.
+- `Utils\Mem`: memory pool management with optional persistence.
+- `Utils\Loader`: class loader for local discovery.
+
+## Quick Start: Guard a Loop
+
+```php
+use BlueFission\Utils\Util;
+
+$count = 0;
+while (true) {
+    Util::parachute($count, 1000);
+    // work
+}
+```
+
+## Quick Start: CLI Storage
+
+```php
+use BlueFission\Utils\Util;
+
+Util::store('last_job', ['id' => 7, 'status' => 'done']);
+$result = Util::store('last_job');
+```
+
+## Quick Start: Memory Pool
+
+```php
+use BlueFission\Utils\Mem;
+
+$object = new stdClass();
+Mem::register($object);
+Mem::assess();
+Mem::flush();
+```
+
+## Related
+
+Storage paths for CLI sessions live under `src/Utils/storage`.


### PR DESCRIPTION
Intent summary
  - Add a CLI example demonstrating args, tables, status, and progress output.
  - Refresh README and linked docs; add missing documentation pages.

  User stories / acceptance criteria
  - As a developer, I can run `php examples/cli/report.php --limit 3 --delay 50` to see a formatted report and progress bar.
  - README links resolve to actual docs.
  - Updated docs include quick-start examples for core modules.

  Key files changed
  - README.md
  - examples/cli/report.php
  - examples/README.md
  - app_framework.md
  - data_management.md
  - html_tools.md
  - network_services.md
  - system_tools.md
  - utilities.md
  - behavior.md
  - datatypes.md
  - date.md
  - object.md
  - collections.md
  - connections.md
  - parsing.md
  - tests.md

  How to test
  - `php examples/cli/report.php --limit 3 --delay 50`
  - Optional: `vendor/bin/phpunit --do-not-cache-result tests/Cli`

  QA checklist
  - [ ] CLI example runs and renders table/progress
  - [ ] README links open without 404
  - [ ] No unintended files included

  Approval conditions
  - Docs review complete and CLI example output verified