### PR TITLE
Harden let parsing for inline JSON values

### DIFF
--- a/src/Parsing/Registry/TagRegistry.php
+++ b/src/Parsing/Registry/TagRegistry.php
@@ -151,6 +151,14 @@ class TagRegistry {
         $clean = preg_replace('/^[{@]?#?' . preg_quote($tag, '/') . '\s*/i', '', $raw);
         $clean = preg_replace('/[{}]$/', '', $clean); // trailing brace
 
+        if ($tag === 'let') {
+            if (preg_match('/^\{\#let\s+([a-zA-Z_][a-zA-Z0-9_]*(?::[a-zA-Z_][a-zA-Z0-9_]*)?)\s*=\s*(.+)\}$/s', $raw, $letMatch)) {
+                $attributes[$letMatch[1]] = $letMatch[2];
+            }
+
+            return Dev::apply('_attributes', $attributes);
+        }
+
         preg_match('/
             ^[{@]?
             (?<tag_open>[\#=\$])\s*?                            # tag type
@@ -232,7 +240,7 @@ class TagRegistry {
 
         self::register(new TagDefinition(
             name: 'let',
-            pattern: '{open}\#let (.*?)=(.*?){close}',
+            pattern: '{open}\#let\s+(?:[^{}\'"]+|"(?:[^"\\\\]|\\\\.)*"|\'(?:[^\'\\\\]|\\\\.)*\')+{close}',
             attributes: ['*'],
             interface: Contracts\IExecutableElement::class,
             class: Elements\LetElement::class

--- a/tests/Parsing/ParserBasicTest.php
+++ b/tests/Parsing/ParserBasicTest.php
@@ -31,6 +31,35 @@ class ParserBasicTest extends ParsingTestCase
         $this->assertSame('bar', $output);
     }
 
+    public function testTypedLetSupportsInlineJsonLiterals()
+    {
+        $template = '{#let settings:json=\'{"theme":"dark","layout":"wide"}\'}';
+        $parser = new Parser($template);
+        $output = $parser->render();
+
+        $this->assertSame('', $output);
+        $this->assertSame(
+            ['theme' => 'dark', 'layout' => 'wide'],
+            $parser->root()->getScopeVariable('settings')
+        );
+    }
+
+    public function testTypedLetSupportsNestedInlineJsonLiterals()
+    {
+        $template = '{#let settings:json=\'{"theme":"dark","layout":{"width":"wide","columns":2}}\'}';
+        $parser = new Parser($template);
+        $output = $parser->render();
+
+        $this->assertSame('', $output);
+        $this->assertSame(
+            [
+                'theme' => 'dark',
+                'layout' => ['width' => 'wide', 'columns' => 2],
+            ],
+            $parser->root()->getScopeVariable('settings')
+        );
+    }
+
     public function testIfConditionOutputsMatchingBlock()
     {
         $template = '{#let status="ok"}{#if var=status equals="ok"}yes{/if}{#if var=status equals="no"}no{/if}';

--- a/tests/Parsing/TagRegistryPatternTest.php
+++ b/tests/Parsing/TagRegistryPatternTest.php
@@ -30,4 +30,26 @@ class TagRegistryPatternTest extends ParsingTestCase
 
         $this->assertSame('', $output);
     }
+
+    public function testUnifiedPatternSupportsQuotedJsonInLetTags()
+    {
+        $pattern = TagRegistry::unifiedPattern();
+        $template = '{#let settings:json=\'{"theme":"dark","layout":{"width":"wide"}}\'}';
+
+        $matched = preg_match($pattern, $template, $matches);
+
+        $this->assertSame(1, $matched);
+        $this->assertSame($template, $matches['let']);
+    }
+
+    public function testExtractAttributesPreservesTypedLetVariableNames()
+    {
+        $template = '{#let settings:json=\'{"theme":"dark"}\'}';
+        $attributes = TagRegistry::extractAttributes('let', $template);
+
+        $this->assertSame(
+            ['settings:json' => '\'{"theme":"dark"}\''],
+            $attributes
+        );
+    }
 }


### PR DESCRIPTION
## Intent
Harden `#let` parsing so inline typed JSON literals survive parsing without changing the existing `name:type=value` contract.

## Linked Issues
- Closes #61

## User story / outcome supported
As a parser/template author, I want inline typed JSON in `#let` tags to parse reliably, so structured local values can be declared directly in templates without malformed captures or broken typed assignment.

## Summary of changes
- Harden the `let` tag regex so quoted braces inside values are treated as content rather than premature tag closes.
- Add a `let`-specific attribute extraction path that preserves typed variable names like `settings:json`.
- Add regression coverage for inline JSON literals, nested JSON literals, full `let` tag matching, and typed `let` attribute preservation.

## Key files / areas touched
- `src/Parsing/Registry/TagRegistry.php` — fixes `let` matching and extraction.
- `tests/Parsing/ParserBasicTest.php` — covers inline and nested typed JSON `#let` values.
- `tests/Parsing/TagRegistryPatternTest.php` — covers raw pattern matching and attribute extraction for typed `let` tags.

## QA / Validation checklist
### Manual QA
- [ ] Render `{#let settings:json='{"theme":"dark"}'}` and confirm `settings` resolves as structured JSON.
- [ ] Render nested JSON inside `#let` and confirm parsing stays intact.

### Automated checks
- [x] Unit tests added/updated
- [x] Full PHPUnit suite passes locally

## Setup / configuration / migrations
- [ ] Env vars added/changed: none
- [ ] DB migrations: none
- [ ] Seeds needed: none
- [ ] Package updates: none
- [ ] Feature flags / config toggles: none

## Unit tests (specific)
- `vendor/bin/phpunit --do-not-cache-result tests/Parsing/TagRegistryPatternTest.php tests/Parsing/ParserBasicTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Parsing`
- `vendor/bin/phpunit --do-not-cache-result`

## Risk and rollout
- Risk level: low
- What could break?
  - Only code relying on malformed `#let` truncation behavior, which is not a supported contract.
- Backward compatibility notes:
  - Keeps the existing `name:type=value` typed-let contract.
  - Does not introduce new `#let` syntax.
- Rollback plan:
  - Revert this PR.

## Dependencies / sequencing
- No upstream/downstream code dependency required beyond consumers picking up the parser fix.

## Notes / discussion
This is intentionally narrow. It hardens the existing typed `#let` behavior instead of introducing a broader typed-attribute syntax or changing other parser contracts.