### PR TITLE
migrates graph logic from Automata

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Handle queues, storage solutions, databases, Redis, MemQ, files, and logs with a
 
 - [Data Management Documentation](data_management.md)
 - [Schema Documentation](schema.md)
+- [Graph Documentation](graph.md)
 
 ### HTML Building Tools
 Construct HTML elements for forms, tables, and templating with ease, improving the speed of frontend development.

--- a/data_management.md
+++ b/data_management.md
@@ -55,6 +55,25 @@ if ($schema->errors()) {
 
 See `schema.md` for nested schemas, arrays, and constraint patterns.
 
+## Graph Utilities
+
+`BlueFission\Data\Graph` provides lightweight node/edge helpers and a
+shortest-path utility when you need an in-memory graph structure.
+
+```php
+use BlueFission\Data\Graph\Graph;
+
+$graph = new Graph([], false);
+$graph->connect('a', 'b', ['weight' => 2]);
+$graph->connect('b', 'c', ['weight' => 1]);
+
+$path = $graph->shortestPath('a', 'c', function (array $edge): int {
+    return (int)($edge['weight'] ?? 1);
+});
+```
+
+See `graph.md` for more examples and event hooks.
+
 ## Quick Start: Session Storage
 
 ```php

--- a/graph.md
+++ b/graph.md
@@ -1,0 +1,59 @@
+# Graph Utilities
+
+`BlueFission\Data\Graph` provides small, reusable graph and node helpers for
+adjacency maps, edge metadata, and simple pathfinding.
+
+## Quick Start
+
+```php
+use BlueFission\Data\Graph\Graph;
+use BlueFission\Data\Graph\Node;
+
+$graph = new Graph([], true); // directed by default
+
+$graph->addNode(new Node('a'));
+$graph->addNode(new Node('b'));
+$graph->connect('a', 'b', ['weight' => 2]);
+$graph->connect('a', 'c', ['weight' => 1]);
+$graph->connect('c', 'b', ['weight' => 1]);
+
+$path = $graph->shortestPath('a', 'b', function (array $edge): int {
+    return (int)($edge['weight'] ?? 1);
+});
+```
+
+## Nodes and Edges
+
+```php
+use BlueFission\Data\Graph\Node;
+
+$node = new Node('alpha');
+$node->addEdge('beta', ['weight' => 3, 'label' => 'link']);
+
+$node->getEdgeAttributes('beta'); // ['weight' => 3, 'label' => 'link']
+```
+
+## Directed vs Undirected
+
+```php
+$graph = new Graph([], false); // undirected
+$graph->connect('a', 'b', ['weight' => 2]); // adds a->b and b->a
+```
+
+## Events and Hooks
+
+Graph and Node dispatch behavioral events you can listen to:
+
+```php
+use BlueFission\Behavioral\Behaviors\Event;
+
+$graph->when(new Event(Event::ITEM_ADDED), function () {
+    // node or edge added
+});
+```
+
+Filters and actions are available via `DevElation::apply()` and
+`DevElation::do()` using the internal hook names:
+
+- `_node`, `_connect`, `_edge`
+- `_node_added`, `_edge_added`, `_edge_removed`

--- a/src/Data/Graph/Graph.php
+++ b/src/Data/Graph/Graph.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace BlueFission\Data\Graph;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\DataTypes;
+use BlueFission\DevElation as Dev;
+use BlueFission\Behavioral\Behaviors\Event;
+
+class Graph extends Obj
+{
+    protected $_data = [
+        'nodes' => [],
+        'edges' => [],
+        'directed' => true,
+        'meta' => [],
+    ];
+
+    protected $_types = [
+        'nodes' => DataTypes::ARRAY,
+        'edges' => DataTypes::ARRAY,
+        'directed' => DataTypes::BOOLEAN,
+        'meta' => DataTypes::ARRAY,
+    ];
+
+    protected $_lockDataType = true;
+
+    public function __construct(array $graph = [], bool $directed = true)
+    {
+        parent::__construct();
+
+        $this->exposeValueObject(true);
+        $this->nodes->constraint(function (&$value): bool {
+            $value = Arr::toArray($value);
+            return true;
+        });
+        $this->edges->constraint(function (&$value): bool {
+            $value = Arr::toArray($value);
+            return true;
+        });
+        $this->meta->constraint(function (&$value): bool {
+            $value = Arr::toArray($value);
+            return true;
+        });
+        $this->exposeValueObject(false);
+
+        $this->nodes = [];
+        $this->edges = [];
+        $this->directed = $directed;
+        $this->meta = [];
+
+        $this->echo($this->nodeMap(), [Event::CHANGE]);
+        $this->echo($this->edgeMap(), [Event::CHANGE]);
+
+        $this->when(Event::CHANGE, function (): void {
+            if (!($this->_data['nodes'] ?? null) instanceof Arr) {
+                $this->_data['nodes'] = new Arr([]);
+            }
+            if (!($this->_data['edges'] ?? null) instanceof Arr) {
+                $this->_data['edges'] = new Arr([]);
+            }
+            if (!Arr::is($this->meta)) {
+                $this->meta = [];
+            }
+        });
+
+        if (!empty($graph)) {
+            $this->load($graph);
+        }
+    }
+
+    public function addNode(Node $node): void
+    {
+        $node = Dev::apply('_node', $node);
+        if (!$node instanceof Node) {
+            return;
+        }
+
+        $this->nodeMap()->set($node->getName(), $node);
+        $this->edgeMap()->set($node->getName(), $node->edges());
+
+        $node->when(Event::CHANGE, function () use ($node): void {
+            $this->syncNode($node);
+        });
+
+        $this->dispatch(Event::ITEM_ADDED, ['node' => $node]);
+        $this->dispatch(Event::CHANGE, ['node' => $node]);
+        Dev::do('_node_added', [$node, $this]);
+    }
+
+    public function node(string $id): ?Node
+    {
+        $node = $this->nodeMap()->get($id);
+        return $node instanceof Node ? $node : null;
+    }
+
+    public function nodes(): array
+    {
+        return $this->nodeMap()->val();
+    }
+
+    public function connect(string $from, string $to, array $attributes = [], ?bool $directed = null): void
+    {
+        $edge = [
+            'from' => $from,
+            'to' => $to,
+            'attributes' => Arr::toArray($attributes),
+        ];
+        $edge = Dev::apply('_connect', $edge);
+        $edge = Arr::toArray($edge);
+        $edge = Arr::merge([
+            'from' => $from,
+            'to' => $to,
+            'attributes' => Arr::toArray($attributes),
+        ], $edge);
+
+        $fromNode = $this->ensureNode((string)$edge['from']);
+        $toNode = $this->ensureNode((string)$edge['to']);
+
+        $attributes = Arr::toArray($edge['attributes'] ?? []);
+        $fromNode->addEdge($toNode->getName(), $attributes);
+        $this->edgeMap()->set($fromNode->getName(), $fromNode->edges());
+
+        if ($this->isUndirected($directed)) {
+            $toNode->addEdge($fromNode->getName(), $attributes);
+            $this->edgeMap()->set($toNode->getName(), $toNode->edges());
+        }
+
+        $this->dispatch(Event::ITEM_ADDED, ['edge' => $edge]);
+        $this->dispatch(Event::CHANGE, ['edge' => $edge]);
+        Dev::do('_edge_added', [$edge, $this]);
+    }
+
+    public function neighbors(string $id): array
+    {
+        $edges = $this->edgeMap()->get($id);
+        if (!Arr::is($edges)) {
+            return [];
+        }
+
+        return Arr::keys($edges);
+    }
+
+    public function edgeAttributes(string $from, string $to): ?array
+    {
+        $edges = $this->edgeMap()->get($from);
+        if (!Arr::is($edges)) {
+            return null;
+        }
+
+        if (!Arr::hasKey($edges, $to)) {
+            return null;
+        }
+
+        $attributes = $edges[$to];
+        if (!Arr::is($attributes)) {
+            return ['weight' => $attributes];
+        }
+
+        return $attributes;
+    }
+
+    public function getEdgeAttributes(string $from, string $to): ?array
+    {
+        return $this->edgeAttributes($from, $to);
+    }
+
+    public function shortestPath(string $start, string $end, ?callable $fitnessFunction = null): array
+    {
+        $nodeNames = Arr::keys($this->nodeMap()->val());
+        if (count($nodeNames) === 0) {
+            $nodeNames = Arr::keys($this->edgeMap()->val());
+        }
+
+        if (count($nodeNames) === 0) {
+            return [];
+        }
+
+        $fitnessFunction = $fitnessFunction ?? function (array $attributes): float {
+            if (Arr::hasKey($attributes, 'weight')) {
+                return (float)$attributes['weight'];
+            }
+            if (Arr::hasKey($attributes, 'cost')) {
+                return (float)$attributes['cost'];
+            }
+            if (Arr::hasKey($attributes, 'distance')) {
+                return (float)$attributes['distance'];
+            }
+            if (Arr::hasKey($attributes, 0) && is_numeric($attributes[0])) {
+                return (float)$attributes[0];
+            }
+            return 1.0;
+        };
+
+        $distances = [];
+        $previous = [];
+        $unvisited = new Arr([]);
+
+        foreach ($nodeNames as $name) {
+            $distances[$name] = PHP_INT_MAX;
+            $previous[$name] = null;
+            $unvisited->set($name, true);
+        }
+
+        if (!Arr::hasKey($distances, $start) || !Arr::hasKey($distances, $end)) {
+            return [];
+        }
+
+        $distances[$start] = 0;
+
+        while ($unvisited->count() > 0) {
+            $unvisitedArray = $unvisited->val();
+
+            $closest = null;
+            $closestDistance = PHP_INT_MAX;
+
+            foreach ($unvisitedArray as $name => $_) {
+                if ($distances[$name] < $closestDistance) {
+                    $closestDistance = $distances[$name];
+                    $closest = $name;
+                }
+            }
+
+            if ($closest === null) {
+                break;
+            }
+
+            if ($closest === $end) {
+                $path = [];
+                $current = $end;
+
+                while ($current !== null) {
+                    $path[] = $current;
+                    $current = $previous[$current] ?? null;
+                }
+
+                return array_reverse($path);
+            }
+
+            if ($distances[$closest] === PHP_INT_MAX) {
+                break;
+            }
+
+            $edges = $this->edgeMap()->get($closest);
+            if (!Arr::is($edges)) {
+                $edges = [];
+            }
+
+            foreach ($edges as $neighbor => $value) {
+                if (!Arr::hasKey($unvisitedArray, $neighbor)) {
+                    continue;
+                }
+
+                $attributes = Arr::is($value) ? $value : ['weight' => $value];
+                $edgeCost = $fitnessFunction($attributes);
+                if ($edgeCost < 0) {
+                    continue;
+                }
+
+                $alt = $distances[$closest] + $edgeCost;
+
+                if ($alt < ($distances[$neighbor] ?? PHP_INT_MAX)) {
+                    $distances[$neighbor] = $alt;
+                    $previous[$neighbor] = $closest;
+                }
+            }
+
+            $unvisited->delete($closest);
+        }
+
+        return [];
+    }
+
+    public function load(array $graph): void
+    {
+        $graph = Dev::apply('_in', $graph);
+        foreach ($graph as $from => $edges) {
+            $this->ensureNode((string)$from);
+            $edges = Arr::toArray($edges);
+            foreach ($edges as $to => $attributes) {
+                if (!Arr::is($attributes)) {
+                    $attributes = ['weight' => $attributes];
+                }
+                $this->connect((string)$from, (string)$to, $attributes);
+            }
+        }
+    }
+
+    protected function ensureNode(string $id): Node
+    {
+        $node = $this->node($id);
+        if ($node instanceof Node) {
+            return $node;
+        }
+
+        $node = new Node($id);
+        $this->addNode($node);
+        return $node;
+    }
+
+    protected function syncNode(Node $node): void
+    {
+        $this->nodeMap()->set($node->getName(), $node);
+        $this->edgeMap()->set($node->getName(), $node->edges());
+    }
+
+    protected function isUndirected(?bool $directed): bool
+    {
+        if ($directed === null) {
+            return !$this->directed;
+        }
+
+        return !$directed;
+    }
+
+    protected function nodeMap(): Arr
+    {
+        $nodes = $this->_data['nodes'] ?? null;
+        if (!$nodes instanceof Arr) {
+            $nodes = new Arr([]);
+            $this->_data['nodes'] = $nodes;
+        }
+
+        return $nodes;
+    }
+
+    protected function edgeMap(): Arr
+    {
+        $edges = $this->_data['edges'] ?? null;
+        if (!$edges instanceof Arr) {
+            $edges = new Arr([]);
+            $this->_data['edges'] = $edges;
+        }
+
+        return $edges;
+    }
+}

--- a/src/Data/Graph/Node.php
+++ b/src/Data/Graph/Node.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace BlueFission\Data\Graph;
+
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Obj;
+use BlueFission\DataTypes;
+use BlueFission\DevElation as Dev;
+use BlueFission\Behavioral\Behaviors\Event;
+
+class Node extends Obj
+{
+    protected $_data = [
+        'id' => '',
+        'edges' => [],
+        'data' => null,
+        'meta' => [],
+    ];
+
+    protected $_types = [
+        'id' => DataTypes::STRING,
+        'edges' => DataTypes::ARRAY,
+        'data' => DataTypes::GENERIC,
+        'meta' => DataTypes::ARRAY,
+    ];
+
+    protected $_lockDataType = true;
+
+    public function __construct(string $id, $data = null, array $edges = [], array $meta = [])
+    {
+        parent::__construct();
+
+        $this->exposeValueObject(true);
+        $this->id->constraint(function (&$value): bool {
+            $value = Str::trim((string)$value);
+            return $value !== '';
+        });
+        $this->edges->constraint(function (&$value): bool {
+            $value = Arr::toArray($value);
+            return true;
+        });
+        $this->meta->constraint(function (&$value): bool {
+            $value = Arr::toArray($value);
+            return true;
+        });
+        $this->exposeValueObject(false);
+
+        $this->id = $id;
+        $this->data = Dev::apply('_in', $data);
+        $this->edges = $edges;
+        $this->meta = $meta;
+
+        $this->when(Event::CHANGE, function (): void {
+            if (!($this->_data['edges'] ?? null) instanceof Arr) {
+                $this->_data['edges'] = new Arr([]);
+            }
+            if (!Arr::is($this->meta)) {
+                $this->meta = [];
+            }
+        });
+    }
+
+    public function name(): string
+    {
+        return (string)$this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name();
+    }
+
+    public function edges(): array
+    {
+        return Arr::toArray($this->edges);
+    }
+
+    public function getEdges(): array
+    {
+        return $this->edges();
+    }
+
+    public function hasEdge(string $nodeName): bool
+    {
+        $edges = $this->edgeMap()->val();
+        return Arr::hasKey($edges, $nodeName);
+    }
+
+    public function addEdge(string $nodeName, array $attributes = []): self
+    {
+        $attributes = Arr::toArray($attributes);
+        $attributes = Dev::apply('_edge', $attributes);
+        $this->edgeMap()->set($nodeName, $attributes);
+        $this->dispatch(Event::ITEM_ADDED, ['node' => $this->name(), 'edge' => $nodeName, 'attributes' => $attributes]);
+        $this->dispatch(Event::CHANGE, ['node' => $this->name(), 'edge' => $nodeName]);
+        Dev::do('_edge_added', [$this, $nodeName, $attributes]);
+
+        return $this;
+    }
+
+    public function removeEdge(string $nodeName): self
+    {
+        $edges = $this->edgeMap();
+        $edges->delete($nodeName);
+
+        $this->dispatch(Event::DELETED, ['node' => $this->name(), 'edge' => $nodeName]);
+        $this->dispatch(Event::CHANGE, ['node' => $this->name(), 'edge' => $nodeName]);
+        Dev::do('_edge_removed', [$this, $nodeName]);
+
+        return $this;
+    }
+
+    public function getEdgeAttributes(string $nodeName): ?array
+    {
+        $edges = $this->edgeMap()->val();
+        if (!Arr::hasKey($edges, $nodeName)) {
+            return null;
+        }
+
+        $attributes = $edges[$nodeName];
+        if (!Arr::is($attributes)) {
+            return ['weight' => $attributes];
+        }
+
+        return $attributes;
+    }
+
+    protected function edgeMap(): Arr
+    {
+        $edges = $this->_data['edges'] ?? null;
+        if (!$edges instanceof Arr) {
+            $edges = new Arr([]);
+            $this->_data['edges'] = $edges;
+        }
+
+        return $edges;
+    }
+}

--- a/tests/Data/GraphTest.php
+++ b/tests/Data/GraphTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace BlueFission\Tests\Data;
+
+use BlueFission\Data\Graph\Graph;
+use BlueFission\Data\Graph\Node;
+use BlueFission\Behavioral\Behaviors\Event;
+
+class GraphTest extends \PHPUnit\Framework\TestCase
+{
+    public function testAddNodeFiresItemAdded()
+    {
+        $graph = new Graph();
+        $added = false;
+
+        $graph->when(new Event(Event::ITEM_ADDED), function () use (&$added) {
+            $added = true;
+        });
+
+        $graph->addNode(new Node('alpha'));
+
+        $this->assertTrue($added);
+        $this->assertInstanceOf(Node::class, $graph->node('alpha'));
+    }
+
+    public function testConnectAddsEdgesAndNeighbors()
+    {
+        $graph = new Graph();
+        $graph->connect('a', 'b', ['weight' => 2]);
+
+        $this->assertSame(['b'], $graph->neighbors('a'));
+        $this->assertSame(['weight' => 2], $graph->edgeAttributes('a', 'b'));
+    }
+
+    public function testShortestPathUsesFitnessFunction()
+    {
+        $graph = new Graph();
+        $graph->connect('a', 'b', ['weight' => 5]);
+        $graph->connect('a', 'c', ['weight' => 1]);
+        $graph->connect('c', 'b', ['weight' => 1]);
+
+        $path = $graph->shortestPath('a', 'b', function (array $attributes): int {
+            return (int)($attributes['weight'] ?? 0);
+        });
+
+        $this->assertSame(['a', 'c', 'b'], $path);
+    }
+}


### PR DESCRIPTION
## Intent
  Introduce reusable graph/node utilities in BlueFission\Data with DevElation behaviors/hooks, and document the new graph module alongside existing data tooling.

##  User stories / acceptance criteria

  - As a library user, I can model nodes/edges and compute shortest paths using a lightweight in-memory graph.
  - Graph/Node dispatch behavioral events for change tracking and can be filtered via DevElation hooks.
  - Documentation includes the new graph utilities under Data Management.

##   Key files changed

  - src/Data/Graph/Graph.php
  - src/Data/Graph/Node.php
  - tests/Data/GraphTest.php
  - graph.md
  - data_management.md
  - README.md

##  How to test

  - vendor/bin/phpunit --do-not-cache-result
  - vendor/bin/phpunit --do-not-cache-result tests/Data/GraphTest.php

##  QA checklist

  - [ ] Directed/undirected connections behave as expected
  - [ ] shortestPath honors fitness function
  - [ ] Graph/Node event hooks fire on add/connect/remove