### PR TITLE
Harden evaluator assignment and typed-let contracts

### DIFF
--- a/parsing.md
+++ b/parsing.md
@@ -55,6 +55,14 @@ echo $template->render();
 
 Register defaults once per process (for example, during bootstrap) so custom tags and renderers are available everywhere.
 
+Current `#let` typed-value contract:
+
+```vibe
+{#let settings:json='{"theme":"dark"}'}
+```
+
+Treat `name:type=value` as the supported syntax today. Do not document or depend on `name:type=json = ...` style attribute syntax unless it is separately implemented and covered by tests.
+
 A simple Vibe layout pattern:
 
 ```vibe

--- a/src/Parsing/Elements/EvalElement.php
+++ b/src/Parsing/Elements/EvalElement.php
@@ -22,7 +22,7 @@ class EvalElement extends Element implements IExecutableElement, IRenderableElem
     protected array $params;
     protected string $var;
     protected string $type;
-    protected string $value = '';
+    protected mixed $value = null;
     protected $generatorDriver;
 
     public function __construct(string $tag, string $match, string $raw, array $attributes = [])

--- a/src/Parsing/Evaluator.php
+++ b/src/Parsing/Evaluator.php
@@ -30,7 +30,7 @@ class Evaluator implements IDispatcher
     protected array $params;
     protected string $var;
     protected string $type;
-    protected string $value = '';
+    protected mixed $value = null;
     protected $generatorDriver;
 
     public function __construct($element = null)
@@ -79,7 +79,7 @@ class Evaluator implements IDispatcher
         $value = $this->process();
         $value = Dev::apply('_out', $value);
 
-        $this->value = $value ?? '';
+        $this->value = $value;
 
         if ($append) {
             if (!$this->element->hasScopeVariable($this->var)) {
@@ -464,14 +464,20 @@ class Evaluator implements IDispatcher
     protected function useGenerator(string $expression): mixed
     {
         // Generators are used when a variable is a content-producing tag.
-        try {
-            $generator = GeneratorRegistry::get();
-            $generator->setDriver($this->generatorDriver);
-            return $generator->generate($this->element);
+        $generator = GeneratorRegistry::get();
+
+        if (!$generator) {
+            throw new \RuntimeException(
+                sprintf(
+                    "No generator registered for expression '%s'.",
+                    $expression
+                )
+            );
         }
-        catch (\Exception $e) {
-            return "[Generation Error]";
-        }
+
+        $generator->setDriver($this->generatorDriver);
+
+        return $generator->generate($this->element);
     }
 
     protected function call($classOrObject, $method, $args = []): mixed

--- a/tests/Parsing/EvaluatorToolInvocationTest.php
+++ b/tests/Parsing/EvaluatorToolInvocationTest.php
@@ -6,6 +6,7 @@ use BlueFission\Parsing\Contracts\IToolFunction;
 use BlueFission\Parsing\Element;
 use BlueFission\Parsing\Evaluator;
 use BlueFission\Parsing\Registry\FunctionRegistry;
+use BlueFission\Parsing\Registry\GeneratorRegistry;
 use PHPUnit\Framework\TestCase;
 
 class EvaluatorToolInvocationTest extends TestCase
@@ -33,5 +34,45 @@ class EvaluatorToolInvocationTest extends TestCase
 
         $this->assertSame('Nairobi forecast', $result);
         $this->assertSame('Nairobi forecast', $element->getScopeVariable('weatherData'));
+    }
+
+    public function testToolInvocationCanAssignStructuredValues(): void
+    {
+        FunctionRegistry::register(new class implements IToolFunction {
+            public function name(): string
+            {
+                return 'arrTool';
+            }
+
+            public function execute(array $args): mixed
+            {
+                return ['a' => 1, 'b' => 2];
+            }
+        });
+
+        $element = new Element('root', '', '', []);
+        $evaluator = new Evaluator($element);
+
+        $result = $evaluator->evaluate('arrTool() -> data');
+
+        $this->assertSame(['a' => 1, 'b' => 2], $result);
+        $this->assertSame(['a' => 1, 'b' => 2], $element->getScopeVariable('data'));
+        $this->assertSame(1, $element->resolveValue('data.a'));
+    }
+
+    public function testEvaluateWithoutGeneratorFailsPredictably(): void
+    {
+        $reflection = new \ReflectionClass(GeneratorRegistry::class);
+        $property = $reflection->getProperty('generator');
+        $property->setAccessible(true);
+        $property->setValue(null, null);
+
+        $element = new Element('root', '', '', []);
+        $evaluator = new Evaluator($element);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("No generator registered for expression 'headline'.");
+
+        $evaluator->evaluate('headline');
     }
 }


### PR DESCRIPTION
## Intent
Harden evaluator assignment semantics and document the current typed-let contract without widening parser/runtime contracts beyond what is already implemented.

## Linked Issues
- Closes #56

## User story / outcome supported
As a Vibe/template author, I need structured tool output to survive assignment into scope and I need the documented typed-let syntax to match the actual engine, so I can keep more logic inside templates without depending on misleading docs or brittle host-language glue.

## Summary of changes
- Changes `Parsing\Evaluator` assignment state to accept mixed values instead of string-only values.
- Preserves arrays/objects/scalars assigned through eval so dotted access continues to work from scope.
- Makes generator lookup fail with a clear runtime error when no generator is registered instead of null-calling `setDriver()`.
- Documents the current typed-let contract as `name:type=value` in parsing docs.
- Adds regression coverage for structured eval assignment and missing-generator failure.

## Key files / areas touched
- `src/Parsing/Evaluator.php` — mixed assignment + generator safety
- `src/Parsing/Elements/EvalElement.php` — mixed eval value storage
- `tests/Parsing/EvaluatorToolInvocationTest.php` — structured assignment + missing generator regressions
- `parsing.md` — typed-let contract correction

## QA / Validation checklist
### Automated checks
- [x] `vendor/bin/phpunit --do-not-cache-result tests/Parsing/EvaluatorToolInvocationTest.php`
- [x] `vendor/bin/phpunit --do-not-cache-result tests/Parsing/ParserBasicTest.php tests/Parsing/TemplateSectionTest.php`
- [x] `vendor/bin/phpunit --do-not-cache-result tests/Parsing`
- [x] `vendor/bin/phpunit --do-not-cache-result`

## Risk and rollout
- Risk level: low to medium
- Backward compatibility: preserves existing eval contracts while removing an unsafe string-only assumption; no new parser syntax is introduced here.
- Explicit boundary: this PR does not attempt the broader `src=` / file-handle / directory-binding bundle requested downstream. That work should be scoped separately.
