### PR TITLE
Honor eval assignment targets for zero-arg dotted calls

### DIFF
--- a/src/Parsing/Elements/EvalElement.php
+++ b/src/Parsing/Elements/EvalElement.php
@@ -106,8 +106,9 @@ class EvalElement extends Element implements IExecutableElement, IRenderableElem
     {
         $expression = (string)($this->attributes['expression'] ?? '');
         $params = (string)($this->attributes['params'] ?? '');
+        $invoked = Flag::parseBool($this->attributes['invoked'] ?? false, false);
 
-        if ($params !== '') {
+        if ($invoked) {
             return "{$expression}({$params})";
         }
 

--- a/src/Parsing/Registry/TagRegistry.php
+++ b/src/Parsing/Registry/TagRegistry.php
@@ -210,13 +210,19 @@ class TagRegistry {
         $assign_target = $meta['assign_target'] ?? '';
 
         if (isset($meta['tag_open']) && $meta['tag_open'] === '=') {
+            $invoked = (bool)preg_match(
+                '/^[{@]?[=#]?\s*\$?[a-zA-Z_][a-zA-Z0-9_.-]*\([^)]*\)/',
+                $raw
+            );
+
             // If it's a variable tag, we only care about the variable name
             $attributes['expression'] = $tag_name;
             if ($assign_target !== '') {
                 $attributes['assign'] = $assign_target;
             }
-            if ($function_args !== '') {
+            if ($invoked) {
                 $attributes['params'] = $function_args;
+                $attributes['invoked'] = true;
             }
         }
 

--- a/tests/Parsing/EvaluatorToolInvocationTest.php
+++ b/tests/Parsing/EvaluatorToolInvocationTest.php
@@ -7,6 +7,7 @@ use BlueFission\Parsing\Element;
 use BlueFission\Parsing\Evaluator;
 use BlueFission\Parsing\Registry\FunctionRegistry;
 use BlueFission\Parsing\Registry\GeneratorRegistry;
+use BlueFission\Parsing\Registry\StandardRegistry;
 use PHPUnit\Framework\TestCase;
 
 class EvaluatorToolInvocationTest extends TestCase
@@ -76,6 +77,24 @@ class EvaluatorToolInvocationTest extends TestCase
         $this->assertSame(['a' => 1, 'b' => 2], $result);
         $this->assertSame(['a' => 1, 'b' => 2], $element->getScopeVariable('data'));
         $this->assertSame(1, $element->resolveValue('data.a'));
+    }
+
+    public function testZeroArgDottedStandardCallAssignsTargetVariable(): void
+    {
+        StandardRegistry::register('system', new class {
+            public function os(): string
+            {
+                return 'TestOS';
+            }
+        });
+
+        $element = new Element('root', '', '', []);
+        $evaluator = new Evaluator($element);
+
+        $result = $evaluator->evaluate('system.os() -> operatingSystem');
+
+        $this->assertSame('TestOS', $result);
+        $this->assertSame('TestOS', $element->getScopeVariable('operatingSystem'));
     }
 
     public function testEvaluateWithoutGeneratorFailsPredictably(): void

--- a/tests/Parsing/ParserBasicTest.php
+++ b/tests/Parsing/ParserBasicTest.php
@@ -3,6 +3,7 @@ namespace BlueFission\Tests\Parsing;
 
 use BlueFission\Parsing\Contracts\IToolFunction;
 use BlueFission\Parsing\Parser;
+use BlueFission\Parsing\Registry\StandardRegistry;
 use BlueFission\Parsing\Registry\TagRegistry;
 use BlueFission\Parsing\Registry\FunctionRegistry;
 use BlueFission\Parsing\TagDefinition;
@@ -532,6 +533,22 @@ class ParserBasicTest extends ParsingTestCase
 
         $this->assertSame('AFTER', $output);
         $this->assertSame('generated', $parser->root()->getScopeVariable('generatedBook'));
+    }
+
+    public function testZeroArgDottedStandardEvalAssignsTargetVariable()
+    {
+        StandardRegistry::register('system', new class {
+            public function os(): string
+            {
+                return 'TestOS';
+            }
+        });
+
+        $parser = new Parser('{=system.os() -> operatingSystem}AFTER');
+        $output = $parser->render();
+
+        $this->assertSame('AFTER', $output);
+        $this->assertSame('TestOS', $parser->root()->getScopeVariable('operatingSystem'));
     }
 
     public function testQuotedEvalAttributesSupportScopedInterpolationFilters()


### PR DESCRIPTION
## Intent
Honor eval assignment targets for dotted zero-argument calls.

## Linked Issues
- Closes #84

## User story / outcome supported
As a template/runtime author, I want zero-argument dotted calls like `{=system.os() -> operatingSystem}` to assign into scope the same way argument-bearing dotted calls do, so authored runtime expressions are consistent and predictable.

## Summary of changes
- Preserves empty `()` invocation syntax for zero-argument eval expressions.
- Ensures parser-level eval attribute extraction distinguishes plain variable expressions from actual zero-argument calls.
- Keeps eval assignment and silent-output behavior intact for existing non-call expressions.
- Adds parser-level and evaluator-level regressions for zero-argument dotted standard calls.

## Key files / areas touched
- `src/Parsing/Registry/TagRegistry.php` - preserves zero-arg invocation metadata only for real callable syntax.
- `src/Parsing/Elements/EvalElement.php` - re-emits empty parentheses for invoked expressions so the evaluator receives `system.os()` instead of `system.os`.
- `tests/Parsing/ParserBasicTest.php` - adds parser-level zero-arg dotted eval assignment regression.
- `tests/Parsing/EvaluatorToolInvocationTest.php` - adds evaluator-level zero-arg dotted call regression.

## QA / Validation checklist
### Automated checks
- [x] `vendor/bin/phpunit --do-not-cache-result tests/Parsing/ParserBasicTest.php`
- [x] `vendor/bin/phpunit --do-not-cache-result tests/Parsing/EvaluatorToolInvocationTest.php`
- [x] `vendor/bin/phpunit --do-not-cache-result tests/Parsing`
- [x] `vendor/bin/phpunit --do-not-cache-result`

## Risk and rollout
- Risk level: low
- What could break?
  - Eval parsing for edge cases where plain expressions and zero-arg call syntax are very close.
- Backward compatibility notes:
  - Existing plain variable eval behavior remains intact.
  - Only real callable syntax now preserves empty parentheses.
- Rollback plan:
  - Revert the PR if downstream eval parsing depends on the prior ambiguity.

## Notes / discussion
This keeps the parser/evaluator contract aligned with Vibe runtime namespaces: dotted zero-argument standard calls now behave like normal callable expressions instead of collapsing into bare variable-like strings.
