### PR TITLE
Prevent SQLite auto-create from misclassifying arbitrary strings as dates

### DIFF
--- a/src/Data/Storage/SQLite.php
+++ b/src/Data/Storage/SQLite.php
@@ -84,6 +84,7 @@ class SQLite extends Storage implements IData
     {
         $this->_source = new SQLiteLink();
         $this->_source->database($this->config('location'));
+        $this->_source->open();
         // load object fields and related data
         $this->fields();
 
@@ -555,7 +556,7 @@ class SQLite extends Storage implements IData
                     if (is_numeric($b)) {
                         $type = is_float($b) ? "REAL" : "INTEGER";
                     } elseif (is_string($b)) {
-                        if (Date::is($b)) {
+                        if ($this->looksLikeDateValue($b)) {
                             $type = "DATETIME";
                         } else {
                             $length = Val::isNotNull($b) ? (int)(strlen($b) * 1.3) : 90;
@@ -659,6 +660,7 @@ class SQLite extends Storage implements IData
             $this->perform(State::DRAFT);
             $active_fields = Arr::toArray($this->config('fields'));
             foreach ($tables as $table) {
+                $fields = [];
                 $query = "PRAGMA table_info(`$table`)";
                 $result = false;
                 if ($db) {
@@ -675,7 +677,6 @@ class SQLite extends Storage implements IData
                     }
                     $this->_fields[$table] = $fields;
                 }
-                $fields = null;
             }
 
             $this->halt(State::DRAFT);
@@ -1211,6 +1212,40 @@ class SQLite extends Storage implements IData
             }
         }
         return $array;
+    }
+
+    /**
+     * Determine whether a scalar string should be treated as a date-like value
+     * during SQLite auto-create inference without invoking exception-prone parsing.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    private function looksLikeDateValue($value): bool
+    {
+        if (!Str::is($value)) {
+            return false;
+        }
+
+        $value = Str::trim((string)$value);
+        if ($value === '') {
+            return false;
+        }
+
+        $patterns = [
+            '/^\d{4}-\d{2}-\d{2}$/',
+            '/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(:\d{2})?$/',
+            '/^\d{1,2}\/\d{1,2}\/\d{4}$/',
+            '/^\d{1,2}-\d{1,2}-\d{4}$/',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Data/Storage/SQLiteAutoCreateTest.php
+++ b/tests/Data/Storage/SQLiteAutoCreateTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Data\Storage\SQLite;
+
+class SQLiteAutoCreateTest extends \PHPUnit\Framework\TestCase
+{
+    private string $_database;
+
+    protected function setUp(): void
+    {
+        if (!class_exists('SQLite3')) {
+            $this->markTestSkipped('SQLite3 extension is not available.');
+        }
+
+        $this->_database = tempnam(sys_get_temp_dir(), 'bf_sqlite_auto_');
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->_database) && file_exists($this->_database)) {
+            @unlink($this->_database);
+        }
+    }
+
+    public function testCreateInfersTextForOrdinaryStrings()
+    {
+        $storage = new SQLite([
+            'location' => $this->_database,
+            'name' => 'test_records',
+        ]);
+
+        $storage->activate();
+
+        $ref = new \ReflectionClass($storage);
+        $data = $ref->getProperty('_data');
+        $data->setAccessible(true);
+        $data->setValue($storage, [
+            'name' => 'alpha',
+            'status' => 'active',
+        ]);
+
+        $create = $ref->getMethod('create');
+        $create->setAccessible(true);
+        $create->invoke($storage);
+
+        $this->assertSame(SQLite::STATUS_SUCCESS, $storage->status());
+        $this->assertStringContainsString('`name` TEXT', $storage->query());
+        $this->assertStringNotContainsString('DATETIME', $storage->query());
+
+        $db = new \SQLite3($this->_database);
+        $result = $db->query("PRAGMA table_info(`test_records`)");
+        $fields = [];
+        while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+            $fields[$row['name']] = $row;
+        }
+        $db->close();
+
+        $this->assertArrayHasKey('name', $fields);
+        $this->assertSame('TEXT', strtoupper($fields['name']['type']));
+    }
+}


### PR DESCRIPTION
## Intent
Prevent SQLite auto-create from treating ordinary strings as dates during schema inference.

## Linked Issues
- Closes #48

## User story / outcome supported
As a downstream maintainer using SQLite-backed state stores, I need first-use schema inference to classify ordinary strings as TEXT without throwing date parsing exceptions, so SQLite auto-create works reliably for repository-style writes.

## Summary of changes
- Opens the SQLite link during SQLite::activate() so schema introspection can run reliably on first use.
- Replaces exception-prone Date::is(...) inference in SQLite::create() with a safe date-shape check.
- Restricts automatic date inference to explicit date-like string formats.
- Initializes the field collection in SQLite::fields() to avoid undefined-variable warnings during first activation.
- Adds a regression test that exercises the auto-create path and verifies ordinary strings infer as TEXT.

## Key files / areas touched
- src/Data/Storage/SQLite.php
- 	ests/Data/Storage/SQLiteAutoCreateTest.php

## QA / Validation checklist
### Automated checks
- [x] Regression test added
- [x] Full PHPUnit suite passes

## Unit tests (specific)
- endor/bin/phpunit --do-not-cache-result tests/Data/Storage/SQLiteAutoCreateTest.php
- endor/bin/phpunit --do-not-cache-result

## Risk and rollout
- Risk level: low
- Backward compatibility: only narrows auto-date inference for ambiguous strings; explicit date-shaped strings still infer as dates.
- Rollback plan: revert this PR.
