### PR TITLE
Add CLI option→request mapping for Application and Request

### DIFF
--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -8,6 +8,8 @@ use BlueFission\Behavioral\IConfigurable;
 use BlueFission\Utils\Util;
 use BlueFission\Collections\Collection;
 use BlueFission\Services\Mapping;
+use BlueFission\Cli\Args;
+use BlueFission\Cli\Args\OptionDefinition;
 use BlueFission\Val;
 use BlueFission\Str;
 use BlueFission\Arr;
@@ -188,6 +190,27 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
     private $_cmdpath = "";
 
     /**
+     * CLI option definitions for argument parsing.
+     *
+     * @var array
+     */
+    private $_cliOptions = [];
+
+    /**
+     * Optional CLI argument parser override.
+     *
+     * @var Args|null
+     */
+    private $_cliParser = null;
+
+    /**
+     * Store the active request instance.
+     *
+     * @var Request|null
+     */
+    private $_request = null;
+
+    /**
      * The class constructor
      *
      * @return void
@@ -269,8 +292,24 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 
 		if ( $argc > 1 ) {
 			$this->_arguments[$this->_parameters[0]] = 'console';
-			for ( $i = 1; $i <= $argc-1; $i++) {
-				$this->_arguments[$this->_parameters[$i]] = $argv[$i];
+			$parser = $this->cliParser();
+			$definitions = $this->buildCliDefinitions($argv);
+			if (!empty($definitions)) {
+				$parser->addOptions($definitions);
+			}
+
+			$parser->parse($argv);
+			$positionals = $parser->positionals();
+			$options = $parser->options();
+
+			$this->_arguments[$this->_parameters[1]] = $positionals[0] ?? $this->name();
+			$this->_arguments[$this->_parameters[2]] = $positionals[1] ?? '';
+			$this->_arguments[$this->_parameters[3]] = array_slice($positionals, 2);
+			$this->_arguments['query'] = $options;
+
+			if (!empty($options)) {
+				$_GET = array_merge($_GET ?? [], $options);
+				$_REQUEST = array_merge($_REQUEST ?? [], $options);
 			}
 		} elseif ( count( $_GET ) > 0 || count( $_POST ) > 0 ) {
 			$args = $this->_parameters;
@@ -396,6 +435,7 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 			$mapping = $this->_mappings[$this->_arguments['_method']][$this->_cmdpath];
 
 			$request = new Request();
+			$this->_request = $request;
 
 			foreach ($mapping->gateways() as $gatewayName) {
 				if ( isset( $this->_gateways[$gatewayName] ) ) {
@@ -580,6 +620,46 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 	public function bindArgs( array $arguments, string $classname = '_' )
 	{
 		$this->_boundArguments[$classname] = $arguments;
+	}
+
+	/**
+	 * Get the current request instance.
+	 *
+	 * @return Request|null
+	 */
+	public function request(): ?Request
+	{
+		return $this->_request;
+	}
+
+	/**
+	 * Register CLI option definitions.
+	 *
+	 * @param array $definitions
+	 * @return self
+	 */
+	public function cliOptions(array $definitions): self
+	{
+		$this->_cliOptions = $definitions;
+		return $this;
+	}
+
+	/**
+	 * Provide a custom CLI argument parser.
+	 *
+	 * @param Args $parser
+	 * @return self
+	 */
+	public function cliParser(Args $parser = null): Args
+	{
+		if ($parser instanceof Args) {
+			$this->_cliParser = $parser;
+		}
+
+		return $this->_cliParser ?? new Args([
+			'allowUnknown' => true,
+			'autoHelp' => false,
+		]);
 	}
 
 	/**
@@ -1181,6 +1261,11 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 			// Merge the arguments with the application registered named bindings by class
 			$arguments = array_merge($this->boundArguments($callingClass), $arguments);
 
+			if ($dependencyClass === Request::class && $this->_request) {
+				$dependencies[$dependencyName] = $this->_request;
+				continue;
+			}
+
 			// Check if the argument exists for the current dependency
 			if ( isset($arguments[$dependencyName]) ) {
 				$dependencies[$dependencyName] = $arguments[$dependencyName];
@@ -1234,5 +1319,67 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 		if ( \is_callable($callable) ) {
 			return $callable;
 		}
+	}
+
+	/**
+	 * Build CLI option definitions from registered options and argv inspection.
+	 *
+	 * @param array $argv
+	 * @return array
+	 */
+	private function buildCliDefinitions(array $argv): array
+	{
+		$definitions = [];
+
+		foreach ($this->_cliOptions as $definition) {
+			if ($definition instanceof OptionDefinition) {
+				$definitions[$definition->name()] = $definition;
+			}
+		}
+
+		$count = count($argv);
+		for ($i = 1; $i < $count; $i++) {
+			$arg = $argv[$i];
+			if (!Str::is($arg) || Str::pos($arg, '--') !== 0) {
+				continue;
+			}
+
+			$name = substr($arg, 2);
+			if ($name === '') {
+				continue;
+			}
+
+			$value = null;
+			$eqPos = Str::pos($name, '=');
+			if ($eqPos !== false) {
+				$value = substr($name, $eqPos + 1);
+				$name = substr($name, 0, $eqPos);
+			}
+
+			if ($name === '') {
+				continue;
+			}
+
+			$type = 'string';
+			if (Str::pos($name, 'no-') === 0) {
+				$name = substr($name, 3);
+				$type = 'bool';
+			} elseif ($value === null) {
+				$next = $argv[$i + 1] ?? null;
+				$type = ($next !== null && Str::pos((string)$next, '-') !== 0) ? 'string' : 'bool';
+			}
+
+			if ($name === '') {
+				continue;
+			}
+
+			if (!isset($definitions[$name])) {
+				$definitions[$name] = new OptionDefinition($name, [
+					'type' => $type,
+				]);
+			}
+		}
+
+		return array_values($definitions);
 	}
 }

--- a/src/Services/Request.php
+++ b/src/Services/Request.php
@@ -35,14 +35,27 @@ class Request extends Obj
         switch ($this->type()) {
             case 'GET':
                 $request = filter_input_array(INPUT_GET);
+                if ($request === null || $request === false) {
+                    $request = $_GET ?? [];
+                }
                 break;
             case 'POST':
                 $request = filter_input_array(INPUT_POST);
+                if ($request === null || $request === false) {
+                    $request = $_POST ?? [];
+                }
                 break;
             default:
                 // $request = filter_input_array(INPUT_REQUEST); // Awaiting implmentation
                 $get = filter_input_array(INPUT_GET) ?? [];
                 $post = filter_input_array(INPUT_POST) ?? [];
+
+                if ($get === [] && !empty($_GET)) {
+                    $get = $_GET;
+                }
+                if ($post === [] && !empty($_POST)) {
+                    $post = $_POST;
+                }
 
                 $request = array_merge($get, $post);
                 break;

--- a/tests.md
+++ b/tests.md
@@ -16,6 +16,13 @@ $env:BF_SERVICES = 'mysql,redis'
 powershell -File scripts/bf-test.ps1
 ```
 
+## CLI Request Mapping
+
+CLI option parsing is tested alongside Services:
+
+- `vendor/bin/phpunit --do-not-cache-result tests/Services/RequestTest.php`
+- `vendor/bin/phpunit --do-not-cache-result tests/Services/ApplicationTest.php`
+
 ## Optional Integrations
 
 Some tests require external services or PHP extensions. These are skipped by default and only run when the relevant environment variables are set.

--- a/tests/Services/ApplicationTest.php
+++ b/tests/Services/ApplicationTest.php
@@ -104,4 +104,32 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $this->expectOutputString('Start Continue End');
         $this->object->perform(new Event('StartEvent'));
     }
+
+    public function testCliOptionsMapToRequest()
+    {
+        global $argv, $argc;
+
+        $originalArgv = $argv ?? [];
+        $originalArgc = $argc ?? 0;
+        $originalGet = $_GET ?? [];
+        $originalRequest = $_REQUEST ?? [];
+
+        $_GET = [];
+        $_REQUEST = [];
+
+        $argv = ['app.php', 'service', 'behavior', 'item', '--foo=bar', '--flag'];
+        $argc = count($argv);
+
+        $app = Application::getInstance('CliArgsTest');
+        $app->args();
+
+        $request = new \BlueFission\Services\Request();
+        $this->assertEquals('bar', $request->all()['foo']);
+        $this->assertEquals(true, $request->all()['flag']);
+
+        $argv = $originalArgv;
+        $argc = $originalArgc;
+        $_GET = $originalGet;
+        $_REQUEST = $originalRequest;
+    }
 }

--- a/tests/Services/RequestTest.php
+++ b/tests/Services/RequestTest.php
@@ -15,6 +15,25 @@ class RequestTest extends TestCase
         $this->assertIsArray($request->all());
     }
 
+    public function testAllFallsBackToGet()
+    {
+        $originalGet = $_GET ?? [];
+        $originalMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET = ['cli_option' => 'value'];
+
+        $request = new Request();
+        $this->assertEquals('value', $request->all()['cli_option']);
+
+        $_GET = $originalGet;
+        if ($originalMethod === null) {
+            unset($_SERVER['REQUEST_METHOD']);
+        } else {
+            $_SERVER['REQUEST_METHOD'] = $originalMethod;
+        }
+    }
+
     public function testType()
     {
         $request = new Request();


### PR DESCRIPTION
Intent
  Make CLI flags behave like HTTP query vars while keeping positional routing intact.

  Summary of changes

  - CLI args now split into positionals (service/behavior/data) plus options, with options mapped into $_GET/$_REQUEST for HTTP-like access.
  - Application now tracks the active Request and injects it via DI.
  - Request::all() now falls back to $_GET/$_POST in CLI contexts.
  - Added tests covering CLI option mapping and Request fallback.
  - Documented the new CLI request mapping tests in tests.md.

  Key files / areas touched

  - src/Services/Application.php — CLI parsing integration, option mapping, request DI
  - src/Services/Request.php — CLI-safe input fallback
  - tests/Services/ApplicationTest.php — CLI option mapping test
  - tests/Services/RequestTest.php — CLI fallback test
  - tests.md — new test commands

  Tests run

  - vendor/bin/phpunit --do-not-cache-result tests/Services/RequestTest.php
  - vendor/bin/phpunit --do-not-cache-result tests/Services/ApplicationTest.php