### PR TITLE
Support dotted reserved loop placeholders

### DIFF
--- a/src/Parsing/Elements/CurrentElement.php
+++ b/src/Parsing/Elements/CurrentElement.php
@@ -5,6 +5,7 @@ namespace BlueFission\Parsing\Elements;
 use BlueFission\Parsing\Element;
 use BlueFission\Parsing\Contracts\ILoopElement;
 use BlueFission\Parsing\Contracts\IRenderableElement;
+use BlueFission\Str;
 use BlueFission\DevElation as Dev;
 
 class CurrentElement extends Element implements IRenderableElement
@@ -29,45 +30,33 @@ class CurrentElement extends Element implements IRenderableElement
         $match = $this->getMatch();
 
         if (preg_match('/^\{@current\.?(.*?)\}$/', $match, $matches)) {
-            return trim($matches[1] ?? '');
+            return Str::trim((string)($matches[1] ?? ''));
         }
 
         if (preg_match('/^\{\.(.*?)\}$/', $match, $matches)) {
-            return trim($matches[1] ?? '');
+            return Str::trim((string)($matches[1] ?? ''));
         }
 
         return '';
     }
 
-    protected function resolveCurrentValue(mixed $value, string $path = ''): mixed
-    {
-        if (!$path) {
-            return $value;
-        }
-
-        foreach (explode('.', $path) as $part) {
-            if (is_array($value) && array_key_exists($part, $value)) {
-                $value = $value[$part];
-            } elseif (is_object($value) && property_exists($value, $part)) {
-                $value = $value->$part;
-            } else {
-                return null;
-            }
-        }
-
-        return $value;
-    }
-
     public function render(): string
     {
         Dev::do('_before', [$this]);
-        $loop = $this->getLoopContext();
-        if (!$loop) {
+        $path = $this->getCurrentPath();
+        $value = $this->getScopeVariable('current');
+
+        if ($value === null) {
+            $value = $this->getLoopContext()?->getScopeVariable('current');
+        }
+
+        if ($value === null) {
             return '';
         }
 
-        $path = $this->getCurrentPath();
-        $value = $this->resolveCurrentValue($loop->getScopeVariable('current'), $path);
+        if ($path !== '') {
+            $value = $this->getPathValue("current.{$path}");
+        }
 
         $output = (string)$value;
         $output = Dev::apply('_out', $output);

--- a/src/Parsing/Elements/IndexElement.php
+++ b/src/Parsing/Elements/IndexElement.php
@@ -4,6 +4,7 @@ namespace BlueFission\Parsing\Elements;
 
 use BlueFission\Parsing\Element;
 use BlueFission\Parsing\Contracts\IRenderableElement;
+use BlueFission\Str;
 use BlueFission\DevElation as Dev;
 
 class IndexElement extends Element implements IRenderableElement
@@ -26,7 +27,13 @@ class IndexElement extends Element implements IRenderableElement
     public function render(): string
     {
         Dev::do('_before', [$this]);
-        $output = (string) ($this->getLoopContext()?->getIndex() ?? '');
+        $index = $this->getScopeVariable('index');
+
+        if ($index === null) {
+            $index = $this->getLoopContext()?->getIndex();
+        }
+
+        $output = Str::is($index) || is_numeric($index) ? (string)$index : '';
         $output = Dev::apply('_out', $output);
         Dev::do('_after', [$output, $this]);
         return $output;

--- a/tests/Parsing/ParserBasicTest.php
+++ b/tests/Parsing/ParserBasicTest.php
@@ -263,6 +263,41 @@ class ParserBasicTest extends ParsingTestCase
         $this->assertSame('0:a,1:b', $output);
     }
 
+    public function testEachSupportsDottedAtCurrentPlaceholderAccess()
+    {
+        $template = '{#each items=items glue=","}{@current.title}:{@current.seed.number}{/each}';
+        $parser = new Parser($template);
+        $parser->setVariables([
+            'items' => [
+                ['title' => 'Alpha', 'seed' => ['number' => 1]],
+                ['title' => 'Beta', 'seed' => ['number' => 2]],
+            ],
+        ]);
+        $output = $parser->render();
+
+        $this->assertSame('Alpha:1,Beta:2', $output);
+    }
+
+    public function testIncludeCanRenderDottedAtCurrentPlaceholderFromScopedLoopContext()
+    {
+        $dir = $this->createTempDir('current_reserved_include');
+        $partialPath = $dir . DIRECTORY_SEPARATOR . 'current-label.vibe';
+        file_put_contents($partialPath, '{@index}:{@current.title}:{@current.seed.number}');
+
+        $template = '{#each items=items glue="|"}@include(\'current-label.vibe\'){/each}';
+        $parser = new Parser($template);
+        $parser->setVariables([
+            'items' => [
+                ['title' => 'Alpha', 'seed' => ['number' => 1]],
+                ['title' => 'Beta', 'seed' => ['number' => 2]],
+            ],
+        ]);
+        $parser->setIncludePaths(['modules' => $dir]);
+        $output = $parser->render();
+
+        $this->assertSame('0:Alpha:1|1:Beta:2', $output);
+    }
+
     public function testEachExposesCurrentAsScopedVariableForNestedIterationInPartials()
     {
         $dir = $this->createTempDir('nested_sections');


### PR DESCRIPTION
## Intent
Support dotted reserved loop placeholders in authored parser output.

## Linked Issues
- Closes #90

## User story / outcome supported
As a template/runtime author, I want reserved loop placeholders like `{@current.title}` and `{@current.seed.number}` to behave consistently in authored output, so the `@current.*` surface can be standardized without forcing fallback to bare `current.*` paths.

## Summary of changes
- Makes `CurrentElement` resolve dotted `@current.*` placeholder access through scoped `current` state first, with loop-context fallback.
- Makes `IndexElement` read scoped `index` first, with loop-context fallback.
- Adds parser regressions covering dotted `@current.*` rendering in loop bodies and included partials.
- Keeps existing direct `{@current}` and `{@index}` behavior intact.

## Key files / areas touched
- `src/Parsing/Elements/CurrentElement.php` - resolves dotted reserved loop placeholders through scoped state.
- `src/Parsing/Elements/IndexElement.php` - aligns `@index` with scoped loop state.
- `tests/Parsing/ParserBasicTest.php` - adds dotted reserved placeholder regressions.

## QA / Validation checklist
### Automated checks
- [x] `vendor/bin/phpunit --do-not-cache-result tests/Parsing/ParserBasicTest.php`
- [x] `vendor/bin/phpunit --do-not-cache-result tests/Parsing`
- [x] `vendor/bin/phpunit --do-not-cache-result`

## Risk and rollout
- Risk level: low
- What could break?
  - Placeholder rendering in unusual loop contexts if consumers were implicitly depending on direct parent traversal only.
- Backward compatibility notes:
  - Existing `{@current}` and `{@index}` behavior remains intact.
  - This expands the reserved authored surface rather than replacing bare `current.*` access.
- Rollback plan:
  - Revert the PR if downstream templating relies on the older placeholder-resolution asymmetry.

## Notes / discussion
This aligns the authored placeholder surface with the existing expression-side runtime contract: `@current.*` and `@index` now behave like first-class reserved loop values instead of special-cased direct placeholders only.
