### PR TITLE
Applies minor updates in html and utility classes.

### DIFF
--- a/src/Cli/Util/Tty.php
+++ b/src/Cli/Util/Tty.php
@@ -21,7 +21,11 @@ class Tty extends Obj
         Dev::do('_before', [$stream, $this]);
 
         if ($stream === null) {
-            $stream = STDOUT;
+            if (defined('STDOUT')) {
+                $stream = STDOUT;
+            } else {
+                $stream = fopen('php://output', 'w');
+            }
         }
 
         if (function_exists('stream_isatty')) {

--- a/src/HTML/HTML.php
+++ b/src/HTML/HTML.php
@@ -39,7 +39,20 @@ class HTML
                 $href .= $_SERVER['REQUEST_URI'] ?? '';
             }
         } else {
-            if (Str::pos($href, 'http') === false) {
+            if (Str::sub((string)$href, 0, 1) === '/') {
+                return $href;
+            }
+            if (Str::pos((string)$href, '://') !== false) {
+                return $href;
+            }
+            if (Str::pos((string)$href, 'http') === 0) {
+                return $href;
+            }
+            if (Str::sub((string)$href, 0, 1) === '#' || Str::sub((string)$href, 0, 1) === '?') {
+                return $href;
+            }
+
+            if (Str::pos((string)$href, 'http') === false) {
                 $protocol = isset($_SERVER['HTTPS']) ? 'https' : 'http';
                 $href = $protocol . '://' . $href;
             }

--- a/src/HTML/Template.php
+++ b/src/HTML/Template.php
@@ -234,7 +234,7 @@ class Template extends Obj {
 
 		if (Str::is($var))
 		{
-			if ( !$content )
+			if ( Val::isNull($content) )
 			{
 				throw new InvalidArgumentException( 'Cannot assign empty value.');
 			}

--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -14,6 +14,7 @@ use BlueFission\Val;
 use BlueFission\Str;
 use BlueFission\Arr;
 use BlueFission\Obj;
+use BlueFission\DevElation as Dev;
 use BlueFission\Behavioral\Behaviors\Behavior;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\Handler;

--- a/src/System/CommandLocator.php
+++ b/src/System/CommandLocator.php
@@ -97,7 +97,7 @@ class CommandLocator
 
     protected static function isAbsolutePath(string $command): bool
     {
-        if (Str::contains($command, '://')) {
+        if (Str::has($command, '://')) {
             return true;
         }
 

--- a/tests/HTML/HTMLTest.php
+++ b/tests/HTML/HTMLTest.php
@@ -15,6 +15,10 @@ class HTMLTest extends \PHPUnit\Framework\TestCase
         $expected = '';
         $result = HTML::href(null, false);
         $this->assertEquals($expected, $result);
+
+        $expected = '/';
+        $result = HTML::href('/');
+        $this->assertEquals($expected, $result);
     }
 
     public function testFormatMethod()


### PR DESCRIPTION
 ## Intent

  Fix CLI and HTML edge cases + cleanup DevElation usage

  ## Summary

  - Allow empty strings in HTML\Template::field (only throw on null values).
  - Make Cli\Util\Tty safe in web SAPI by falling back to php://output when STDOUT is undefined.
  - Import BlueFission\DevElation as Dev in Services\Application for getMimeType hook usage.
  - Replace Str::contains with Str::has in System\CommandLocator to match available API.

  ## Tests

  - vendor/bin/phpunit --do-not-cache-result tests/HTML/TemplateTest.php
  - vendor/bin/phpunit --do-not-cache-result

  ## Notes

  - Full suite passed with 35 skipped tests (expected optional/integration skips).