### PR TITLE
Decouples programmable from configurable and add several updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -1,0 +1,100 @@
+name: General Issue
+description: Bugs, tasks, refactors, improvements
+title: "[Issue]: "
+labels: ["triage"]
+body:
+  - type: textarea
+    id: one_sentence
+    attributes:
+      label: One-sentence description
+      description: Summarize the problem in one sentence.
+      placeholder: "PDF upload fails for vendors in DocumentResource."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_vs_actual
+    attributes:
+      label: Expected vs actual (user story)
+      description: Explain why it's a problem using a short user story.
+      placeholder: |
+        User story:
+        As a <role>, I want <goal>, so that <benefit>.
+
+        Expected:
+        <what should happen>
+
+        Actual:
+        <what happened instead>
+    validations:
+      required: true
+
+  - type: textarea
+    id: errors
+    attributes:
+      label: Errors / logs / outputs
+      description: Paste any relevant stack traces, console output, screenshots, request payloads, etc.
+      placeholder: |
+        - Error message:
+        - Stack trace:
+        - Request/response:
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Where/when it occurred
+      description: Provide environment and location in the code/UI.
+      placeholder: |
+        Environment: local | dev | staging | production
+        App/module/page:
+        Endpoint/job/command:
+        First observed: YYYY-MM-DD
+        Frequency: always | intermittent
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Give exact steps to reproduce (include data prerequisites if any).
+      placeholder: |
+        1) ...
+        2) ...
+        3) ...
+        Expected result: ...
+        Actual result: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: suspects
+    attributes:
+      label: Suspicions / diagnosis / notes
+      description: Any hypotheses, suspected files, related PRs, prior commits, or known constraints.
+      placeholder: |
+        - Suspected cause:
+        - Suspected files:
+        - Related issues/PRs:
+        - Workarounds:
+    validations:
+      required: false
+
+  - type: input
+    id: severity
+    attributes:
+      label: Severity
+      description: Choose one.
+      placeholder: "blocker | high | medium | low"
+    validations:
+      required: true
+
+  - type: input
+    id: owner
+    attributes:
+      label: Suggested owner (optional)
+      placeholder: "@username"
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,62 @@
+## Intent
+One sentence: what is this PR trying to accomplish?
+
+## Linked Issues
+- Closes #<issue-number>
+- Related: #<issue-number>
+
+## User story / outcome supported
+As a <role>, I want <goal>, so that <benefit>.
+
+## Summary of changes
+- 
+- 
+- 
+
+## Key files / areas touched (callouts)
+- `path/to/file` — why it matters
+- `path/to/file` — why it matters
+
+## QA / Validation checklist
+Provide a *step-by-step* validation plan.
+
+### Manual QA
+- [ ] Step 1: ...
+- [ ] Step 2: ...
+- [ ] Expected result: ...
+
+### Automated checks
+- [ ] Unit tests added/updated: yes/no (details below)
+- [ ] Lint/format: passes
+- [ ] CI pipeline: passes
+
+## Setup / configuration / migrations
+List anything needed to run this PR.
+
+- [ ] Env vars added/changed:
+- [ ] DB migrations:
+- [ ] Seeds needed:
+- [ ] Package updates (composer/npm):
+- [ ] Feature flags / config toggles:
+
+## Unit tests (specific)
+Explain exactly what tests validate this PR and how to run them.
+
+- Test(s) added/updated:
+- Command(s):
+  - `...`
+
+## Risk and rollout
+- Risk level: low | medium | high
+- What could break?
+- Backward compatibility notes:
+- Rollback plan:
+  - Revert PR? Feature flag off? DB rollback steps?
+
+## Dependencies / sequencing
+- Depends on: #...
+- Blocks: #...
+- Requires coordinated deploy with: ...
+
+## Notes / discussion
+Anything else reviewers should know (tradeoffs, alternative approaches considered, follow-ups).

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
         ports:
           - 9200:9200
     strategy:
+      fail-fast: false
       matrix:
         php: ['8.1', '8.2', '8.3']
     env:
@@ -102,7 +103,12 @@ jobs:
       - name: PHPUnit
         run: |
           set -o pipefail
-          vendor/bin/phpunit --do-not-cache-result --log-junit artifacts/ci/junit.xml | tee artifacts/ci/phpunit.log
+          if [ "${{ matrix.php }}" = "8.1" ]; then
+            curl -Ls -o artifacts/phpunit.phar https://phar.phpunit.de/phpunit-10.phar
+            php artifacts/phpunit.phar --do-not-cache-result -c phpunit.xml --log-junit artifacts/ci/junit.xml | tee artifacts/ci/phpunit.log
+          else
+            vendor/bin/phpunit --do-not-cache-result --log-junit artifacts/ci/junit.xml | tee artifacts/ci/phpunit.log
+          fi
       - name: Run CLI example
         run: |
           set -o pipefail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,42 +2,94 @@ name: CI
 
 on:
   push:
+  pull_request:
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo
+        image: mongo:6
         ports:
           - 27017:27017
       mysql:
         image: mysql:5.7
         env:
           MYSQL_ROOT_PASSWORD: password
-          MYSQL_DATABASE: testdb
+          MYSQL_DATABASE: develation_test
         ports:
           - 3306:3306
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
           --health-timeout=5s
-          --health-retries=3
+          --health-retries=5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+      memcached:
+        image: memcached:1.6
+        ports:
+          - 11211:11211
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.16
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: "false"
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+        ports:
+          - 9200:9200
     strategy:
       matrix:
-        php: ['8.2', '8.3']
+        php: ['8.1', '8.2', '8.3']
+    env:
+      DEV_ELATION_NETWORK_TESTS: "1"
+      DEV_ELATION_EMAIL_TESTS: "1"
+      DEV_ELATION_DBQUEUE_TESTS: "1"
+      DEV_ELATION_MYSQL_HOST: 127.0.0.1
+      DEV_ELATION_MYSQL_PORT: "3306"
+      DEV_ELATION_MYSQL_USER: root
+      DEV_ELATION_MYSQL_PASS: password
+      DEV_ELATION_MYSQL_DB: develation_test
+      DEV_ELATION_MONGO_URI: mongodb://127.0.0.1:27017
+      DEV_ELATION_MEMCACHED_HOST: 127.0.0.1
+      DEV_ELATION_MEMCACHED_PORT: "11211"
+      DEV_ELATION_CURL_TEST_URL: https://www.bluefission.com
+      DEV_ELATION_HTTP_TEST_URL: https://www.bluefission.com
+      DEV_ELATION_STREAM_TEST_URL: https://bluefission.com
+      DEV_ELATION_SOCKET_TEST_URL: https://bluefission.com
+      DEV_ELATION_IO_FETCH_URL: https://bluefission.com
+      DEV_ELATION_IO_STREAM_URL: https://bluefission.com
+      DEV_ELATION_IO_SOCKET_URL: https://bluefission.com
+      DEV_ELATION_REMOTE_TEST_URL: https://bluefission.com
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, xml, mysqli, pdo_mysql, mongodb
+          extensions: mbstring, xml, mysqli, pdo_mysql, mongodb, redis, memcached
           coverage: none
       - name: Check PHP version
         run: php -v
       - uses: php-actions/composer@v6
       - run: echo "Composer dependencies have been installed"
-      - run: vendor/bin/phpunit
-        continue-on-error: true  # Allows the workflow to continue even if this step fails
+      - name: Lint PHP
+        run: find src tests -name "*.php" -print0 | xargs -0 -n 1 php -l
+      - name: PHPMD (complexity baseline)
+        run: |
+          for d in Async Behavioral Cli Collections Connections Data Exceptions HTML IPC Net Parsing Security Services System Utils; do
+            php artifacts/phpmd.phar "src/$d" text phpmd.xml
+          done
+          php artifacts/phpmd.phar tests text phpmd.xml
+      - name: PHPUnit
+        run: vendor/bin/phpunit --do-not-cache-result
+      - name: Run CLI example
+        run: php examples/cli/report.php --limit 2 --delay 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,15 +81,36 @@ jobs:
         run: php -v
       - uses: php-actions/composer@v6
       - run: echo "Composer dependencies have been installed"
+      - name: Prepare CI logs
+        run: mkdir -p artifacts/ci
+      - name: Download PHPMD
+        run: |
+          mkdir -p artifacts
+          curl -Ls -o artifacts/phpmd.phar https://github.com/phpmd/phpmd/releases/latest/download/phpmd.phar
+          php artifacts/phpmd.phar --version
       - name: Lint PHP
-        run: find src tests -name "*.php" -print0 | xargs -0 -n 1 php -l
+        run: |
+          set -o pipefail
+          find src tests -name "*.php" -print0 | xargs -0 -n 1 php -l | tee artifacts/ci/php-lint.log
       - name: PHPMD (complexity baseline)
         run: |
+          set -o pipefail
           for d in Async Behavioral Cli Collections Connections Data Exceptions HTML IPC Net Parsing Security Services System Utils; do
-            php artifacts/phpmd.phar "src/$d" text phpmd.xml
+            php artifacts/phpmd.phar "src/$d" text phpmd.xml | tee -a artifacts/ci/phpmd.log
           done
-          php artifacts/phpmd.phar tests text phpmd.xml
+          php artifacts/phpmd.phar tests text phpmd.xml | tee -a artifacts/ci/phpmd.log
       - name: PHPUnit
-        run: vendor/bin/phpunit --do-not-cache-result
+        run: |
+          set -o pipefail
+          vendor/bin/phpunit --do-not-cache-result --log-junit artifacts/ci/junit.xml | tee artifacts/ci/phpunit.log
       - name: Run CLI example
-        run: php examples/cli/report.php --limit 2 --delay 0
+        run: |
+          set -o pipefail
+          php examples/cli/report.php --limit 2 --delay 0 | tee artifacts/ci/cli-example.log
+      - name: Upload CI logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-logs
+          path: artifacts/ci
+          retention-days: 14

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.2', '8.3']
     env:
       DEV_ELATION_NETWORK_TESTS: "1"
       DEV_ELATION_EMAIL_TESTS: "1"
@@ -103,12 +103,7 @@ jobs:
       - name: PHPUnit
         run: |
           set -o pipefail
-          if [ "${{ matrix.php }}" = "8.1" ]; then
-            curl -Ls -o artifacts/phpunit.phar https://phar.phpunit.de/phpunit-10.phar
-            php artifacts/phpunit.phar --do-not-cache-result -c phpunit.xml --log-junit artifacts/ci/junit.xml | tee artifacts/ci/phpunit.log
-          else
-            vendor/bin/phpunit --do-not-cache-result --log-junit artifacts/ci/junit.xml | tee artifacts/ci/phpunit.log
-          fi
+          vendor/bin/phpunit --do-not-cache-result --log-junit artifacts/ci/junit.xml | tee artifacts/ci/phpunit.log
       - name: Run CLI example
         run: |
           set -o pipefail

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ DevElation implements a behavior-driven event handling system, which includes `E
 A collection of wrapper classes around PHP's primitive data types that offer enhanced functionality and utility methods.
 
 - [Data Types Documentation](datatypes.md)
+- [Library Overview](library_overview.md)
 
 Static helpers: most `Val`/`Obj`-based classes expose their underscored instance helpers as static shorthand. For example, `Str` has an internal `_pluralize()` instance method which can be invoked statically via `Str::pluralize('comment')` thanks to `Val::__callStatic`. This pattern is used throughout the library and examples.
 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<ruleset name="DevElation PHPMD Rules"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                             http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>
+        Baseline rules for complexity and size. Thresholds are intentionally
+        lenient to establish CI coverage, with plans to tighten over time.
+    </description>
+
+    <exclude-pattern>*/Services/Application.php</exclude-pattern>
+
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
+        <properties>
+            <property name="reportLevel" value="80" />
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/codesize.xml/NPathComplexity">
+        <properties>
+            <property name="minimum" value="200000000" />
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="350" />
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
+        <properties>
+            <property name="minimum" value="5000" />
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList">
+        <properties>
+            <property name="minimum" value="14" />
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/codesize.xml/ExcessivePublicCount">
+        <properties>
+            <property name="minimum" value="100" />
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/codesize.xml/TooManyMethods">
+        <properties>
+            <property name="maxmethods" value="50" />
+        </properties>
+    </rule>
+</ruleset>

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -800,9 +800,9 @@ class Arr extends Val implements IVal, ArrayAccess, Countable, IteratorAggregate
         }
 
         if (is_null($offset)) {
-            while (array_key_exists($offset, $this->_data) || !$offset) {
-                $offset = count($this->_data);
-            }
+            $this->_data[] = $value;
+            $this->trigger(Event::CHANGE);
+            return;
         }
 
         $this->set($offset, $value);

--- a/src/Async/Sock.php
+++ b/src/Async/Sock.php
@@ -5,20 +5,23 @@ namespace BlueFission\Async;
 use Ratchet\Server\IoServer;
 use Ratchet\Http\HttpServer;
 use Ratchet\WebSocket\WsServer;
+use BlueFission\Behavioral\Behaves;
 use BlueFission\Behavioral\Configurable;
 use BlueFission\Behavioral\IConfigurable;
 use BlueFission\Behavioral\IDispatcher;
+use BlueFission\Behavioral\IBehavioral;
 use BlueFission\Behavioral\Behaviors\Event;
 
 /**
  * Sock class sets up a WebSocket server using Ratchet.
  * It supports configuration for host, port, and handler class.
  */
-class Sock implements IDispatcher, IConfigurable
+class Sock implements IDispatcher, IConfigurable, IBehavioral
 {
-    use Configurable {
-        Configurable::__construct as private __configConstruct;
+    use Behaves {
+        Behaves::__construct as private __behavesConstruct;
     }
+    use Configurable;
 
     private $_server;
     private $_port;
@@ -38,7 +41,8 @@ class Sock implements IDispatcher, IConfigurable
      */
     public function __construct(int $port = 8080, array $config = [])
     {
-        $this->__configConstruct($config);
+        $this->__behavesConstruct();
+        $this->bootstrapConfig($config);
 
         $this->_port = $port;
         $this->config($config);

--- a/src/Behavioral/Configurable.php
+++ b/src/Behavioral/Configurable.php
@@ -25,10 +25,6 @@ use BlueFission\Behavioral\Behaviors\Meta;
  */
 trait Configurable
 {
-    use Behaves {
-        Behaves::__construct as private __behavesConstruct;
-    }
-
     /**
      * @var array $_config The configuration for the object.
      */
@@ -40,13 +36,12 @@ trait Configurable
     protected $_status;
 
     /**
-     * Constructor for the Configurable trait. Initializes the parent trait, and sets
-     * the _config and _status properties to arrays if they are not already set.
-     * Dispatches the State::NORMAL event.
+     * Initialize configuration defaults and status collection.
+     *
+     * @param array|null $config
      */
-    public function __construct($config = null)
+    protected function bootstrapConfig($config = null): void
     {
-        $this->__behavesConstruct();
         if (!Val::is($this->_config)) {
             $this->_config = [];
         }

--- a/src/Connections/Connection.php
+++ b/src/Connections/Connection.php
@@ -2,7 +2,6 @@
 
 namespace BlueFission\Connections;
 
-use BlueFission\Arr;
 use BlueFission\Obj;
 use BlueFission\IObj;
 use BlueFission\Behavioral\IConfigurable;
@@ -19,9 +18,7 @@ use BlueFission\Behavioral\Behaviors\Meta;
  */
 abstract class Connection extends Obj implements IConfigurable
 {
-    use Configurable {
-        Configurable::__construct as private __configConstruct;
-    }
+    use Configurable;
     /**
      * Connection resource
      *
@@ -68,12 +65,8 @@ abstract class Connection extends Obj implements IConfigurable
      */
     public function __construct($config = null)
     {
-        $this->__configConstruct();
         parent::__construct();
-
-        if (Arr::is($config)) {
-            $this->config($config);
-        }
+        $this->bootstrapConfig($config);
 
         $this->status(self::STATUS_NOTCONNECTED);
 

--- a/src/Data/Data.php
+++ b/src/Data/Data.php
@@ -19,14 +19,12 @@ use BlueFission\Behavioral\Behaviors\Meta;
  */
 class Data extends Obj implements IData
 {
-    use Configurable {
-        Configurable::__construct as private __configConstruct;
-    }
+    use Configurable;
 
     public function __construct( $config = null )
     {
         parent::__construct();
-        $this->__configConstruct($config);
+        $this->bootstrapConfig($config);
 
         $this->behavior(new Action( Action::CREATE ), function($behavior) {
             $this->write();

--- a/src/Data/Storage/StorageDrive.php
+++ b/src/Data/Storage/StorageDrive.php
@@ -6,16 +6,22 @@ use BlueFission\IObj;
 use BlueFission\Data\Storage\Storage;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\State;
+use BlueFission\Behavioral\Behaves;
 use BlueFission\Behavioral\Configurable;
 use BlueFission\Behavioral\IConfigurable;
+use BlueFission\Behavioral\IDispatcher;
+use BlueFission\Behavioral\IBehavioral;
 
 /**
  * Class StorageDrive
  *
  * @package BlueFission\Data\Storage
  */
-class StorageDrive implements IConfigurable
+class StorageDrive implements IConfigurable, IDispatcher, IBehavioral
 {
+    use Behaves {
+        Behaves::__construct as private __behavesConstruct;
+    }
     use Configurable;
     /**
      * An array of storage devices in the drive
@@ -29,6 +35,12 @@ class StorageDrive implements IConfigurable
      * @var
      */
     protected $_active_bay;
+
+    public function __construct($config = null)
+    {
+        $this->__behavesConstruct();
+        $this->bootstrapConfig($config);
+    }
 
     /**
      * Add a storage device to the drive

--- a/src/HTML/Table.php
+++ b/src/HTML/Table.php
@@ -16,9 +16,7 @@ use BlueFission\Behavioral\Configurable;
  */
 class Table extends Obj
 {
-    use Configurable {
-        Configurable::__construct as private __configConstruct;
-    }
+    use Configurable;
 
 
     /**
@@ -51,7 +49,8 @@ class Table extends Obj
      */
     public function __construct($config = null)
     {
-        $this->__configConstruct($config);
+        parent::__construct();
+        $this->bootstrapConfig($config);
     }
 
     /**

--- a/src/HTML/Template.php
+++ b/src/HTML/Template.php
@@ -28,9 +28,7 @@ use \InvalidArgumentException;
  * This class provides functionality for handling templates. It extends the Configurable class to handle configuration.
  */
 class Template extends Obj {
-	use Configurable {
-		Configurable::__construct as private __configConstruct;
-	}
+	use Configurable;
 
     /**
      * @var string $_template The contents of the template file
@@ -84,7 +82,7 @@ class Template extends Obj {
             $config = ['file'=>$config];
         }
 
-    	$this->__configConstruct($config);
+    	$this->bootstrapConfig($config);
     	$this->load();
         
         $this->_cached = false;

--- a/src/Net/Email.php
+++ b/src/Net/Email.php
@@ -18,9 +18,7 @@ use BlueFission\Arr;
  */
 class Email extends Obj implements IConfigurable, IEmail
 {	
-    use Configurable {
-        Configurable::__construct as private __configConstruct;
-    }
+    use Configurable;
 
     /**
      * An array that stores the email configurations.
@@ -110,8 +108,8 @@ class Email extends Obj implements IConfigurable, IEmail
      */
     public function __construct($recipient = null, $from = null, $subject = null, $message = null, $cc = null, $bcc = null, $html = false, $headers_r = null, $additional = null, $attachments = null)
     {
-    	$this->__configConstruct();
 		parent::__construct();
+    	$this->bootstrapConfig();
 
 		$recipient = Arr::toArray($recipient);
 		$cc = Arr::toArray($cc);

--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -2,6 +2,7 @@
 namespace BlueFission\Services;
 
 use BlueFission\Behavioral\Programmable;
+use BlueFission\Behavioral\Configurable;
 use BlueFission\Behavioral\IDispatcher;
 use BlueFission\Behavioral\IBehavioral;
 use BlueFission\Behavioral\IConfigurable;
@@ -24,9 +25,7 @@ use Exception;
  * @package BlueFission\Services
  */
 class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral {
-	use Programmable {
-        Programmable::__construct as private __tConstruct;
-    }
+	use Configurable, Programmable;
 
 	/**
 	 * A collection of instances of this class
@@ -203,8 +202,8 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
         }
 
         parent::__construct();
-        $this->__tConstruct(); // Call trait constructor
-        $this->config($config);
+        $this->bootstrapConfig($config);
+        $this->bootstrapProgrammable();
         $this->_services = new Collection();
         $this->_broadcastedEvents[$name] = [];
 
@@ -675,7 +674,14 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 		if ( Val::isNull($this->$name)) {
 			// Create anonymous class
 			$object = new class extends Obj {
-				use Programmable;
+				use Configurable, Programmable;
+
+				public function __construct($config = null)
+				{
+					parent::__construct();
+					$this->bootstrapConfig($config);
+					$this->bootstrapProgrammable();
+				}
 			};
 			$object->config( $configuration );
 			if (Val::isNotNull($data)) {

--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -19,9 +19,7 @@ use BlueFission\Data\Storage\Storage;
 
 class Authenticator extends Service
 {
-    use Configurable {
-        Configurable::__construct as private __configConstruct;
-    }
+    use Configurable;
     /**
      * Default configuration values
      *
@@ -81,8 +79,8 @@ class Authenticator extends Service
      */
     public function __construct(Storage $session, Storage $datasource, $config = null)
     {
-        $this->__configConstruct($config);
         parent::__construct();
+        $this->bootstrapConfig($config);
         // if (is_array($config)) {
         // 	$this->config($config);
         // }

--- a/src/Services/Credentials.php
+++ b/src/Services/Credentials.php
@@ -8,9 +8,7 @@ use BlueFission\Obj;
 
 class Credentials extends Obj
 {
-    use Configurable {
-        Configurable::__construct as private __configConstruct;
-    }
+    use Configurable;
 
     /**
      * Error message for an empty username
@@ -34,7 +32,8 @@ class Credentials extends Obj
 
     public function __construct()
     {
-        $this->__configConstruct();
+        parent::__construct();
+        $this->bootstrapConfig();
     }
 
     /**

--- a/src/System/CommandLocator.php
+++ b/src/System/CommandLocator.php
@@ -97,7 +97,7 @@ class CommandLocator
 
     protected static function isAbsolutePath(string $command): bool
     {
-        if (Str::contains($command, '://')) {
+        if (Str::pos($command, '://') !== false) {
             return true;
         }
 

--- a/tests.md
+++ b/tests.md
@@ -79,3 +79,21 @@ setx DEV_ELATION_EMAIL_TESTS 1
 
 - Skipped tests indicate optional integrations are not configured.
 - If a full suite run is slow, run feature suites individually from `tests/`.
+
+## CI Parity (Local)
+
+To mirror the CI pipeline locally, run:
+
+```
+vendor/bin/phpunit --do-not-cache-result
+```
+
+Static checks used in CI:
+
+```
+find src tests -name "*.php" -print0 | xargs -0 -n 1 php -l
+php artifacts/phpmd.phar src,tests text phpmd.xml
+```
+
+CI also uses integration services (MySQL, MongoDB, Redis, Memcached, Elasticsearch).
+Set the environment variables above to enable those tests locally.

--- a/tests/Behavioral/ConfigurableTest.php
+++ b/tests/Behavioral/ConfigurableTest.php
@@ -18,6 +18,12 @@ class ConfigurableTest extends BehavioralTest
 	            use $traitName;
 
 	            protected \$_config = [];
+
+                public function __construct()
+                {
+                    parent::__construct();
+                    \$this->bootstrapConfig();
+                }
 	        };
 	    ");
     }

--- a/tests/Behavioral/ProgrammableTest.php
+++ b/tests/Behavioral/ProgrammableTest.php
@@ -9,6 +9,26 @@ class ProgrammableTest extends ConfigurableTest
 {
     public static $classname = 'BlueFission\Behavioral\Programmable';
 
+    public function setUp(): void
+    {
+        $traitName = static::$classname;
+        $this->object = eval("
+            return new class extends BlueFission\\Obj implements BlueFission\\Behavioral\\IDispatcher {
+                use BlueFission\\Behavioral\\Configurable;
+                use $traitName;
+
+                protected \$_config = [];
+
+                public function __construct()
+                {
+                    parent::__construct();
+                    \$this->bootstrapConfig();
+                    \$this->bootstrapProgrammable();
+                }
+            };
+        ");
+    }
+
     public function testAddMethodWithLearn()
     {
         $this->expectOutputString('This is a test');

--- a/tests/HTML/TemplateTest.php
+++ b/tests/HTML/TemplateTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class TemplateTest extends TestCase {
 
-    static $testdirectory = '../../testdirectory';
+    static $testdirectory = 'develation_template_testdirectory';
 
     static $classname = 'BlueFission\HTML\Template';
 
@@ -21,7 +21,7 @@ class TemplateTest extends TestCase {
 
     static $configuration = [
         'file' => 'sample.txt',
-        'template_directory' => '../../testdirectory',
+        'template_directory' => '',
         'cache' => true,
         'cache_expire' => 60,
         'cache_directory' => 'cache',
@@ -38,24 +38,27 @@ class TemplateTest extends TestCase {
 
     private function baseDir(): string
     {
-        $baseDir = realpath(__DIR__.DIRECTORY_SEPARATOR.static::$testdirectory);
-        if (!$baseDir) {
-            $baseDir = realpath(static::$testdirectory);
+        $baseDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.static::$testdirectory;
+        if (!is_dir($baseDir)) {
+            @mkdir($baseDir, 0777, true);
         }
 
-        return $baseDir ?: '';
+        return $baseDir;
     }
 
     public function setUp() :void {
-        chdir(__DIR__);
-
-        touch(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file);
+        $baseDir = $this->baseDir();
+        $filePath = $baseDir.DIRECTORY_SEPARATOR.static::$file;
+        touch($filePath);
 
         $data = 'This is a sample text file';
 
-        file_put_contents(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file, $data);
+        file_put_contents($filePath, $data);
 
-        $this->object = new static::$classname(static::$configuration);
+        $config = static::$configuration;
+        $config['template_directory'] = $baseDir;
+        $config['module_directory'] = $baseDir;
+        $this->object = new static::$classname($config);
     }
 
     public function tearDown() :void {
@@ -67,15 +70,18 @@ class TemplateTest extends TestCase {
             'cache'
         ];
 
+        $baseDir = $this->baseDir();
         foreach ($testfiles as $file) {
-            if (is_dir(realpath(static::$testdirectory).DIRECTORY_SEPARATOR.$file)) {
-                @rmdir(realpath(static::$testdirectory).DIRECTORY_SEPARATOR.$file);
+            if (is_dir($baseDir.DIRECTORY_SEPARATOR.$file)) {
+                @rmdir($baseDir.DIRECTORY_SEPARATOR.$file);
             }
 
-            if (file_exists(realpath(static::$testdirectory).DIRECTORY_SEPARATOR.$file)) {
-                @unlink(realpath(static::$testdirectory).DIRECTORY_SEPARATOR.$file);
+            if (file_exists($baseDir.DIRECTORY_SEPARATOR.$file)) {
+                @unlink($baseDir.DIRECTORY_SEPARATOR.$file);
             }
         }
+
+        @rmdir($baseDir);
     }
 
     public function testConstructor() {

--- a/tests/HTML/XMLTest.php
+++ b/tests/HTML/XMLTest.php
@@ -8,18 +8,28 @@ use BlueFission\Arr;
 
 class XMLTest extends TestCase
 {
-    public static $testdirectory = '../../testdirectory';
+    public static $testdirectory = 'develation_xml_testdirectory';
     public static $file = 'test.xml';
 
     public static $classname = 'BlueFission\HTML\XML';
 
     protected $object;
 
+    private function baseDir(): string
+    {
+        $baseDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.static::$testdirectory;
+        if (!is_dir($baseDir)) {
+            @mkdir($baseDir, 0777, true);
+        }
+
+        return $baseDir;
+    }
+
     public function setUp(): void
     {
-        chdir(__DIR__);
-
-        touch(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file);
+        $baseDir = $this->baseDir();
+        $filePath = $baseDir.DIRECTORY_SEPARATOR.static::$file;
+        touch($filePath);
 
         $data = '<?xml version="1.0" encoding="UTF-8"?>
             <library>
@@ -40,23 +50,28 @@ class XMLTest extends TestCase
                 </book>
             </library>';
 
-        file_put_contents(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file, $data);
+        file_put_contents($filePath, $data);
 
         $this->object = new static::$classname();
     }
 
     public function tearDown(): void
     {
-        if (file_exists(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file)) {
-            @unlink(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file);
+        $baseDir = $this->baseDir();
+        $filePath = $baseDir.DIRECTORY_SEPARATOR.static::$file;
+        if (file_exists($filePath)) {
+            @unlink($filePath);
         }
+
+        @rmdir($baseDir);
     }
 
     public function testParseXML()
     {
-        $this->object = new static::$classname(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file);
+        $baseDir = $this->baseDir();
+        $this->object = new static::$classname($baseDir.DIRECTORY_SEPARATOR.static::$file);
 
-        $this->assertEquals(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file, $this->object->file());
+        $this->assertEquals($baseDir.DIRECTORY_SEPARATOR.static::$file, $this->object->file());
         $this->assertEquals(XML::STATUS_SUCCESS, $this->object->status());
         $this->assertEquals(1, Arr::size($this->object->data()));
         $this->assertEquals('The Great Gatsby', $this->object->data()[0]['child'][0]['child'][0]['content']);
@@ -64,7 +79,8 @@ class XMLTest extends TestCase
 
     public function testFileMethod()
     {
-        $this->object->file(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file);
-        $this->assertEquals(static::$testdirectory.DIRECTORY_SEPARATOR.static::$file, $this->object->file());
+        $baseDir = $this->baseDir();
+        $this->object->file($baseDir.DIRECTORY_SEPARATOR.static::$file);
+        $this->assertEquals($baseDir.DIRECTORY_SEPARATOR.static::$file, $this->object->file());
     }
 }

--- a/tests/Services/ServiceTest.php
+++ b/tests/Services/ServiceTest.php
@@ -64,6 +64,12 @@ class ServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->object->type = new class () extends Obj {
             use Configurable;
+
+            public function __construct()
+            {
+                parent::__construct();
+                $this->bootstrapConfig();
+            }
         };
 
         $behavior = new Behavior('Test behavior');
@@ -83,6 +89,12 @@ class ServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->object->type = new class () extends Obj {
             use Configurable;
+
+            public function __construct()
+            {
+                parent::__construct();
+                $this->bootstrapConfig();
+            }
         };
 
         $behavior = new Behavior('Test behavior');
@@ -102,6 +114,12 @@ class ServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->object->type = new class () extends Obj {
             use Configurable;
+
+            public function __construct()
+            {
+                parent::__construct();
+                $this->bootstrapConfig();
+            }
         };
 
         $behavior = new Behavior('Test behavior');
@@ -127,6 +145,12 @@ class ServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->object->type = new class () extends Obj {
             use Configurable;
+
+            public function __construct()
+            {
+                parent::__construct();
+                $this->bootstrapConfig();
+            }
         };
 
         $behavior = new Behavior('Test behavior');
@@ -183,6 +207,12 @@ class ServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->object->type = new class () extends Obj {
             use Configurable;
+
+            public function __construct()
+            {
+                parent::__construct();
+                $this->bootstrapConfig();
+            }
         };
 
         $this->object->instance();


### PR DESCRIPTION
## Intent
  Remove trait constructor collisions, make bootstrap explicit, and align local/CI PHPMD runs with the new helper.

 ## Summary of changes
  - Removed __construct from Configurable/Programmable; added explicit bootstrap calls in consumers.
  - Added local PHPMD helper: scripts/bf-phpmd.ps1.
  - Fixed CommandLocator use of Str::contains and improved XML/table handling stability.

## Key files
  - src/Behavioral/Configurable.php
  - src/Behavioral/Programmable.php
  - src/Services/Application.php
  - phpmd.xml
  - tests/Behavioral/ConfigurableTest.php
  - tests/Behavioral/ProgrammableTest.php

## Tests
  - vendor/bin/phpunit --do-not-cache-result
  - pwsh -File scripts/bf-phpmd.ps1

###  Notes
  - PHPMD phar emits Symfony deprecation warnings; no rule violations.