### PR TITLE
Harden SQLite compatibility and substring helpers

### DIFF
--- a/src/Connections/Database/SQLiteLink.php
+++ b/src/Connections/Database/SQLiteLink.php
@@ -518,50 +518,43 @@ class SQLiteLink extends Connection implements IConfigurable
      */
     public static function sanitize($string, $datetime = false)
     {
-        $db = end(self::$_database);
-        $pattern = [ '/\'/', '/^([\w\W\d\D\s]+)$/', '/(\d+)\/(\d+)\/(\d{4})/', '/\'(\d)\'/', '/\$/', '/^\'\'$/' ];
-        $replacement = [ '\'', '\'$1\'', '$3-$1-$2', '\'$1\'', '$', '' ];
+        $db = (is_array(self::$_database) && count(self::$_database) > 0) ? end(self::$_database) : null;
 
-        if ($datetime === true) {
-            $replacement = [ '\'', '\'$1\'', '$3-$1-$2 12:00:00', '$1', '$', '' ];
+        if ($string instanceof \BlueFission\IVal) {
+            $string = $string->val();
         }
 
-        $string = new Str($string, true);
+        if (Val::isNull($string)) {
+            return 'NULL';
+        }
 
-        $string->constraint(function (&$value) {
-            if (Val::isNull($value)) {
-                $value = 'NULL';
-            }
-        });
+        if (is_bool($string)) {
+            return $string ? '1' : '0';
+        }
 
-        $string->constraint(function (&$value) {
-            if (Val::isNull($value) || Val::isEmpty($value) || Str::len($value) <= 0) {
-                $value = '';
-            }
-        });
+        if (is_int($string) || is_float($string)) {
+            return (string)$string;
+        }
 
-        $string->constraint(function (&$value) use ($db, $pattern, $replacement) {
-            if (Val::isNotNull($value)) {
-                if ($db) {
-                    $value = $db->escapeString(stripslashes($value));
-                }
-                $value = preg_replace($pattern, $replacement, $value);
-            }
-        });
+        $value = (string)$string;
 
-        $string->constraint(function (&$value) {
-            if ($value == '\'NOW()\'') {
-                $value = 'NOW()';
-            }
-        });
+        if ($datetime === true && preg_match('/^(\d+)\/(\d+)\/(\d{4})$/', $value, $matches)) {
+            $value = "{$matches[3]}-{$matches[1]}-{$matches[2]} 12:00:00";
+        } elseif (preg_match('/^(\d+)\/(\d+)\/(\d{4})$/', $value, $matches)) {
+            $value = "{$matches[3]}-{$matches[1]}-{$matches[2]}";
+        }
 
-        $string->constraint(function (&$value) {
-            if ($value == '\'NULL\'') {
-                $value = 'NULL';
-            }
-        });
+        if ($value === 'NOW()' || $value === 'NULL') {
+            return $value;
+        }
 
-        return $string();
+        if ($db) {
+            $value = $db->escapeString(stripslashes($value));
+        } elseif (class_exists('SQLite3')) {
+            $value = \SQLite3::escapeString(stripslashes($value));
+        }
+
+        return "'" . $value . "'";
     }
 
     /**

--- a/src/Data/Storage/SQLite.php
+++ b/src/Data/Storage/SQLite.php
@@ -5,8 +5,7 @@ namespace BlueFission\Data\Storage;
 use BlueFission\Val;
 use BlueFission\Arr;
 use BlueFission\Str;
-use BlueFission\Date
-;
+use BlueFission\Date;
 use BlueFission\IObj;
 use BlueFission\Data\IData;
 use BlueFission\Connections\Database\SQLiteLink;
@@ -84,6 +83,7 @@ class SQLite extends Storage implements IData
     {
         $this->_source = new SQLiteLink();
         $this->_source->database($this->config('location'));
+        $this->_source->open();
         // load object fields and related data
         $this->fields();
 
@@ -379,6 +379,63 @@ class SQLite extends Storage implements IData
         $this->run($query);
 
         return $this;
+    }
+
+    /**
+     * Remove row limits for the next read operation.
+     *
+     * @return IObj
+     */
+    public function noLimit(): IObj
+    {
+        $this->_row_start = null;
+        $this->_row_end = null;
+
+        return $this;
+    }
+
+    /**
+     * Read all matching rows without the default single-row limit.
+     *
+     * @return IObj
+     */
+    public function readAll(): IObj
+    {
+        return $this->noLimit()->read();
+    }
+
+    /**
+     * Fetch all rows from the active result set.
+     *
+     * @return array
+     */
+    public function fetchRows(): array
+    {
+        $rows = [];
+
+        if ($this->_result && is_object($this->_result)) {
+            $this->_result->reset();
+
+            while ($row = $this->_result->fetchArray(SQLITE3_ASSOC)) {
+                $rows[] = $row;
+            }
+
+            $this->_result->reset();
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Convenience list helper that reads and returns all matching rows.
+     *
+     * @return array
+     */
+    public function all(): array
+    {
+        $this->readAll();
+
+        return $this->fetchRows();
     }
 
     /**

--- a/src/Data/Storage/Structure/SQLiteField.php
+++ b/src/Data/Storage/Structure/SQLiteField.php
@@ -215,7 +215,7 @@ class SQLiteField
         }
 
         if ($this->_default !== null && !$this->_autoincrement) {
-            $definition[] = "DEFAULT " . SQLiteLink::sanitize((string)$this->_default);
+            $definition[] = "DEFAULT " . SQLiteLink::sanitize($this->_default);
         }
 
         if (!$this->_autoincrement) {

--- a/src/Str.php
+++ b/src/Str.php
@@ -405,6 +405,17 @@ class Str extends Val implements IVal {
 	}
 
 	/**
+	 * Compatibility alias for substring checks.
+	 *
+	 * @param string $needle
+	 * @return bool
+	 */
+	public function _contains(string $needle): bool
+	{
+		return $this->_has($needle);
+	}
+
+	/**
 	 * Check if the current string starts with the given needle.
 	 *
 	 * @param string $needle

--- a/tests/Data/Storage/SQLiteTest.php
+++ b/tests/Data/Storage/SQLiteTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Data\Storage\SQLite;
+
+class SQLiteTest extends \PHPUnit\Framework\TestCase
+{
+    private string $_database;
+
+    protected function setUp(): void
+    {
+        if (!class_exists('SQLite3')) {
+            $this->markTestSkipped('SQLite3 extension is not available.');
+        }
+
+        $this->_database = tempnam(sys_get_temp_dir(), 'bf_sqlite_test_');
+        $db = new \SQLite3($this->_database);
+        $db->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $db->exec("INSERT INTO items (name) VALUES ('one')");
+        $db->exec("INSERT INTO items (name) VALUES ('two')");
+        $db->exec("INSERT INTO items (name) VALUES ('three')");
+        $db->close();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->_database) && file_exists($this->_database)) {
+            @unlink($this->_database);
+        }
+    }
+
+    public function testDefaultReadMaintainsSingleRowBehavior()
+    {
+        $storage = new SQLite([
+            'location' => $this->_database,
+            'name' => 'items',
+        ]);
+
+        $storage->activate()->read();
+
+        $this->assertCount(1, $storage->fetchRows());
+    }
+
+    public function testReadAllFetchesAllRows()
+    {
+        $storage = new SQLite([
+            'location' => $this->_database,
+            'name' => 'items',
+        ]);
+
+        $storage->activate()->readAll();
+        $rows = $storage->fetchRows();
+
+        $this->assertCount(3, $rows);
+        $this->assertSame(['one', 'two', 'three'], array_column($rows, 'name'));
+    }
+
+    public function testAllReturnsAllRowsDirectly()
+    {
+        $storage = new SQLite([
+            'location' => $this->_database,
+            'name' => 'items',
+        ]);
+
+        $rows = $storage->activate()->all();
+
+        $this->assertCount(3, $rows);
+    }
+}

--- a/tests/Data/Storage/Structure/SQLiteFieldTest.php
+++ b/tests/Data/Storage/Structure/SQLiteFieldTest.php
@@ -14,4 +14,24 @@ class SQLiteFieldTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('PRIMARY KEY AUTOINCREMENT', $definition);
         $this->assertSame('', $field->extras());
     }
+
+    public function testNumericDefaultDefinitionDoesNotRequireOpenConnection()
+    {
+        $field = new SQLiteField('enabled');
+        $field->type('numeric')->default(1);
+
+        $definition = $field->definition();
+
+        $this->assertStringContainsString('DEFAULT 1', $definition);
+    }
+
+    public function testTextDefaultDefinitionIsSafelyQuotedWithoutOpenConnection()
+    {
+        $field = new SQLiteField('name');
+        $field->type('text')->default('blue');
+
+        $definition = $field->definition();
+
+        $this->assertStringContainsString("DEFAULT 'blue'", $definition);
+    }
 }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -130,4 +130,10 @@ class StrTest extends ValTest {
 		$this->assertTrue(Str::toBoolStrict('true'));
 		$this->assertTrue(Str::toBoolStrict('yes'));
 	}
+
+	public function testContainsProvidesCompatibilityAlias()
+	{
+		$this->assertTrue(Str::contains('orchestrate', 'strate'));
+		$this->assertFalse(Str::contains('orchestrate', 'matrix'));
+	}
 }


### PR DESCRIPTION
## Intent
Harden SQLite behavior used by downstream integrations and restore substring compatibility helpers.

## Linked Issues
- Closes #46

## User story / outcome supported
As a downstream library maintainer, I need SQLite list/read flows and structure builders to behave safely by default, and I need stable substring helpers across supported DevElation versions, so integration code does not need repo-local workarounds.

## Summary of changes
- Adds Str::contains(...) as a compatibility alias for substring checks.
- Hardens SQLiteLink::sanitize(...) so it safely handles null, bool, numeric, and string defaults without requiring an active SQLite connection.
- Opens the SQLite connection during SQLite::activate() so field introspection and reads work reliably.
- Adds explicit multi-row SQLite helpers: 
oLimit(), eadAll(), etchRows(), and ll() while preserving existing single-row ead() behavior.
- Stops forcing SQLite field defaults to string before sanitization so numeric defaults remain numeric.
- Adds regression tests for substring compatibility, SQLite field defaults, and SQLite multi-row reads.

## Key files / areas touched
- src/Str.php - restores substring compatibility.
- src/Connections/Database/SQLiteLink.php - sanitization hardening.
- src/Data/Storage/SQLite.php - explicit multi-row read helpers and connection activation fix.
- src/Data/Storage/Structure/SQLiteField.php - preserves scalar default types.
- 	ests/Data/Storage/SQLiteTest.php - new SQLite regression coverage.

## QA / Validation checklist
### Automated checks
- [x] Targeted tests pass
- [x] Full PHPUnit suite passes

## Unit tests (specific)
- endor/bin/phpunit --do-not-cache-result tests/StrTest.php tests/Data/Storage/Structure/SQLiteFieldTest.php tests/Data/Storage/SQLiteTest.php
- endor/bin/phpunit --do-not-cache-result

## Risk and rollout
- Risk level: low
- Backward compatibility: existing ead() single-row behavior is preserved; new helpers provide the safer multi-row path explicitly.
- Rollback plan: revert this PR.
