### PR TITLE
Add scoped value transforms for parsing

### DIFF
--- a/src/Parsing/Evaluator.php
+++ b/src/Parsing/Evaluator.php
@@ -14,6 +14,7 @@ use BlueFission\Parsing\Registry\TagRegistry;
 use BlueFission\Parsing\Contracts\IRenderableElement;
 use BlueFission\Parsing\Contracts\IExecutableElement;
 use BlueFission\Data\FileSystem;
+use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Obj;
 use BlueFission\Behavioral\IDispatcher;
@@ -469,8 +470,13 @@ class Evaluator implements IDispatcher
         return $additional;
     }
 
-    protected function parseParameters(string $params): array
+    protected function parseParameters(?string $params): array
     {
+        $params = $params ?? '';
+        if (Str::trim($params) === '') {
+            return [];
+        }
+
         // Parse loosely-typed arguments; resolved values can be vars, strings, or bracketed values.
         $pattern = '/(?:
             (?<param>
@@ -491,11 +497,17 @@ class Evaluator implements IDispatcher
             return [];
 
         foreach ($matches as $match) {
-            if (!isset($match['param']) || trim($match['param']) === '') {
+            $param = $match['param'] ?? null;
+            if (!is_string($param) || Str::trim($param) === '') {
                 continue;
             }
-            $arg = trim($this->element->resolveValue($match['param']));
-            $arg = (empty($arg)) ? null : $arg;
+
+            $arg = $this->element->resolveValue($param);
+
+            if (is_string($arg)) {
+                $arg = Str::trim($arg);
+                $arg = $arg === '' ? null : $arg;
+            }
 
             $args[] = $arg;
         }

--- a/tests/Parsing/EvaluatorToolInvocationTest.php
+++ b/tests/Parsing/EvaluatorToolInvocationTest.php
@@ -11,6 +11,24 @@ use PHPUnit\Framework\TestCase;
 
 class EvaluatorToolInvocationTest extends TestCase
 {
+    public function testParseParametersHandlesNullAndFalsyResolvedValuesSafely(): void
+    {
+        $element = new Element('root', '', '', []);
+        $element->setScopeVariable('maybeNull', null);
+        $element->setScopeVariable('zero', 0);
+        $element->setScopeVariable('disabled', false);
+
+        $evaluator = new class($element) extends Evaluator {
+            public function parsePublic(?string $params): array
+            {
+                return $this->parseParameters($params);
+            }
+        };
+
+        $this->assertSame([], $evaluator->parsePublic(null));
+        $this->assertSame([null, 0, false], $evaluator->parsePublic('maybeNull, zero, disabled'));
+    }
+
     public function testToolInvocationAssignsVariable(): void
     {
         FunctionRegistry::register(new class implements IToolFunction {


### PR DESCRIPTION
## Intent
Add scoped value transforms for existing parsed values without colliding with generation/tool eval semantics, and harden evaluator parameter parsing for null-safe typed values.

## Linked Issues
- Closes #63
- Related: #64

## User story / outcome supported
As a Vibe or DevElation template author, I want to transform already-bound scoped values directly in templates, so routine formatting can stay declarative and interpreter-agnostic.

## Summary of changes
- Adds clone-only scoped transforms like `{$name -> $.trim().capitalize()}`
- Adds mutating scoped transforms like `{$name.trim().capitalize()}`
- Supports the same transform behavior for dotted paths such as `{$profile.value.trim()}`
- Allows `#let` to assign transformed existing values without invoking the generator path
- Throws a runtime exception when a `#let` transform references a missing source value
- Makes `Evaluator::parseParameters()` null-safe and preserves typed falsy values like `0` and `false`
- Merges current parser updates from `master` into the transform branch so the branch is mergeable

## Key files / areas touched
- `src/Parsing/Element.php` - scoped transform parsing, path resolution, and nested path mutation helpers
- `src/Parsing/Elements/VarElement.php` - render-time clone vs mutate behavior
- `src/Parsing/Elements/LetElement.php` - assignment from transformed existing values
- `src/Parsing/Evaluator.php` - null-safe parameter parsing
- `src/Parsing/Registry/TagRegistry.php` - parser registration/pattern support for the transform syntax
- `tests/Parsing/ParserBasicTest.php` - transform syntax and assignment coverage
- `tests/Parsing/EvaluatorToolInvocationTest.php` - null-safe evaluator parameter coverage

## QA / Validation checklist
### Manual QA
- [ ] Render `{$name -> $.trim().capitalize()}` and confirm the output changes while `name` remains unchanged
- [ ] Render `{$name.trim().capitalize()}` and confirm `name` is mutated in scope
- [ ] Render nested transforms like `{$profile.value.trim()}` and confirm dotted path behavior
- [ ] Confirm `#let` transform assignment throws when the source value does not exist

### Automated checks
- [x] Unit tests added/updated
- [x] Full PHPUnit suite passes locally

## Unit tests
- `vendor/bin/phpunit --do-not-cache-result tests/Parsing/EvaluatorToolInvocationTest.php tests/Parsing/ParserBasicTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Parsing`
- `vendor/bin/phpunit --do-not-cache-result`

## Risk and rollout
- Risk level: medium
- Main risk is parser ambiguity around new scoped transform syntax; coverage is included for root and dotted values, clone-vs-mutate behavior, and null-safe evaluator params
- Backward compatibility: intended to be non-breaking because transforms are added to existing-value syntax rather than overloading current generation/tool eval semantics
- Rollback plan: revert this PR

## Notes / discussion
- This PR supersedes the previously closed transform PR for the same branch.
- Latest local full-suite result: 575 tests, 3868 assertions, 35 skipped.
