### PR TITLE
Adds sqlite fixes, piggy backs cli spinners

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ for ($i = 1; $i <= $limit; $i++) {
     $console->rewriteLine($console->progress($limit, $i));
 }
 $console->writeln('');
+
+$spinner = $console->spinner('Working');
+for ($i = 0; $i < 12; $i++) {
+    $console->rewriteLine($spinner->tick());
+    usleep(120000);
+}
+$spinner->stop();
+$console->writeln('');
+
+$result = $console->working('Fetching', function () {
+    usleep(250000);
+    return 'ok';
+});
+$console->writeln('Result: ' . $result);
 ```
 
 ### Storage pipeline: session-backed data

--- a/src/Cli/Util/Spinner.php
+++ b/src/Cli/Util/Spinner.php
@@ -1,0 +1,194 @@
+<?php
+namespace BlueFission\Cli\Util;
+
+use BlueFission\Obj;
+use BlueFission\Arr;
+use BlueFission\Val;
+use BlueFission\DataTypes;
+use BlueFission\Behavioral\Behaviors\Action;
+use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\DevElation as Dev;
+
+class Spinner extends Obj
+{
+    protected $_data = [
+        'label' => '',
+        'frames' => ['|', '/', '-', '\\'],
+        'index' => 0,
+        'intervalMs' => 120,
+        'running' => false,
+        'lastTick' => 0.0,
+    ];
+
+    protected $_types = [
+        'label' => DataTypes::STRING,
+        'frames' => DataTypes::ARRAY,
+        'index' => DataTypes::INTEGER,
+        'intervalMs' => DataTypes::INTEGER,
+        'running' => DataTypes::BOOLEAN,
+        'lastTick' => DataTypes::NUMBER,
+    ];
+
+    public function __construct(string $label = '', ?array $frames = null, int $intervalMs = 120)
+    {
+        parent::__construct();
+
+        $label = Dev::apply('_in', $label);
+        $frames = Dev::apply('_in', $frames);
+        $intervalMs = Dev::apply('_in', $intervalMs);
+
+        $this->setValue('label', (string)$label);
+        $this->setValue('frames', Arr::is($frames) ? $frames : $this->_data['frames']);
+        $this->setValue('intervalMs', max(10, (int)$intervalMs));
+        $this->setValue('index', 0);
+        $this->setValue('running', false);
+        $this->setValue('lastTick', 0.0);
+
+        $this->behavior(new Action(Action::START), function () {
+            $this->setValue('running', true);
+            $this->setValue('lastTick', $this->timestampMs());
+            $this->trigger(Event::STARTED);
+        });
+
+        $this->behavior(new Action(Action::STOP), function () {
+            $this->setValue('running', false);
+            $this->trigger(Event::STOPPED);
+        });
+
+        $this->behavior(new Action(Action::UPDATE), function ($behavior, $args) {
+            $meta = ($args instanceof Meta) ? $args : null;
+            if ($meta && is_array($meta->data ?? null)) {
+                $data = $meta->data;
+                if (array_key_exists('label', $data)) {
+                    $this->setValue('label', (string)$data['label']);
+                }
+                if (array_key_exists('frames', $data) && Arr::is($data['frames'])) {
+                    $this->setValue('frames', $data['frames']);
+                    $this->setValue('index', 0);
+                }
+                if (array_key_exists('intervalMs', $data)) {
+                    $this->setValue('intervalMs', max(10, (int)$data['intervalMs']));
+                }
+            }
+            $this->trigger(Event::CHANGE, $meta);
+        });
+
+        $this->behavior(new Action(Action::PROCESS), function () {
+            $output = $this->render();
+            $this->trigger(Event::PROCESSED, new Meta(data: $output));
+        });
+    }
+
+    public function start(): self
+    {
+        $this->perform(new Action(Action::START));
+        return $this;
+    }
+
+    public function stop(): self
+    {
+        $this->perform(new Action(Action::STOP));
+        return $this;
+    }
+
+    public function label(string $label): self
+    {
+        $this->perform(new Action(Action::UPDATE), new Meta(data: ['label' => $label]));
+        return $this;
+    }
+
+    public function frames(array $frames): self
+    {
+        $this->perform(new Action(Action::UPDATE), new Meta(data: ['frames' => $frames]));
+        return $this;
+    }
+
+    public function interval(int $intervalMs): self
+    {
+        $this->perform(new Action(Action::UPDATE), new Meta(data: ['intervalMs' => $intervalMs]));
+        return $this;
+    }
+
+    public function tick(?float $nowMs = null): string
+    {
+        $nowMs = Dev::apply('_in', $nowMs);
+        if (!$this->getValue('running')) {
+            $this->start();
+        }
+
+        $now = Val::isNotNull($nowMs) ? (float)$nowMs : $this->timestampMs();
+        $lastTick = (float)$this->getValue('lastTick');
+        $interval = (int)$this->getValue('intervalMs');
+
+        if ($lastTick <= 0 || ($now - $lastTick) >= $interval) {
+            $this->advance();
+            $this->setValue('lastTick', $now);
+        }
+
+        $output = $this->render();
+        $output = Dev::apply('_out', $output);
+        Dev::do('_after', [$output, $this]);
+        return $output;
+    }
+
+    public function render(): string
+    {
+        Dev::do('_before', [$this]);
+        $label = (string)$this->getValue('label');
+        $frame = $this->frame();
+
+        $output = trim($label . ' ' . $frame);
+        $output = Dev::apply('_out', $output);
+        $this->trigger(Event::PROCESSED, new Meta(data: $output));
+        Dev::do('_after', [$output, $this]);
+        return $output;
+    }
+
+    public function frame(): string
+    {
+        $frames = $this->getValue('frames');
+        if (!Arr::is($frames) || count($frames) === 0) {
+            return '';
+        }
+
+        $index = (int)$this->getValue('index');
+        $frame = $frames[$index % count($frames)] ?? '';
+        return (string)$frame;
+    }
+
+    public function advance(): self
+    {
+        $frames = $this->getValue('frames');
+        $count = Arr::is($frames) ? count($frames) : 0;
+        $index = (int)$this->getValue('index');
+        $index = $count > 0 ? ($index + 1) % $count : 0;
+        $this->setValue('index', $index);
+        $this->trigger(Event::CHANGE);
+        return $this;
+    }
+
+    protected function setValue(string $field, $value): void
+    {
+        $current = $this->_data[$field] ?? null;
+        if ($current instanceof \BlueFission\IVal) {
+            $current->val($value);
+            return;
+        }
+        $this->_data[$field] = $value;
+    }
+
+    protected function getValue(string $field)
+    {
+        $current = $this->_data[$field] ?? null;
+        if ($current instanceof \BlueFission\IVal) {
+            return $current->val();
+        }
+        return $current;
+    }
+
+    protected function timestampMs(): float
+    {
+        return microtime(true) * 1000;
+    }
+}

--- a/src/Cli/Util/Working.php
+++ b/src/Cli/Util/Working.php
@@ -1,0 +1,226 @@
+<?php
+namespace BlueFission\Cli\Util;
+
+use BlueFission\Obj;
+use BlueFission\Arr;
+use BlueFission\Val;
+use BlueFission\DataTypes;
+use BlueFission\Async\Promise;
+use BlueFission\Behavioral\Behaviors\Action;
+use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\DevElation as Dev;
+
+class Working extends Obj
+{
+    protected Spinner $_spinner;
+
+    protected $_data = [
+        'label' => '',
+        'frames' => ['|', '/', '-', '\\'],
+        'intervalMs' => 120,
+        'running' => false,
+        'lastOutput' => '',
+        'outputHandler' => null,
+    ];
+
+    protected $_types = [
+        'label' => DataTypes::STRING,
+        'frames' => DataTypes::ARRAY,
+        'intervalMs' => DataTypes::INTEGER,
+        'running' => DataTypes::BOOLEAN,
+        'lastOutput' => DataTypes::STRING,
+    ];
+
+    public function __construct(string $label = '', ?array $frames = null, int $intervalMs = 120, ?callable $outputHandler = null)
+    {
+        parent::__construct();
+
+        $label = Dev::apply('_in', $label);
+        $frames = Dev::apply('_in', $frames);
+        $intervalMs = Dev::apply('_in', $intervalMs);
+
+        $this->setValue('label', (string)$label);
+        $this->setValue('frames', Arr::is($frames) ? $frames : $this->_data['frames']);
+        $this->setValue('intervalMs', max(10, (int)$intervalMs));
+        $this->setValue('outputHandler', $outputHandler);
+        $this->setValue('running', false);
+
+        $this->_spinner = new Spinner($label, $this->getValue('frames'), $this->getValue('intervalMs'));
+
+        $this->behavior(new Action(Action::START), function () {
+            $this->setValue('running', true);
+            $this->_spinner->start();
+            $this->trigger(Event::STARTED);
+        });
+
+        $this->behavior(new Action(Action::STOP), function () {
+            $this->setValue('running', false);
+            $this->_spinner->stop();
+            $this->trigger(Event::STOPPED);
+        });
+
+        $this->behavior(new Action(Action::UPDATE), function ($behavior, $args) {
+            $meta = ($args instanceof Meta) ? $args : null;
+            if ($meta && is_array($meta->data ?? null)) {
+                $data = $meta->data;
+                if (array_key_exists('label', $data)) {
+                    $this->setValue('label', (string)$data['label']);
+                    $this->_spinner->label((string)$data['label']);
+                }
+                if (array_key_exists('frames', $data) && Arr::is($data['frames'])) {
+                    $this->setValue('frames', $data['frames']);
+                    $this->_spinner->frames($data['frames']);
+                }
+                if (array_key_exists('intervalMs', $data)) {
+                    $interval = max(10, (int)$data['intervalMs']);
+                    $this->setValue('intervalMs', $interval);
+                    $this->_spinner->interval($interval);
+                }
+                if (array_key_exists('outputHandler', $data)) {
+                    $this->setValue('outputHandler', $data['outputHandler']);
+                }
+            }
+            $this->trigger(Event::CHANGE, $meta);
+        });
+    }
+
+    public function outputHandler(?callable $handler = null)
+    {
+        if (Val::isNull($handler)) {
+            return $this->getValue('outputHandler');
+        }
+
+        $this->setValue('outputHandler', $handler);
+        return $this;
+    }
+
+    public function run(callable $work)
+    {
+        $work = Dev::apply('_in', $work);
+        Dev::do('_before', [$work, $this]);
+        $this->perform(new Action(Action::START));
+
+        try {
+            $result = $this->invoke($work);
+
+            if ($result instanceof Promise) {
+                $result = $this->runPromise($result);
+            } elseif ($result instanceof \Generator) {
+                $result = $this->runGenerator($result);
+            }
+        } finally {
+            $this->perform(new Action(Action::STOP));
+        }
+
+        $result = Dev::apply('_out', $result);
+        $this->trigger(Event::PROCESSED, new Meta(data: $result));
+        Dev::do('_after', [$result, $this]);
+        return $result;
+    }
+
+    public function tick(?float $nowMs = null): string
+    {
+        $output = $this->_spinner->tick($nowMs);
+        $this->write($output);
+        return $output;
+    }
+
+    protected function runPromise(Promise $promise)
+    {
+        $done = false;
+        $result = null;
+        $error = null;
+
+        $promise->then(
+            function ($value = null) use (&$done, &$result) {
+                $result = $value;
+                $done = true;
+            },
+            function ($reason = null) use (&$done, &$error) {
+                $error = $reason;
+                $done = true;
+            }
+        );
+
+        $promise->try();
+
+        while (!$done) {
+            $this->tick();
+            usleep((int)$this->getValue('intervalMs') * 1000);
+        }
+
+        if ($error instanceof \Throwable) {
+            throw $error;
+        }
+
+        return $result;
+    }
+
+    protected function runGenerator(\Generator $generator)
+    {
+        $last = null;
+        foreach ($generator as $value) {
+            $last = $value;
+            $this->tick();
+            usleep((int)$this->getValue('intervalMs') * 1000);
+        }
+
+        try {
+            $returnValue = $generator->getReturn();
+            if (Val::isNotNull($returnValue)) {
+                return $returnValue;
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        return $last;
+    }
+
+    protected function write(string $text): void
+    {
+        $handler = $this->getValue('outputHandler');
+        $payload = Screen::rewriteLine($text);
+        $this->setValue('lastOutput', $payload);
+
+        if (is_callable($handler)) {
+            call_user_func($handler, $payload);
+        } else {
+            echo $payload;
+        }
+    }
+
+    protected function invoke(callable $work)
+    {
+        try {
+            $reflection = new \ReflectionFunction(\Closure::fromCallable($work));
+            if ($reflection->getNumberOfParameters() > 0) {
+                return $work($this);
+            }
+        } catch (\Throwable $e) {
+            // fallback below
+        }
+
+        return $work();
+    }
+
+    protected function setValue(string $field, $value): void
+    {
+        $current = $this->_data[$field] ?? null;
+        if ($current instanceof \BlueFission\IVal) {
+            $current->val($value);
+            return;
+        }
+        $this->_data[$field] = $value;
+    }
+
+    protected function getValue(string $field)
+    {
+        $current = $this->_data[$field] ?? null;
+        if ($current instanceof \BlueFission\IVal) {
+            return $current->val();
+        }
+        return $current;
+    }
+}

--- a/src/Connections/Database/SQLiteLink.php
+++ b/src/Connections/Database/SQLiteLink.php
@@ -295,7 +295,9 @@ class SQLiteLink extends Connection implements IConfigurable
                 $result = $db->exec($query);
                 $success = ($result) ? true : false;
                 $status = ($success) ? self::STATUS_SUCCESS : ($db->lastErrorMsg() ?? self::STATUS_FAILED);
-                $this->assign($db->lastInsertRowID());
+                $lastRow = $db->lastInsertRowID();
+                $this->_last_row = $lastRow;
+                $this->_data['last_row'] = $lastRow;
             } catch (\Exception $e) {
                 error_log($e->getMessage());
                 $status = self::STATUS_FAILED;
@@ -377,7 +379,7 @@ class SQLiteLink extends Connection implements IConfigurable
                 $result = $db->exec($query);
                 $success = ($result) ? true : false;
                 $status = ($success) ? self::STATUS_SUCCESS : ($db->lastErrorMsg() ?? self::STATUS_FAILED);
-                $this->assign($result);
+                $this->_result = $result;
             } catch (\Exception $e) {
                 error_log($e->getMessage());
                 $status = self::STATUS_FAILED;

--- a/src/Data/Storage/Structure/SQLiteField.php
+++ b/src/Data/Storage/Structure/SQLiteField.php
@@ -117,6 +117,10 @@ class SQLiteField
     public function autoincrement($isTrue = true)
     {
         $this->_autoincrement = $isTrue;
+        if ($isTrue) {
+            $this->_primary = true;
+            $this->_null = false;
+        }
 
         return $this;
     }
@@ -210,18 +214,20 @@ class SQLiteField
                 break;
         }
 
-        if ($this->_default !== null) {
+        if ($this->_default !== null && !$this->_autoincrement) {
             $definition[] = "DEFAULT " . SQLiteLink::sanitize((string)$this->_default);
         }
 
-        if (!$this->_null) {
-            $definition[] = "NOT";
+        if (!$this->_autoincrement) {
+            if (!$this->_null) {
+                $definition[] = "NOT";
+            }
+
+            $definition[] = "NULL";
         }
 
-        $definition[] = "NULL";
-
         if ($this->_autoincrement) {
-            $definition[] = "AUTOINCREMENT";
+            $definition[] = "PRIMARY KEY AUTOINCREMENT";
         }
 
         $definition_string = implode(' ', $definition);
@@ -238,7 +244,7 @@ class SQLiteField
     {
         $extras = [];
 
-        if ($this->_primary) {
+        if ($this->_primary && !$this->_autoincrement) {
             $extras[] = "PRIMARY KEY (`{$this->_name}`)";
         }
 

--- a/tests/Cli/Util/SpinnerTest.php
+++ b/tests/Cli/Util/SpinnerTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace BlueFission\Tests;
+
+use BlueFission\Cli\Util\Spinner;
+use BlueFission\Behavioral\Behaviors\Event;
+
+class SpinnerTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRenderSpinner()
+    {
+        $spinner = new Spinner('Loading', ['.', 'o'], 100);
+        $this->assertSame('Loading .', $spinner->render());
+    }
+
+    public function testAdvanceChangesFrame()
+    {
+        $spinner = new Spinner('', ['.', 'o'], 100);
+        $first = $spinner->frame();
+        $spinner->advance();
+        $second = $spinner->frame();
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testAdvanceFiresChangeEvent()
+    {
+        $spinner = new Spinner('Work', ['|', '/'], 100);
+        $changed = false;
+
+        $spinner->when(new Event(Event::CHANGE), function () use (&$changed) {
+            $changed = true;
+        });
+
+        $spinner->advance();
+
+        $this->assertTrue($changed);
+    }
+}

--- a/tests/Cli/Util/WorkingTest.php
+++ b/tests/Cli/Util/WorkingTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace BlueFission\Tests;
+
+use BlueFission\Cli\Util\Working;
+
+class WorkingTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRunReturnsResult()
+    {
+        $working = new Working('Work', ['.', 'o'], 10, function ($text) {
+            // suppress output
+        });
+
+        $result = $working->run(function () {
+            return 'done';
+        });
+
+        $this->assertSame('done', $result);
+    }
+
+    public function testRunConsumesGenerator()
+    {
+        $buffer = '';
+        $working = new Working('Spin', ['.', 'o'], 10, function ($text) use (&$buffer) {
+            $buffer .= $text;
+        });
+
+        $result = $working->run(function () {
+            yield 1;
+            yield 2;
+            return 'complete';
+        });
+
+        $this->assertSame('complete', $result);
+        $this->assertNotSame('', $buffer);
+    }
+}

--- a/tests/Data/Storage/Structure/SQLiteFieldTest.php
+++ b/tests/Data/Storage/Structure/SQLiteFieldTest.php
@@ -1,0 +1,17 @@
+<?php
+namespace BlueFission\Tests;
+
+use BlueFission\Data\Storage\Structure\SQLiteField;
+
+class SQLiteFieldTest extends \PHPUnit\Framework\TestCase
+{
+    public function testAutoincrementDefinitionUsesPrimaryKey()
+    {
+        $field = new SQLiteField('id');
+        $field->type('numeric')->primary()->autoincrement();
+
+        $definition = $field->definition();
+        $this->assertStringContainsString('PRIMARY KEY AUTOINCREMENT', $definition);
+        $this->assertSame('', $field->extras());
+    }
+}


### PR DESCRIPTION
## Intent

  Improve SQLite schema/CRUD correctness and add CLI “working” spinner utility per DevOps request.

  ## Summary of changes

  - Fixed SQLite autoincrement DDL to use inline PRIMARY KEY AUTOINCREMENT and avoid duplicate PK extras.
  - Corrected SQLite condition defaults and key detection from PRAGMA pk/name.
  - Prevented SQLiteLink from calling assign() with scalar values; track last_row internally.
  - Added CLI Working helper (async-friendly spinner runner) and Console::working(); kept Spinner for manual control.
  - Updated README with spinner/working examples; added tests for Spinner/Working and SQLiteField autoincrement.

  ## Key files / areas

  - src/Data/Storage/Structure/SQLiteField.php — autoincrement DDL fix.
  - src/Data/Storage/SQLite.php — condition/key handling fixes.
  - src/Connections/Database/SQLiteLink.php — safe last-row tracking.
  - src/Cli/Util/Working.php — new helper for spinner + callable.
  - src/Cli/Console.php — working() API.
  - README.md — CLI examples updated.

  ## Tests

  - vendor/bin/phpunit --do-not-cache-result tests/Cli/Util/SpinnerTest.php tests/Cli/Util/WorkingTest.php tests/Data/Storage/Structure/SQLiteFieldTest.php
  - vendor/bin/phpunit --do-not-cache-result tests/Cli/Util/WorkingTest.php

  ## Notes

  - Spinner remains available for manual ticking; Working wraps the DevOps-requested “run work while animating” flow.