### PR TITLE
Add content-based src loading for eval assignments

### DIFF
--- a/parsing.md
+++ b/parsing.md
@@ -63,6 +63,22 @@ Current `#let` typed-value contract:
 
 Treat `name:type=value` as the supported syntax today. Do not document or depend on `name:type=json = ...` style attribute syntax unless it is separately implemented and covered by tests.
 
+## Phase 1 `src` Loading
+
+The current safe `src` contract is content-oriented:
+
+```vibe
+{=data src="notes.txt"}
+```
+
+Behavior:
+
+- `src` resolves against existing include paths (`includes`, `modules`, `templates`) and explicit absolute paths.
+- the file contents are loaded into the eval result and assigned variable on the direct eval-assignment path.
+- JSON files hydrate through the existing value-resolution behavior when the loaded content begins with `{` or `[`.
+
+This is intentionally narrower than a full filesystem contract. It does not yet promise template-native file handles, directory iteration, or `.vibe.gen` execution semantics.
+
 A simple Vibe layout pattern:
 
 ```vibe

--- a/src/Parsing/Evaluator.php
+++ b/src/Parsing/Evaluator.php
@@ -13,6 +13,7 @@ use BlueFission\Parsing\Registry\StandardRegistry;
 use BlueFission\Parsing\Registry\TagRegistry;
 use BlueFission\Parsing\Contracts\IRenderableElement;
 use BlueFission\Parsing\Contracts\IExecutableElement;
+use BlueFission\Data\FileSystem;
 use BlueFission\Val;
 use BlueFission\Obj;
 use BlueFission\Behavioral\IDispatcher;
@@ -163,7 +164,9 @@ class Evaluator implements IDispatcher
 
                     $this->var = $var;
 
-                    if (isset($call) && !empty($call) && $call != "") {
+                    if (isset($options['src']) && !empty($options['src'])) {
+                        $value = $this->loadSourceValue((string)$options['src']);
+                    } elseif (isset($call) && !empty($call) && $call != "") {
                         
                         // Split chained calls while keeping argument groups.
                         preg_match_all('/((?<call>[a-zA-Z_][a-zA-Z0-9_-]*(\((?<arguments>[^)]*)\))?))/', $call, $callMatch);
@@ -351,6 +354,64 @@ class Evaluator implements IDispatcher
         }
 
         return $value;
+    }
+
+    protected function loadSourceValue(string $source): mixed
+    {
+        $resolved = $this->resolveSourcePath($source);
+        $directory = dirname($resolved);
+        $file = basename($resolved);
+
+        $filesystem = new FileSystem(['root' => $directory]);
+        $filesystem->open($file)->read();
+        $contents = $filesystem->contents();
+
+        if (!is_string($contents)) {
+            return $contents;
+        }
+
+        return $this->element->resolveValue($contents);
+    }
+
+    protected function resolveSourcePath(string $source): string
+    {
+        $source = trim($source, "'\"");
+        $candidates = [];
+
+        if ($this->isAbsolutePath($source)) {
+            $candidates[] = $source;
+        } else {
+            $paths = $this->element->getIncludePaths();
+
+            foreach (['includes', 'modules', 'templates'] as $key) {
+                if (isset($paths[$key]) && is_string($paths[$key]) && $paths[$key] !== '') {
+                    $candidates[] = rtrim($paths[$key], '\\/') . DIRECTORY_SEPARATOR . $source;
+                }
+            }
+
+            foreach ($paths as $path) {
+                if (is_string($path) && $path !== '') {
+                    $candidates[] = rtrim($path, '\\/') . DIRECTORY_SEPARATOR . $source;
+                }
+            }
+
+            $candidates[] = $source;
+        }
+
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate)) {
+                return $candidate;
+            }
+        }
+
+        throw new \RuntimeException(
+            sprintf("Unable to resolve src file '%s'.", $source)
+        );
+    }
+
+    protected function isAbsolutePath(string $path): bool
+    {
+        return (bool)preg_match('/^(?:[A-Za-z]:[\\\\\\/]|[\\\\\\/]{2}|\/)/', $path);
     }
 
     protected function match($expression, &$matches): bool

--- a/src/Parsing/Registry/TagRegistry.php
+++ b/src/Parsing/Registry/TagRegistry.php
@@ -241,7 +241,7 @@ class TagRegistry {
         self::register(new TagDefinition(
             name: 'eval',
             pattern: '{open}=(.*?)(?:->(\\w+))?(?:\\s+silent=[\'\"]?(true|false)[\'\"]?)?{close}',
-            attributes: ['expression', 'params', 'assign', 'silent', 'default'],
+            attributes: ['expression', 'params', 'assign', 'silent', 'default', 'src'],
             interface: Contracts\IRenderableElement::class,
             class: Elements\EvalElement::class
         ));

--- a/tests/Parsing/EvaluatorToolInvocationTest.php
+++ b/tests/Parsing/EvaluatorToolInvocationTest.php
@@ -75,4 +75,26 @@ class EvaluatorToolInvocationTest extends TestCase
 
         $evaluator->evaluate('headline');
     }
+
+    public function testSourceAssignmentSupportsStructuredData(): void
+    {
+        $dir = __DIR__ . DIRECTORY_SEPARATOR . '_tmp';
+        if (!is_dir($dir)) {
+            mkdir($dir);
+        }
+
+        $file = $dir . DIRECTORY_SEPARATOR . 'source_' . uniqid() . '.json';
+        file_put_contents($file, '{"a":1,"b":{"title":"Loaded"}}');
+
+        $element = new Element('eval', '', '', [
+            'expression' => 'data',
+            'src' => $file,
+        ]);
+        $evaluator = new Evaluator($element);
+
+        $result = $evaluator->evaluate('data');
+
+        $this->assertSame(['a' => 1, 'b' => ['title' => 'Loaded']], $result);
+        $this->assertSame('Loaded', $element->resolveValue('data.b.title'));
+    }
 }

--- a/tests/Parsing/ParserBasicTest.php
+++ b/tests/Parsing/ParserBasicTest.php
@@ -132,4 +132,17 @@ class ParserBasicTest extends ParsingTestCase
 
         $this->assertSame('bar', $output);
     }
+
+    public function testEvalCanLoadSourceFromIncludePaths()
+    {
+        $dir = $this->createTempDir('eval_src');
+        $sourcePath = $dir . DIRECTORY_SEPARATOR . 'note.txt';
+        file_put_contents($sourcePath, 'Loaded from file');
+
+        $parser = new Parser("{=data src='note.txt'}");
+        $parser->setIncludePaths(['includes' => $dir]);
+        $parser->render();
+
+        $this->assertSame('Loaded from file', $parser->root()->getScopeVariable('data'));
+    }
 }


### PR DESCRIPTION
## Intent
Add a narrow, non-breaking phase-1 `src` contract for parser eval assignments so file-backed content can be loaded through the existing eval/value-resolution flow.

## Linked Issues
- Closes #58

## User story / outcome supported
As a template/parser author, I want to load file content into an eval assignment through a stable `src` attribute, so that file-backed content can be composed through the same parsing/runtime patterns without introducing a larger file-handle or execution contract.

## Summary of changes
- Add `src` to the core eval tag attribute registry.
- Resolve `src` values against parser include paths (`includes`, `modules`, `templates`) or explicit absolute paths.
- Load resolved file contents into the direct eval-assignment path.
- Hydrate structured content through the existing value-resolution flow.
- Document the feature as a phase-1 content-only contract.

## Key files / areas touched
- `src/Parsing/Registry/TagRegistry.php` — exposes `src` on the core eval tag.
- `src/Parsing/Evaluator.php` — resolves and loads file-backed source content safely.
- `tests/Parsing/EvaluatorToolInvocationTest.php` — adds structured source-assignment coverage.
- `tests/Parsing/ParserBasicTest.php` — adds include-path source loading coverage.
- `parsing.md` — documents the supported phase-1 syntax and boundaries.

## QA / Validation checklist
### Manual QA
- [ ] Render an eval assignment with `src="file.txt"` from an include path.
- [ ] Confirm JSON file content resolves into structured data.
- [ ] Confirm unresolved `src` paths fail clearly.

### Automated checks
- [x] Unit tests added/updated
- [x] CI pipeline expected to pass

## Setup / configuration / migrations
- [ ] Env vars added/changed: none
- [ ] DB migrations: none
- [ ] Seeds needed: none
- [ ] Package updates: none
- [ ] Feature flags / config toggles: none

## Unit tests (specific)
- `vendor/bin/phpunit --do-not-cache-result tests/Parsing/EvaluatorToolInvocationTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Parsing/ParserBasicTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Parsing`
- `vendor/bin/phpunit --do-not-cache-result`

## Risk and rollout
- Risk level: low
- What could break?
  - Downstream code that overrides the eval tag attribute list and does not include `src` will not see the new attribute until it is updated.
- Backward compatibility notes:
  - This is additive and scoped to the direct eval-assignment path.
  - It does not introduce file handles, directory iteration, or `.vibe.gen` execution semantics.
- Rollback plan:
  - Revert this PR.

## Dependencies / sequencing
- Requires downstream alignment in `vibe-interpreter` where `Reader` overrides eval tag attributes.

## Notes / discussion
This intentionally keeps the `src` feature narrow. It adds content loading only, using existing parser include paths and value resolution, to avoid overextending parser/runtime contracts in one step.