### PR TITLE
Add schema validation and security hashing utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Facilitate connectivity to various data sources and services, such as MySQL, cUR
 Handle queues, storage solutions, databases, Redis, MemQ, files, and logs with a unified approach to data manipulation and persistence.
 
 - [Data Management Documentation](data_management.md)
+- [Schema Documentation](schema.md)
 
 ### HTML Building Tools
 Construct HTML elements for forms, tables, and templating with ease, improving the speed of frontend development.
@@ -84,6 +85,11 @@ A suite of tools for interacting with the operating system, including CLI utilit
 A set of utility functions and tools for administrative alerts, logging, IP blocking, and safeguards against runaway scripts.
 
 - [Utilities Documentation](utilities.md)
+
+### Security Tools
+Hashing helpers for checksums, content IDs, and signatures.
+
+- [Security Documentation](security.md)
 
 ### Testing
 Guidance for running PHPUnit tests and enabling optional integration coverage.

--- a/data_management.md
+++ b/data_management.md
@@ -28,6 +28,33 @@ $store->assign($payload);
 $store->write();
 ```
 
+## Schema Validation
+
+`BlueFission\Data\Schema` lets you define typed fields, cast input, and validate structured data.
+
+```php
+use BlueFission\Data\Schema;
+
+$schema = new Schema([
+    'name' => ['type' => 'string', 'required' => true],
+    'age' => ['type' => 'int', 'default' => 0],
+    'active' => ['type' => 'bool', 'default' => true],
+    'tags' => ['type' => 'array', 'items' => ['type' => 'string']],
+], ['strict' => true]);
+
+$result = $schema->transform([
+    'name' => 123,
+    'age' => '42',
+    'tags' => ['alpha', 9],
+]);
+
+if ($schema->errors()) {
+    // handle validation errors
+}
+```
+
+See `schema.md` for nested schemas, arrays, and constraint patterns.
+
 ## Quick Start: Session Storage
 
 ```php

--- a/schema.md
+++ b/schema.md
@@ -1,0 +1,106 @@
+# Schema Validation
+
+`BlueFission\Data\Schema` provides a typed schema layer for validation, casting, and normalization. It is built on top of `Obj`, `DataTypes`, and `Val` constraints, so it fits the same DevElation behavioral and hookable patterns as the rest of the library.
+
+## Quick Start
+
+```php
+use BlueFission\Data\Schema;
+
+$schema = new Schema([
+    'name' => ['type' => 'string', 'required' => true],
+    'age' => ['type' => 'int', 'default' => 0],
+    'active' => ['type' => 'bool', 'default' => true],
+], ['strict' => true]);
+
+$result = $schema->transform([
+    'name' => 123,
+    'age' => '42',
+]);
+
+if ($schema->errors()) {
+    // handle errors
+}
+```
+
+## Nested Schemas
+
+```php
+use BlueFission\Data\Schema;
+
+$address = new Schema([
+    'line1' => ['type' => 'string', 'required' => true],
+    'city' => ['type' => 'string', 'required' => true],
+]);
+
+$user = new Schema([
+    'id' => ['type' => 'int', 'required' => true],
+    'address' => ['schema' => $address],
+]);
+
+$result = $user->transform([
+    'id' => '7',
+    'address' => ['line1' => '123 Main', 'city' => 'Austin'],
+]);
+```
+
+## Array Items
+
+```php
+$schema = new Schema([
+    'tags' => [
+        'type' => 'array',
+        'items' => ['type' => 'string'],
+    ],
+]);
+```
+
+## Constraints
+
+Constraints use `Val::constraint()` under the hood and can mutate or reject values.
+
+```php
+use BlueFission\Data\Schema;
+use BlueFission\Data\Schema\FieldDefinition;
+
+$schema = new Schema([
+    'slug' => new FieldDefinition('slug', [
+        'type' => 'string',
+        'constraints' => function (&$value) {
+            $value = trim((string)$value);
+            return $value !== '';
+        },
+    ]),
+]);
+```
+
+## Strict Mode
+
+If `strict` is enabled, unknown fields produce errors. Otherwise, they are passed through.
+
+```php
+$schema = new Schema(['name' => ['type' => 'string']], ['strict' => true]);
+$schema->apply(['name' => 'Ava', 'extra' => true]);
+```
+
+## Errors
+
+Errors are grouped by field name and include message and optional details.
+
+```php
+$errors = $schema->errors();
+// [
+//   'name' => [ ['message' => 'required'] ],
+//   'extra' => [ ['message' => 'unknown_field'] ],
+// ]
+```
+
+## Behavior Hooks
+
+`Schema` triggers standard behaviors:
+
+- `Event::SUCCESS` on valid transforms
+- `Event::FAILURE` on validation failures
+- `Event::PROCESSED` for every apply/transform call
+
+You can also use `DevElation::apply()` and `DevElation::do()` to hook inputs/outputs.

--- a/security.md
+++ b/security.md
@@ -1,0 +1,45 @@
+# Security Tools
+
+This library includes lightweight utilities for hashing, checksums, and content IDs. All helpers are built to fit the DevElation behavioral model and support hooks via `DevElation::apply()` / `DevElation::do()`.
+
+## Hash
+
+`BlueFission\Security\Hash` provides hashing, HMAC, file checksums, and content IDs.
+
+### Quick Start
+
+```php
+use BlueFission\Security\Hash;
+
+$hash = new Hash('sha256');
+$digest = $hash->hash('payload');
+
+if ($hash->verify('payload', $digest)) {
+    echo 'valid';
+}
+```
+
+### HMAC
+
+```php
+$signature = $hash->hmac('payload', 'secret');
+```
+
+### File Checksums
+
+```php
+$checksum = $hash->checksumFile('/path/to/file.txt');
+```
+
+### Content IDs
+
+```php
+$contentId = $hash->contentId(['id' => 7]); // cid:<hash>
+```
+
+### Algorithms
+
+```php
+$algorithms = Hash::algorithms();
+$ok = Hash::supports('sha256');
+```

--- a/src/Data/Schema.php
+++ b/src/Data/Schema.php
@@ -1,0 +1,625 @@
+<?php
+
+namespace BlueFission\Data;
+
+use BlueFission\Arr;
+use BlueFission\IVal;
+use BlueFission\Obj;
+use BlueFission\Val;
+use BlueFission\DataTypes;
+use BlueFission\ValFactory;
+use BlueFission\Data\Schema\FieldDefinition;
+use BlueFission\Behavioral\Behaviors\Action;
+use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\Behavioral\Behaviors\State;
+use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\DevElation as Dev;
+
+class Schema extends Obj
+{
+    protected $_data = [
+        'fields' => [],
+        'strict' => false,
+        'errors' => [],
+        'cast' => true,
+    ];
+
+    protected $_types = [
+        'fields' => DataTypes::ARRAY,
+        'strict' => DataTypes::BOOLEAN,
+        'errors' => DataTypes::ARRAY,
+        'cast' => DataTypes::BOOLEAN,
+    ];
+
+    public function __construct(array $fields = [], array $config = [])
+    {
+        parent::__construct();
+
+        $config = Dev::apply('_in', $config);
+        if (Arr::isAssoc($config)) {
+            if (array_key_exists('strict', $config)) {
+                $this->setValue('strict', (bool)$config['strict']);
+            }
+            if (array_key_exists('cast', $config)) {
+                $this->setValue('cast', (bool)$config['cast']);
+            }
+        }
+
+        if (!empty($fields)) {
+            $this->defineMany($fields);
+        }
+
+        Dev::do('_after', [$this]);
+    }
+
+    public static function from(array $fields, array $config = []): self
+    {
+        return new self($fields, $config);
+    }
+
+    public function define(string $name, $definition): self
+    {
+        $definition = $this->normalizeDefinition($name, $definition);
+        $fields = $this->arrayValue($this->field('fields'));
+        $fields[$name] = $definition;
+        $this->setValue('fields', $fields);
+        $this->trigger(Event::CHANGE, new Meta(data: ['field' => $name]));
+
+        return $this;
+    }
+
+    public function defineMany(array $fields): self
+    {
+        foreach ($fields as $name => $definition) {
+            if (is_string($name)) {
+                $this->define($name, $definition);
+            } elseif ($definition instanceof FieldDefinition) {
+                $this->define($definition->name(), $definition);
+            }
+        }
+
+        return $this;
+    }
+
+    public function fields(): array
+    {
+        return $this->arrayValue($this->field('fields'));
+    }
+
+    public function fieldDefinition(string $name): ?FieldDefinition
+    {
+        $fields = $this->fields();
+        if (!array_key_exists($name, $fields)) {
+            return null;
+        }
+
+        return $this->normalizeDefinition($name, $fields[$name]);
+    }
+
+    public function hasField(string $name): bool
+    {
+        $fields = $this->fields();
+        return array_key_exists($name, $fields);
+    }
+
+    public function requiredFields(): array
+    {
+        $names = [];
+        foreach ($this->fields() as $name => $definition) {
+            $definition = $this->normalizeDefinition((string)$name, $definition);
+            if ($definition->required()) {
+                $names[] = $definition->name();
+            }
+        }
+
+        return $names;
+    }
+
+    public function optionalFields(): array
+    {
+        $names = [];
+        foreach ($this->fields() as $name => $definition) {
+            $definition = $this->normalizeDefinition((string)$name, $definition);
+            if (!$definition->required()) {
+                $names[] = $definition->name();
+            }
+        }
+
+        return $names;
+    }
+
+    public function strict(?bool $value = null): bool
+    {
+        if (Val::isNull($value)) {
+            return (bool)$this->field('strict');
+        }
+
+        $this->setValue('strict', (bool)$value);
+        return (bool)$this->field('strict');
+    }
+
+    public function castSetting(?bool $value = null): bool
+    {
+        if (Val::isNull($value)) {
+            return (bool)$this->field('cast');
+        }
+
+        $this->setValue('cast', (bool)$value);
+        return (bool)$this->field('cast');
+    }
+
+    public function apply($data, ?bool $strict = null, ?bool $cast = null): array
+    {
+        $data = Dev::apply('_in', $data);
+        Dev::do('_before', [$data, $this]);
+
+        $this->perform(State::PROCESSING);
+        $this->perform(new Action(Action::PROCESS), new Meta(data: $data));
+
+        $strict = $strict ?? $this->strict();
+        $cast = $cast ?? $this->castSetting();
+
+        [$result, $errors] = $this->process($data, $strict, $cast);
+
+        $this->setValue('errors', $errors);
+
+        if (!empty($errors)) {
+            $this->perform(Event::FAILURE, new Meta(data: $errors));
+        } else {
+            $this->perform(Event::SUCCESS, new Meta(data: $result));
+        }
+
+        $this->perform(Event::PROCESSED, new Meta(data: $result));
+
+        $result = Dev::apply('_out', $result);
+        Dev::do('_after', [$result, $this]);
+
+        return $result;
+    }
+
+    public function validate($data, ?bool $strict = null): bool
+    {
+        $this->apply($data, $strict, false);
+        return empty($this->errors());
+    }
+
+    public function transform($data, ?bool $strict = null): array
+    {
+        return $this->apply($data, $strict, true);
+    }
+
+    public function errors(): array
+    {
+        return $this->arrayValue($this->field('errors'));
+    }
+
+    public function errorsFor(string $field): array
+    {
+        $errors = $this->errors();
+        return $errors[$field] ?? [];
+    }
+
+    public function clearErrors(): self
+    {
+        $this->setValue('errors', []);
+        return $this;
+    }
+
+    protected function process($data, bool $strict, bool $cast): array
+    {
+        $input = $this->normalizeData($data);
+        $definitions = $this->fields();
+        $result = [];
+        $errors = [];
+        $usedKeys = [];
+        $knownKeys = [];
+
+        foreach ($definitions as $name => $definition) {
+            $definition = $this->normalizeDefinition((string)$name, $definition);
+            $source = $definition->source() !== '' ? $definition->source() : $definition->name();
+            $knownKeys[] = $source;
+
+            $hasKey = array_key_exists($source, $input);
+            if (!$hasKey) {
+                if ($definition->hasDefault()) {
+                    $value = $this->resolveDefault($definition);
+                    $hasKey = true;
+                } elseif ($definition->required()) {
+                    $this->addError($errors, $definition->name(), 'required');
+                    continue;
+                } else {
+                    continue;
+                }
+            } else {
+                $value = $input[$source];
+                $usedKeys[] = $source;
+            }
+
+            if ($value === null) {
+                if ($definition->nullable()) {
+                    $result[$definition->name()] = null;
+                    continue;
+                }
+                $this->addError($errors, $definition->name(), 'null_not_allowed');
+                continue;
+            }
+
+            $processed = $this->processValue($definition->name(), $definition, $value, $cast, $strict, $input, $errors);
+            if ($processed['ok']) {
+                $result[$definition->name()] = $processed['value'];
+            }
+        }
+
+        if ($strict) {
+            foreach ($input as $key => $value) {
+                if (!in_array($key, $knownKeys, true)) {
+                    $this->addError($errors, (string)$key, 'unknown_field');
+                }
+            }
+        } else {
+            foreach ($input as $key => $value) {
+                if (!in_array($key, $knownKeys, true)) {
+                    $result[$key] = $value;
+                }
+            }
+        }
+
+        return [$result, $errors];
+    }
+
+    protected function processValue(string $name, FieldDefinition $definition, $value, bool $cast, bool $strict, array $input, array &$errors): array
+    {
+        $schema = $this->normalizeSchema($definition->schema());
+        $items = $definition->items();
+        $type = $this->normalizeType($definition->type());
+        $useCast = $definition->cast() && $cast;
+
+        if ($schema instanceof self) {
+            if (!is_array($value) && !is_object($value)) {
+                $this->addError($errors, $name, 'expected_object');
+                return ['ok' => false, 'value' => null];
+            }
+            $nested = $schema->apply($value, $strict, $cast);
+            $nestedErrors = $schema->errors();
+            if (!empty($nestedErrors)) {
+                $this->addError($errors, $name, 'schema_failed', $nestedErrors);
+                return ['ok' => false, 'value' => null];
+            }
+            return ['ok' => true, 'value' => $nested];
+        }
+
+        if ($items !== null) {
+            if (!is_array($value)) {
+                if ($useCast) {
+                    $value = Arr::make($value)->val();
+                } else {
+                    $this->addError($errors, $name, 'expected_array');
+                    return ['ok' => false, 'value' => null];
+                }
+            }
+
+            $itemDefinition = $this->normalizeItemDefinition($items);
+            if ($itemDefinition) {
+                $itemErrors = [];
+                $processed = [];
+                foreach ($value as $index => $itemValue) {
+                    if ($itemValue === null && $itemDefinition->nullable()) {
+                        $processed[$index] = null;
+                        continue;
+                    }
+
+                    $itemResult = $this->processValue($name . '[' . $index . ']', $itemDefinition, $itemValue, $cast, $strict, $input, $itemErrors);
+                    if ($itemResult['ok']) {
+                        $processed[$index] = $itemResult['value'];
+                    }
+                }
+
+                if (!empty($itemErrors)) {
+                    $this->addError($errors, $name, 'item_failed', $itemErrors);
+                    return ['ok' => false, 'value' => null];
+                }
+
+                return ['ok' => true, 'value' => $processed];
+            }
+
+            return ['ok' => true, 'value' => $value];
+        }
+
+        if ($useCast && $type === DataTypes::BOOLEAN->value) {
+            $value = $this->normalizeBoolean($value);
+        }
+
+        if ($type === DataTypes::ARRAY->value) {
+            if (!is_array($value)) {
+                if ($useCast) {
+                    $value = Arr::make($value)->val();
+                } else {
+                    $this->addError($errors, $name, 'expected_array');
+                    return ['ok' => false, 'value' => null];
+                }
+            }
+        }
+
+        if ($type === DataTypes::OBJECT->value) {
+            if (!is_object($value)) {
+                $this->addError($errors, $name, 'expected_object');
+                return ['ok' => false, 'value' => null];
+            }
+        }
+
+        $valueObject = $this->makeValueObject($type, $value);
+        if ($valueObject instanceof IVal) {
+            if ($useCast) {
+                $valueObject->cast();
+                $value = $valueObject->val();
+            } elseif (!$valueObject->isValid($value)) {
+                $this->addError($errors, $name, 'invalid_type');
+                return ['ok' => false, 'value' => null];
+            }
+
+            $constraintResult = $this->applyConstraints($valueObject, $value, $definition, $name, $input, $errors);
+            if (!$constraintResult['ok']) {
+                return ['ok' => false, 'value' => null];
+            }
+            $value = $constraintResult['value'];
+        }
+
+        return ['ok' => true, 'value' => $value];
+    }
+
+    protected function applyConstraints(IVal $valueObject, $value, FieldDefinition $definition, string $name, array $input, array &$errors): array
+    {
+        $constraints = $definition->constraints();
+        if (empty($constraints)) {
+            return ['ok' => true, 'value' => $value];
+        }
+
+        $constraintFailed = false;
+        $constraintMessage = null;
+
+        foreach ($constraints as $constraint) {
+            if (!is_callable($constraint)) {
+                continue;
+            }
+            $arity = $this->callableArity($constraint);
+            $valueObject->constraint(function (&$current) use ($constraint, $arity, $name, $input, &$constraintFailed, &$constraintMessage) {
+                $result = null;
+                try {
+                    if ($arity >= 3) {
+                        $result = $constraint($current, $name, $input);
+                    } elseif ($arity === 2) {
+                        $result = $constraint($current, $name);
+                    } else {
+                        $result = $constraint($current);
+                    }
+                } catch (\Throwable $e) {
+                    $constraintFailed = true;
+                    $constraintMessage = $e->getMessage();
+                    return;
+                }
+
+                if ($result === false) {
+                    $constraintFailed = true;
+                    $constraintMessage = 'constraint_failed';
+                }
+            });
+        }
+
+        try {
+            $valueObject->val($value);
+            $value = $valueObject->val();
+        } catch (\Throwable $e) {
+            $constraintFailed = true;
+            $constraintMessage = $e->getMessage();
+        }
+
+        if ($constraintFailed) {
+            $this->addError($errors, $name, $constraintMessage ?: 'constraint_failed');
+            return ['ok' => false, 'value' => null];
+        }
+
+        return ['ok' => true, 'value' => $value];
+    }
+
+    protected function callableArity(callable $callable): int
+    {
+        try {
+            if (is_array($callable) && count($callable) === 2) {
+                $ref = new \ReflectionMethod($callable[0], $callable[1]);
+            } elseif (is_string($callable)) {
+                $ref = new \ReflectionFunction($callable);
+            } elseif ($callable instanceof \Closure) {
+                $ref = new \ReflectionFunction($callable);
+            } elseif (is_object($callable) && method_exists($callable, '__invoke')) {
+                $ref = new \ReflectionMethod($callable, '__invoke');
+            } else {
+                return 1;
+            }
+
+            return $ref->getNumberOfParameters();
+        } catch (\Throwable $e) {
+            return 1;
+        }
+    }
+
+    protected function normalizeDefinition(string $name, $definition): FieldDefinition
+    {
+        if ($definition instanceof FieldDefinition) {
+            return $definition;
+        }
+
+        if ($definition instanceof self) {
+            return new FieldDefinition($name, ['schema' => $definition]);
+        }
+
+        if (is_array($definition)) {
+            $definition['schema'] = $definition['schema'] ?? ($definition['fields'] ?? null);
+            return new FieldDefinition($name, $definition);
+        }
+
+        return new FieldDefinition($name, ['type' => $definition]);
+    }
+
+    protected function normalizeItemDefinition($definition): ?FieldDefinition
+    {
+        if ($definition instanceof FieldDefinition) {
+            return $definition;
+        }
+
+        if ($definition instanceof self) {
+            return new FieldDefinition('item', ['schema' => $definition]);
+        }
+
+        if (is_array($definition)) {
+            return new FieldDefinition('item', $definition);
+        }
+
+        if ($definition !== null) {
+            return new FieldDefinition('item', ['type' => $definition]);
+        }
+
+        return null;
+    }
+
+    protected function normalizeSchema($schema): ?self
+    {
+        if ($schema instanceof self) {
+            return $schema;
+        }
+
+        if (is_array($schema)) {
+            return new self($schema);
+        }
+
+        return null;
+    }
+
+    protected function normalizeType($type): ?string
+    {
+        if ($type instanceof DataTypes) {
+            return $type->value;
+        }
+
+        if (!is_string($type)) {
+            return null;
+        }
+
+        $type = strtolower($type);
+        $aliases = [
+            'int' => DataTypes::INTEGER->value,
+            'integer' => DataTypes::INTEGER->value,
+            'float' => DataTypes::FLOAT->value,
+            'double' => DataTypes::DOUBLE->value,
+            'number' => DataTypes::NUMBER->value,
+            'bool' => DataTypes::BOOLEAN->value,
+            'boolean' => DataTypes::BOOLEAN->value,
+            'string' => DataTypes::STRING->value,
+            'array' => DataTypes::ARRAY->value,
+            'object' => DataTypes::OBJECT->value,
+            'datetime' => DataTypes::DATETIME->value,
+            'callable' => DataTypes::CALLABLE->value,
+            'generic' => DataTypes::GENERIC->value,
+        ];
+
+        return $aliases[$type] ?? $type;
+    }
+
+    protected function makeValueObject(?string $type, $value): ?IVal
+    {
+        if (!$type) {
+            return ValFactory::make(DataTypes::GENERIC, $value);
+        }
+
+        if ($type === DataTypes::OBJECT->value) {
+            return ValFactory::make(DataTypes::GENERIC, $value);
+        }
+
+        return ValFactory::make($type, $value);
+    }
+
+    protected function normalizeData($data): array
+    {
+        if (is_array($data)) {
+            return $data;
+        }
+
+        if ($data instanceof Arr) {
+            return $data->val();
+        }
+
+        if ($data instanceof Obj) {
+            return $data->toArray();
+        }
+
+        if (is_object($data)) {
+            return get_object_vars($data);
+        }
+
+        return [];
+    }
+
+    protected function normalizeBoolean($value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+            if (in_array($normalized, ['1', 'true', 'yes', 'y', 'on'], true)) {
+                return true;
+            }
+            if (in_array($normalized, ['0', 'false', 'no', 'n', 'off', ''], true)) {
+                return false;
+            }
+        }
+
+        return (bool)$value;
+    }
+
+    protected function resolveDefault(FieldDefinition $definition)
+    {
+        $default = $definition->defaultValue();
+        if (is_callable($default)) {
+            return $default($definition->name(), $this);
+        }
+        return $default;
+    }
+
+    protected function addError(array &$errors, string $field, string $message, $details = null): void
+    {
+        $entry = ['message' => $message];
+        if ($details !== null) {
+            $entry['details'] = $details;
+        }
+
+        if (!array_key_exists($field, $errors)) {
+            $errors[$field] = [];
+        }
+
+        $errors[$field][] = $entry;
+    }
+
+    protected function arrayValue($value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if ($value instanceof Arr) {
+            return $value->val();
+        }
+
+        return [];
+    }
+
+    protected function setValue(string $field, $value): void
+    {
+        $current = $this->_data[$field] ?? null;
+        if ($current instanceof IVal) {
+            $current->val($value);
+            return;
+        }
+        $this->_data[$field] = $value;
+    }
+}

--- a/src/Data/Schema/FieldDefinition.php
+++ b/src/Data/Schema/FieldDefinition.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace BlueFission\Data\Schema;
+
+use BlueFission\Obj;
+use BlueFission\DataTypes;
+use BlueFission\Val;
+use BlueFission\DevElation as Dev;
+
+class FieldDefinition extends Obj
+{
+    protected $_data = [
+        'name' => '',
+        'type' => '',
+        'required' => false,
+        'nullable' => false,
+        'default' => null,
+        'hasDefault' => false,
+        'cast' => true,
+        'constraints' => [],
+        'items' => null,
+        'schema' => null,
+        'source' => '',
+    ];
+
+    protected $_types = [
+        'name' => DataTypes::STRING,
+        'type' => DataTypes::STRING,
+        'required' => DataTypes::BOOLEAN,
+        'nullable' => DataTypes::BOOLEAN,
+        'cast' => DataTypes::BOOLEAN,
+        'constraints' => DataTypes::ARRAY,
+        'source' => DataTypes::STRING,
+        'hasDefault' => DataTypes::BOOLEAN,
+    ];
+
+    public function __construct(string $name, array $config = [])
+    {
+        parent::__construct();
+
+        $config = Dev::apply('_in', $config);
+        $type = $config['type'] ?? '';
+        if ($type instanceof DataTypes) {
+            $type = $type->value;
+        }
+
+        $constraints = $config['constraints'] ?? [];
+        if (Val::isNotNull($constraints) && !is_array($constraints)) {
+            $constraints = [$constraints];
+        }
+
+        $hasDefault = array_key_exists('default', $config);
+
+        $this->assign([
+            'name' => $name,
+            'type' => is_string($type) ? $type : '',
+            'required' => (bool)($config['required'] ?? false),
+            'nullable' => (bool)($config['nullable'] ?? false),
+            'default' => $config['default'] ?? null,
+            'hasDefault' => $hasDefault,
+            'cast' => (bool)($config['cast'] ?? true),
+            'constraints' => $constraints ?? [],
+            'items' => $config['items'] ?? null,
+            'schema' => $config['schema'] ?? ($config['fields'] ?? null),
+            'source' => (string)($config['source'] ?? ''),
+        ]);
+
+        Dev::do('_after', [$this]);
+    }
+
+    public function name(): string
+    {
+        return (string)$this->field('name');
+    }
+
+    public function type(): string
+    {
+        return (string)$this->field('type');
+    }
+
+    public function required(): bool
+    {
+        return (bool)$this->field('required');
+    }
+
+    public function nullable(): bool
+    {
+        return (bool)$this->field('nullable');
+    }
+
+    public function cast(): bool
+    {
+        return (bool)$this->field('cast');
+    }
+
+    public function hasDefault(): bool
+    {
+        return (bool)$this->field('hasDefault');
+    }
+
+    public function defaultValue()
+    {
+        return $this->field('default');
+    }
+
+    public function constraints(): array
+    {
+        $value = $this->field('constraints');
+        return is_array($value) ? $value : [];
+    }
+
+    public function items()
+    {
+        return $this->field('items');
+    }
+
+    public function schema()
+    {
+        return $this->field('schema');
+    }
+
+    public function source(): string
+    {
+        return (string)$this->field('source');
+    }
+}

--- a/src/Security/Hash.php
+++ b/src/Security/Hash.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace BlueFission\Security;
+
+use BlueFission\Arr;
+use BlueFission\IVal;
+use BlueFission\Obj;
+use BlueFission\Val;
+use BlueFission\DataTypes;
+use BlueFission\Behavioral\Behaviors\Action;
+use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\DevElation as Dev;
+
+class Hash extends Obj
+{
+    protected $_data = [
+        'algo' => 'sha256',
+        'last' => '',
+        'errors' => [],
+    ];
+
+    protected $_types = [
+        'algo' => DataTypes::STRING,
+        'last' => DataTypes::STRING,
+        'errors' => DataTypes::ARRAY,
+    ];
+
+    public function __construct(?string $algo = null)
+    {
+        parent::__construct();
+
+        if (Val::isNotNull($algo)) {
+            $this->setValue('algo', (string)$algo);
+        }
+
+        Dev::do('_after', [$this]);
+    }
+
+    public static function algorithms(): array
+    {
+        return hash_algos();
+    }
+
+    public static function supports(string $algo): bool
+    {
+        return in_array($algo, hash_algos(), true);
+    }
+
+    public static function value($data, ?string $algo = null, bool $raw = false): string
+    {
+        $hash = new self($algo);
+        return $hash->hash($data, $algo, $raw);
+    }
+
+    public static function hmacValue($data, string $key, ?string $algo = null, bool $raw = false): string
+    {
+        $hash = new self($algo);
+        return $hash->hmac($data, $key, $algo, $raw);
+    }
+
+    public static function checksum(string $path, ?string $algo = null, bool $raw = false): string
+    {
+        $hash = new self($algo);
+        return $hash->checksumFile($path, $algo, $raw);
+    }
+
+    public static function contentIdValue($data, ?string $algo = null, string $prefix = 'cid'): string
+    {
+        $hash = new self($algo);
+        return $hash->contentId($data, $algo, $prefix);
+    }
+
+    public function algorithm(?string $algo = null): string
+    {
+        if (Val::isNull($algo)) {
+            return (string)$this->field('algo');
+        }
+
+        $this->setValue('algo', (string)$algo);
+        return (string)$this->field('algo');
+    }
+
+    public function last(): string
+    {
+        return (string)$this->field('last');
+    }
+
+    public function hash($data, ?string $algo = null, bool $raw = false): string
+    {
+        $data = Dev::apply('_in', $data);
+        $algo = $algo ?? $this->algorithm();
+        $raw = (bool)Dev::apply('_in', $raw);
+        Dev::do('_before', [$data, $algo, $raw, $this]);
+
+        $this->clearErrors();
+        $this->perform(new Action(Action::PROCESS), new Meta(data: ['algo' => $algo]));
+
+        $normalized = $this->normalizeData($data);
+        if (!$this->isAlgorithmSupported($algo)) {
+            $this->addError('algorithm', 'unsupported_hash_algorithm');
+            $this->perform(Event::FAILURE, new Meta(data: $this->errors()));
+            Dev::do('_after', [$this]);
+            return '';
+        }
+
+        $digest = hash($algo, $normalized, $raw);
+        if ($digest === false) {
+            $this->addError('hash', 'hash_failed');
+            $this->perform(Event::FAILURE, new Meta(data: $this->errors()));
+            Dev::do('_after', [$this]);
+            return '';
+        }
+
+        $this->setValue('last', (string)$digest);
+        $digest = (string)Dev::apply('_out', $digest);
+        $this->perform(Event::SUCCESS, new Meta(data: $digest));
+        $this->perform(Event::PROCESSED, new Meta(data: $digest));
+        Dev::do('_after', [$digest, $this]);
+
+        return $digest;
+    }
+
+    public function hmac($data, string $key, ?string $algo = null, bool $raw = false): string
+    {
+        $data = Dev::apply('_in', $data);
+        $key = Dev::apply('_in', $key);
+        $algo = $algo ?? $this->algorithm();
+        $raw = (bool)Dev::apply('_in', $raw);
+        Dev::do('_before', [$data, $key, $algo, $raw, $this]);
+
+        $this->clearErrors();
+        $this->perform(new Action(Action::PROCESS), new Meta(data: ['algo' => $algo, 'hmac' => true]));
+
+        $normalized = $this->normalizeData($data);
+        if (!$this->isAlgorithmSupported($algo)) {
+            $this->addError('algorithm', 'unsupported_hash_algorithm');
+            $this->perform(Event::FAILURE, new Meta(data: $this->errors()));
+            Dev::do('_after', [$this]);
+            return '';
+        }
+
+        $digest = hash_hmac($algo, $normalized, $key, $raw);
+        if ($digest === false) {
+            $this->addError('hash', 'hash_failed');
+            $this->perform(Event::FAILURE, new Meta(data: $this->errors()));
+            Dev::do('_after', [$this]);
+            return '';
+        }
+
+        $this->setValue('last', (string)$digest);
+        $digest = (string)Dev::apply('_out', $digest);
+        $this->perform(Event::SUCCESS, new Meta(data: $digest));
+        $this->perform(Event::PROCESSED, new Meta(data: $digest));
+        Dev::do('_after', [$digest, $this]);
+
+        return $digest;
+    }
+
+    public function verify($data, string $hash, ?string $algo = null, bool $raw = false): bool
+    {
+        $data = Dev::apply('_in', $data);
+        $hash = Dev::apply('_in', $hash);
+        $algo = $algo ?? $this->algorithm();
+        $raw = (bool)Dev::apply('_in', $raw);
+
+        $computed = $this->hash($data, $algo, $raw);
+        if ($computed === '' || $hash === '') {
+            return false;
+        }
+
+        return hash_equals($computed, $hash);
+    }
+
+    public function checksumFile(string $path, ?string $algo = null, bool $raw = false): string
+    {
+        $path = Dev::apply('_in', $path);
+        $algo = $algo ?? $this->algorithm();
+        $raw = (bool)Dev::apply('_in', $raw);
+        Dev::do('_before', [$path, $algo, $raw, $this]);
+
+        $this->clearErrors();
+        $this->perform(new Action(Action::PROCESS), new Meta(data: ['algo' => $algo, 'file' => $path]));
+
+        if (!is_file($path)) {
+            $this->addError('file', 'file_not_found');
+            $this->perform(Event::FAILURE, new Meta(data: $this->errors()));
+            Dev::do('_after', [$this]);
+            return '';
+        }
+
+        if (!$this->isAlgorithmSupported($algo)) {
+            $this->addError('algorithm', 'unsupported_hash_algorithm');
+            $this->perform(Event::FAILURE, new Meta(data: $this->errors()));
+            Dev::do('_after', [$this]);
+            return '';
+        }
+
+        $digest = hash_file($algo, $path, $raw);
+        if ($digest === false) {
+            $this->addError('hash', 'hash_failed');
+            $this->perform(Event::FAILURE, new Meta(data: $this->errors()));
+            Dev::do('_after', [$this]);
+            return '';
+        }
+
+        $this->setValue('last', (string)$digest);
+        $digest = (string)Dev::apply('_out', $digest);
+        $this->perform(Event::SUCCESS, new Meta(data: $digest));
+        $this->perform(Event::PROCESSED, new Meta(data: $digest));
+        Dev::do('_after', [$digest, $this]);
+
+        return $digest;
+    }
+
+    public function contentId($data, ?string $algo = null, string $prefix = 'cid'): string
+    {
+        $prefix = Dev::apply('_in', $prefix);
+        $hash = $this->hash($data, $algo);
+        if ($hash === '') {
+            return '';
+        }
+        $output = $prefix . ':' . $hash;
+        return (string)Dev::apply('_out', $output);
+    }
+
+    public function errors(): array
+    {
+        $value = $this->field('errors');
+        return is_array($value) ? $value : [];
+    }
+
+    public function clearErrors(): self
+    {
+        $this->setValue('errors', []);
+        return $this;
+    }
+
+    protected function normalizeData($data): string
+    {
+        if (is_string($data)) {
+            return $data;
+        }
+
+        if (is_int($data) || is_float($data) || is_bool($data)) {
+            return (string)$data;
+        }
+
+        if (is_array($data) || is_object($data)) {
+            return json_encode($data);
+        }
+
+        if (is_resource($data)) {
+            $contents = stream_get_contents($data);
+            return $contents === false ? '' : $contents;
+        }
+
+        return (string)$data;
+    }
+
+    protected function isAlgorithmSupported(string $algo): bool
+    {
+        return in_array($algo, hash_algos(), true);
+    }
+
+    protected function addError(string $field, string $message): void
+    {
+        $errors = $this->errors();
+        if (!array_key_exists($field, $errors)) {
+            $errors[$field] = [];
+        }
+        $errors[$field][] = ['message' => $message];
+        $this->setValue('errors', $errors);
+    }
+
+    protected function setValue(string $field, $value): void
+    {
+        $current = $this->_data[$field] ?? null;
+        if ($current instanceof IVal) {
+            $current->val($value);
+            return;
+        }
+        $this->_data[$field] = $value;
+    }
+}

--- a/tests/Data/SchemaTest.php
+++ b/tests/Data/SchemaTest.php
@@ -1,0 +1,83 @@
+<?php
+namespace BlueFission\Tests\Data;
+
+use BlueFission\Data\Schema;
+use BlueFission\Data\Schema\FieldDefinition;
+
+class SchemaTest extends \PHPUnit\Framework\TestCase
+{
+    public function testAppliesDefaultsAndCasting()
+    {
+        $schema = new Schema([
+            'name' => ['type' => 'string', 'required' => true],
+            'age' => ['type' => 'int', 'default' => 0],
+            'active' => ['type' => 'bool', 'default' => true],
+            'tags' => ['type' => 'array', 'items' => ['type' => 'string']],
+        ], ['strict' => true]);
+
+        $result = $schema->apply([
+            'name' => 123,
+            'age' => '42',
+            'tags' => ['alpha', 9],
+        ]);
+
+        $this->assertSame('123', $result['name']);
+        $this->assertSame(42, $result['age']);
+        $this->assertSame(true, $result['active']);
+        $this->assertSame(['alpha', '9'], $result['tags']);
+        $this->assertEmpty($schema->errors());
+    }
+
+    public function testBooleanCastingUsesStringLiterals()
+    {
+        $schema = new Schema([
+            'enabled' => ['type' => 'bool'],
+        ]);
+
+        $result = $schema->transform(['enabled' => 'false']);
+
+        $this->assertSame(false, $result['enabled']);
+    }
+
+    public function testValidationErrorsAndStrictUnknowns()
+    {
+        $metaSchema = new Schema([
+            'title' => ['type' => 'string', 'required' => true],
+        ]);
+
+        $schema = new Schema([
+            'id' => ['type' => 'integer', 'required' => true],
+            'meta' => ['schema' => $metaSchema],
+        ], ['strict' => true]);
+
+        $valid = $schema->validate([
+            'meta' => ['title' => null],
+            'extra' => true,
+        ]);
+
+        $errors = $schema->errors();
+
+        $this->assertFalse($valid);
+        $this->assertArrayHasKey('id', $errors);
+        $this->assertArrayHasKey('meta', $errors);
+        $this->assertArrayHasKey('extra', $errors);
+    }
+
+    public function testConstraintFailure()
+    {
+        $schema = new Schema([
+            'name' => new FieldDefinition('name', [
+                'type' => 'string',
+                'constraints' => function (&$value) {
+                    $value = trim((string)$value);
+                    return $value !== '';
+                },
+            ]),
+        ]);
+
+        $schema->apply(['name' => '   ']);
+
+        $errors = $schema->errors();
+        $this->assertArrayHasKey('name', $errors);
+    }
+}

--- a/tests/Security/HashTest.php
+++ b/tests/Security/HashTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace BlueFission\Tests\Security;
+
+use BlueFission\Security\Hash;
+use BlueFission\Tests\Support\TestEnvironment;
+
+require_once __DIR__ . '/../Support/TestEnvironment.php';
+
+class HashTest extends \PHPUnit\Framework\TestCase
+{
+    public function testHashAndVerify()
+    {
+        $hash = new Hash('sha256');
+        $digest = $hash->hash('test');
+
+        $this->assertSame(hash('sha256', 'test'), $digest);
+        $this->assertTrue($hash->verify('test', $digest));
+    }
+
+    public function testHmac()
+    {
+        $hash = new Hash('sha256');
+        $digest = $hash->hmac('payload', 'secret');
+
+        $this->assertSame(hash_hmac('sha256', 'payload', 'secret'), $digest);
+    }
+
+    public function testChecksumFile()
+    {
+        $dir = TestEnvironment::tempDir('bf_hash');
+        $path = $dir . DIRECTORY_SEPARATOR . 'sample.txt';
+        file_put_contents($path, 'content');
+
+        $hash = new Hash('sha1');
+        $digest = $hash->checksumFile($path);
+
+        $this->assertSame(hash_file('sha1', $path), $digest);
+        TestEnvironment::removeDir($dir);
+    }
+
+    public function testContentId()
+    {
+        $hash = new Hash('sha256');
+        $digest = $hash->contentId('data', null, 'bf');
+
+        $this->assertSame('bf:' . hash('sha256', 'data'), $digest);
+    }
+
+    public function testAlgorithmsAndSupport()
+    {
+        $algorithms = Hash::algorithms();
+        $this->assertContains('sha256', $algorithms);
+        $this->assertTrue(Hash::supports('sha256'));
+        $this->assertFalse(Hash::supports('invalid-algo'));
+    }
+
+    public function testUnsupportedAlgorithm()
+    {
+        $hash = new Hash('sha256');
+        $digest = $hash->hash('data', 'invalid-algo');
+
+        $this->assertSame('', $digest);
+        $this->assertNotEmpty($hash->errors());
+    }
+}

--- a/utilities.md
+++ b/utilities.md
@@ -40,6 +40,16 @@ Mem::assess();
 Mem::flush();
 ```
 
+## Hash Utilities
+
+```php
+use BlueFission\Security\Hash;
+
+$hash = new Hash('sha256');
+$digest = $hash->hash('payload');
+$valid = $hash->verify('payload', $digest);
+```
+
 ## Related
 
 Storage paths for CLI sessions live under `src/Utils/storage`.


### PR DESCRIPTION
## Intent summary
  - Introduce `BlueFission\Data\Schema` for typed validation/casting with constraints and nested schemas.
  - Add `BlueFission\Security\Hash` for hashing, HMAC, checksums, and content IDs.
  - Document new utilities and link them from the README.

##  User stories / acceptance criteria
  - As a developer, I can define schemas with types, defaults, and constraints and get normalized output or errors.
  - As a developer, I can hash payloads, verify digests, generate HMACs, compute file checksums, and build content IDs.
  - Documentation covers schema usage, hashing utilities, and links from the README.

##  Key files changed
  - `src/Data/Schema.php`
  - `src/Data/Schema/FieldDefinition.php`
  - `src/Security/Hash.php`
  - `tests/Data/SchemaTest.php`
  - `tests/Security/HashTest.php`
  - `schema.md`
  - `security.md`
  - `data_management.md`
  - `utilities.md`
  - `README.md`

##  How to test
  - `vendor/bin/phpunit --do-not-cache-result tests/Data/SchemaTest.php`
  - `vendor/bin/phpunit --do-not-cache-result tests/Security/HashTest.php`
  - `vendor/bin/phpunit --do-not-cache-result` (full run; note: some integration tests are skipped without env vars)

###  QA checklist
  - [ ] Schema casts/validates and surfaces errors as expected
  - [ ] Hash/HMAC/checksum outputs match PHP hash functions
  - [ ] Docs and README links are valid
  - [ ] Full test suite passes (skips acceptable for optional integrations)

###  Approval conditions
  - Docs reviewed and accepted
  - Test results verified