### PR TITLE
Add prototypes substrate for domains, collectives, conditions, and causality

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Handle queues, storage solutions, databases, Redis, MemQ, files, and logs with a
 - [Data Management Documentation](data_management.md)
 - [Schema Documentation](schema.md)
 - [Graph Documentation](graph.md)
+- [Prototypes Documentation](prototypes.md)
 
 ### HTML Building Tools
 Construct HTML elements for forms, tables, and templating with ease, improving the speed of frontend development.

--- a/prototypes.md
+++ b/prototypes.md
@@ -1,0 +1,233 @@
+# Prototypes Substrate
+
+DevElation's `src/Prototypes/` surface is a generic substrate for world-modeling,
+stateful entities, conditions, collectives, and causal context. It is not a
+reasoning engine. It exists so other Blue Fission libraries can share one set
+of signatures, metadata contracts, hooks, and event surfaces.
+
+## Design Intent
+
+- Keep the substrate generic and useful on its own.
+- Prefer traits and lightweight interfaces over inheritance-heavy design.
+- Reuse DevElation patterns:
+  - `Obj` field storage
+  - `Arr`, `Str`, `Val` normalization
+  - `DevElation::apply` and `DevElation::do`
+  - optional behavior dispatch when the carrier already supports it
+- Do not embed Automata-specific graph or simulation logic in this library.
+- Do not lead with new JenSS grammar. Runtime-backed adapters should come first.
+
+## Core Surface
+
+### Traits
+
+- `Proto`
+- `Blueprint`
+- `Artifact`
+- `Entity`
+- `Agent`
+- `Position`
+- `Domain`
+- `Collective`
+- `HasConditions`
+- `IsCausal`
+- `HasCollectives`
+
+### Interfaces
+
+- `Contracts\\Conditional`
+- `Contracts\\Causal`
+- `Contracts\\DomainAware`
+- `Contracts\\CollectiveAware`
+
+## Semantic Stack
+
+- `Proto`: anything knowable, measurable, labelable, relatable, and inspectable.
+- `Blueprint`: a semantic pattern or template for a kind of thing.
+- `Artifact`: a blueprint-realized thing with substance or thingness.
+- `Entity`: a reactionary artifact that can respond to conditions, state, and events.
+- `Agent`: an entity with autonomy or external control.
+- `Domain`: a world/context model for members, collectives, rules, and subdomains.
+- `Collective`: a shared-fate grouping inside a domain such as a flock, fleet, crowd, or cloud.
+- `Position`: orthogonal multi-dimensional location or frame context.
+
+## Normalized Metadata
+
+Prototype-bearing carriers should be able to expose, directly or through
+`snapshot()`, these common fields:
+
+- `id`
+- `kind`
+- `name`
+- `labels`
+- `traits`
+- `state`
+- `properties`
+- `measures`
+- `relations`
+- `conditions`
+- `causes`
+- `effects`
+- `confidence`
+- `history`
+- `summary`
+- `domain`
+- `position`
+- `collectives`
+
+Additional metadata may be present for blueprint, artifact, agent, domain, and
+collective-specific concerns.
+
+## Conditions
+
+`HasConditions` is intentionally simple. It is meant to support:
+
+- action guards
+- state prerequisites
+- migration dependencies
+- domain constraints
+- game rules
+- simulation defaults
+- causal candidate filtering
+
+Condition records may be:
+
+- callables
+- plain arrays
+- simple named references
+
+The default implementation understands:
+
+- `path`
+- `expected`
+- `operator`
+- `resolver`
+- `confidence`
+
+Supported operators include:
+
+- `requires`
+- `equals`
+- `not_equals`
+- `gt`
+- `gte`
+- `lt`
+- `lte`
+- `in`
+- `not_in`
+- `truthy`
+- `falsy`
+
+## Causality
+
+`IsCausal` stores and filters candidate causes/effects. It does not perform
+advanced inference by itself. Its purpose is to create a stable structure for:
+
+- causal records
+- candidate prior conditions
+- effect chains
+- hooks for future graph reasoning
+- simulation and state-engine integration
+
+Automata can later consume these records through graph edges, decision scoring,
+or simulation loops.
+
+## Domain And Collective Registry
+
+The preferred grouping mechanism is a domain-level registry, not value tags.
+
+- `Domain` owns members, subdomains, rules, defaults, state, and collectives.
+- `Collective` represents shared membership and shared destiny.
+- `HasCollectives` lets any prototype-bearing object join or leave named
+  collectives without depending on a specific simulation or graph engine.
+
+Examples:
+
+- sheep -> flock
+- trucks -> fleet
+- people -> crowd or mob
+- droplets -> cloud
+- bulls -> herd or stampede
+
+Collectives may carry:
+
+- members
+- shared rules
+- shared state
+- shared destiny
+- shared position or anchor
+- shared conditions
+- shared causal hints
+
+## Forward Compatibility
+
+### Automata
+
+This substrate is intentionally compatible with future adaptation in:
+
+- `Goal`
+- `Simulation`
+- `GameTheory`
+- `Comprehension`
+- `DecisionTree`
+- `Memory`
+- graph/path reasoning
+
+Expected integration approach:
+
+- Automata consumes normalized snapshots and relation/condition/causal records.
+- Automata keeps all real scoring, search, pathing, and simulation logic.
+- Automata may wrap or extend Develation substrate traits in richer classes.
+
+### Jenss Interpreter
+
+This substrate is intentionally compatible with runtime adapters and modules
+such as:
+
+- `intelligence.agent`
+- `intelligence.entity`
+- `intelligence.artifact`
+- `intelligence.domain`
+- `intelligence.collective`
+- `intelligence.blueprint`
+- `intelligence.position`
+
+Expected integration approach:
+
+- start with runtime factories/adapters
+- preserve `make(...)`, `snapshot()`, and `explain()`
+- avoid grammar-first expansion until the substrate proves stable
+
+## Existing Develation Enhancement Opportunities
+
+These traits should remain connected to the rest of the library:
+
+- `Behavioral\\StateMachine`
+  - state guards and transitions can reuse `HasConditions`
+  - event/state histories can reuse `IsCausal`
+- `Data\\Graph`
+  - prototype/domain/collective relationships can project naturally into nodes and edges
+- `Data\\Schema`
+  - conditions and defaults can inform schema constraints and pre-validation
+- `Data\\Storage`
+  - prototype snapshots serialize cleanly for persistence and migration planning
+- `Services`
+  - domain defaults and shared rules can help scope applications/services
+
+## Current Scope
+
+This first substrate pass focuses on:
+
+- stable trait and interface signatures
+- normalized metadata
+- hooks and optional behavior dispatch
+- domain/collective registries
+- condition and causal records
+
+It deliberately does not attempt:
+
+- theorem proving
+- full causal inference
+- graph search
+- game simulation
+- Automata-specific reasoning

--- a/src/Prototypes/Agent.php
+++ b/src/Prototypes/Agent.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
+
+trait Agent
+{
+    public function role(?string $role = null): mixed
+    {
+        $this->prototypeBoot('agent');
+        $this->kind('agent');
+
+        if (Val::isNull($role)) {
+            return (string) $this->prototypeGet('role', '');
+        }
+
+        return $this->prototypeSet('role', Str::trim($role), 'prototypes.agent.role_set');
+    }
+
+    public function scope(?string $scope = null): mixed
+    {
+        if (Val::isNull($scope)) {
+            return (string) $this->prototypeGet('scope', '');
+        }
+
+        return $this->prototypeSet('scope', Str::trim($scope), 'prototypes.agent.scope_set');
+    }
+
+    public function awareness(?string $awareness = null): mixed
+    {
+        if (Val::isNull($awareness)) {
+            return (string) $this->prototypeGet('awareness', '');
+        }
+
+        return $this->prototypeSet('awareness', Str::trim($awareness), 'prototypes.agent.awareness_set');
+    }
+
+    public function efficacy(?string $efficacy = null): mixed
+    {
+        if (Val::isNull($efficacy)) {
+            return (string) $this->prototypeGet('efficacy', '');
+        }
+
+        return $this->prototypeSet('efficacy', Str::trim($efficacy), 'prototypes.agent.efficacy_set');
+    }
+
+    public function autonomy(?string $autonomy = null): mixed
+    {
+        if (Val::isNull($autonomy)) {
+            return (string) $this->prototypeGet('autonomy', 'autonomous');
+        }
+
+        return $this->prototypeSet('autonomy', Str::trim($autonomy), 'prototypes.agent.autonomy_set');
+    }
+
+    public function control(?string $control = null): mixed
+    {
+        if (Val::isNull($control)) {
+            return (string) $this->prototypeGet('control', 'self');
+        }
+
+        return $this->prototypeSet('control', Str::trim($control), 'prototypes.agent.control_set');
+    }
+
+    public function addGoal(mixed $goal): static
+    {
+        return $this->prototypeAppend('goals', $goal, false, 'prototypes.agent.goal_added');
+    }
+
+    public function goals(): array
+    {
+        return Arr::toArray($this->prototypeGet('goals', []));
+    }
+
+    public function addCriterion(string $name, int|float $weight = 1, string $concern = ''): static
+    {
+        return $this->prototypeAppend('criteria', [
+            'name' => $name,
+            'weight' => $weight,
+            'concern' => $concern,
+        ], false, 'prototypes.agent.criterion_added');
+    }
+
+    public function criteria(): array
+    {
+        return Arr::toArray($this->prototypeGet('criteria', []));
+    }
+
+    public function addStrategy(string $name, int|float $weight = 1, string $concern = ''): static
+    {
+        return $this->prototypeAppend('strategies', [
+            'name' => $name,
+            'weight' => $weight,
+            'concern' => $concern,
+        ], false, 'prototypes.agent.strategy_added');
+    }
+
+    public function strategies(): array
+    {
+        return Arr::toArray($this->prototypeGet('strategies', []));
+    }
+
+    public function decide(mixed $decisionResult): static
+    {
+        $decision = $this->prototypeSnapshotValue($decisionResult);
+        $this->prototypeSet('lastDecision', $decision, 'prototypes.agent.decision_set');
+        $this->record('decision', ['decision' => $decision]);
+
+        return $this;
+    }
+}

--- a/src/Prototypes/Agent.php
+++ b/src/Prototypes/Agent.php
@@ -6,8 +6,21 @@ use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Val;
 
+/**
+ * Agent
+ *
+ * Autonomous or externally controlled entity substrate. Agents accumulate
+ * goals, criteria, strategies, and decision history without embedding a full
+ * planning or reasoning engine in Develation itself.
+ */
 trait Agent
 {
+    /**
+     * Get or assign the agent's role within a system or domain.
+     *
+     * @param string|null $role
+     * @return mixed
+     */
     public function role(?string $role = null): mixed
     {
         $this->prototypeBoot('agent');
@@ -20,6 +33,12 @@ trait Agent
         return $this->prototypeSet('role', Str::trim($role), 'prototypes.agent.role_set');
     }
 
+    /**
+     * Get or assign the operating scope of the agent.
+     *
+     * @param string|null $scope
+     * @return mixed
+     */
     public function scope(?string $scope = null): mixed
     {
         if (Val::isNull($scope)) {
@@ -29,6 +48,12 @@ trait Agent
         return $this->prototypeSet('scope', Str::trim($scope), 'prototypes.agent.scope_set');
     }
 
+    /**
+     * Get or assign a qualitative awareness descriptor.
+     *
+     * @param string|null $awareness
+     * @return mixed
+     */
     public function awareness(?string $awareness = null): mixed
     {
         if (Val::isNull($awareness)) {
@@ -38,6 +63,12 @@ trait Agent
         return $this->prototypeSet('awareness', Str::trim($awareness), 'prototypes.agent.awareness_set');
     }
 
+    /**
+     * Get or assign a qualitative efficacy descriptor.
+     *
+     * @param string|null $efficacy
+     * @return mixed
+     */
     public function efficacy(?string $efficacy = null): mixed
     {
         if (Val::isNull($efficacy)) {
@@ -47,6 +78,12 @@ trait Agent
         return $this->prototypeSet('efficacy', Str::trim($efficacy), 'prototypes.agent.efficacy_set');
     }
 
+    /**
+     * Get or assign how autonomous the agent is considered to be.
+     *
+     * @param string|null $autonomy
+     * @return mixed
+     */
     public function autonomy(?string $autonomy = null): mixed
     {
         if (Val::isNull($autonomy)) {
@@ -56,6 +93,12 @@ trait Agent
         return $this->prototypeSet('autonomy', Str::trim($autonomy), 'prototypes.agent.autonomy_set');
     }
 
+    /**
+     * Get or assign the controller responsible for the agent.
+     *
+     * @param string|null $control
+     * @return mixed
+     */
     public function control(?string $control = null): mixed
     {
         if (Val::isNull($control)) {
@@ -65,16 +108,35 @@ trait Agent
         return $this->prototypeSet('control', Str::trim($control), 'prototypes.agent.control_set');
     }
 
+    /**
+     * Append one goal descriptor to the agent.
+     *
+     * @param mixed $goal
+     * @return static
+     */
     public function addGoal(mixed $goal): static
     {
         return $this->prototypeAppend('goals', $goal, false, 'prototypes.agent.goal_added');
     }
 
+    /**
+     * Return all registered goals.
+     *
+     * @return array<int, mixed>
+     */
     public function goals(): array
     {
         return Arr::toArray($this->prototypeGet('goals', []));
     }
 
+    /**
+     * Add one weighted decision criterion.
+     *
+     * @param string $name
+     * @param int|float $weight
+     * @param string $concern
+     * @return static
+     */
     public function addCriterion(string $name, int|float $weight = 1, string $concern = ''): static
     {
         return $this->prototypeAppend('criteria', [
@@ -84,11 +146,24 @@ trait Agent
         ], false, 'prototypes.agent.criterion_added');
     }
 
+    /**
+     * Return all weighted decision criteria.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function criteria(): array
     {
         return Arr::toArray($this->prototypeGet('criteria', []));
     }
 
+    /**
+     * Add one weighted strategy descriptor.
+     *
+     * @param string $name
+     * @param int|float $weight
+     * @param string $concern
+     * @return static
+     */
     public function addStrategy(string $name, int|float $weight = 1, string $concern = ''): static
     {
         return $this->prototypeAppend('strategies', [
@@ -98,11 +173,22 @@ trait Agent
         ], false, 'prototypes.agent.strategy_added');
     }
 
+    /**
+     * Return all registered strategies.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function strategies(): array
     {
         return Arr::toArray($this->prototypeGet('strategies', []));
     }
 
+    /**
+     * Persist the most recent decision result and add it to history.
+     *
+     * @param mixed $decisionResult
+     * @return static
+     */
     public function decide(mixed $decisionResult): static
     {
         $decision = $this->prototypeSnapshotValue($decisionResult);

--- a/src/Prototypes/Artifact.php
+++ b/src/Prototypes/Artifact.php
@@ -4,8 +4,21 @@ namespace BlueFission\Prototypes;
 
 use BlueFission\Val;
 
+/**
+ * Artifact
+ *
+ * Represents a blueprint-realized thing with substance or material presence.
+ * Artifacts are still generic, but they carry the notion of "thingness" that
+ * downstream libraries can refine into entities, assets, or world objects.
+ */
 trait Artifact
 {
+    /**
+     * Get or assign the originating blueprint for this artifact.
+     *
+     * @param mixed $blueprint
+     * @return mixed
+     */
     public function blueprint(mixed $blueprint = null): mixed
     {
         $this->prototypeBoot('artifact');
@@ -18,6 +31,12 @@ trait Artifact
         return $this->prototypeSet('blueprint', $this->prototypeSnapshotValue($blueprint), 'prototypes.artifact.blueprint_set');
     }
 
+    /**
+     * Get or assign the artifact's substance payload.
+     *
+     * @param mixed $substance
+     * @return mixed
+     */
     public function substance(mixed $substance = null): mixed
     {
         if (Val::isNull($substance)) {
@@ -27,6 +46,12 @@ trait Artifact
         return $this->prototypeSet('substance', $this->prototypeSnapshotValue($substance), 'prototypes.artifact.substance_set');
     }
 
+    /**
+     * Get or assign a materiality descriptor for the artifact.
+     *
+     * @param mixed $materiality
+     * @return mixed
+     */
     public function materiality(mixed $materiality = null): mixed
     {
         if (Val::isNull($materiality)) {

--- a/src/Prototypes/Artifact.php
+++ b/src/Prototypes/Artifact.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Val;
+
+trait Artifact
+{
+    public function blueprint(mixed $blueprint = null): mixed
+    {
+        $this->prototypeBoot('artifact');
+        $this->kind('artifact');
+
+        if (Val::isNull($blueprint)) {
+            return $this->prototypeGet('blueprint');
+        }
+
+        return $this->prototypeSet('blueprint', $this->prototypeSnapshotValue($blueprint), 'prototypes.artifact.blueprint_set');
+    }
+
+    public function substance(mixed $substance = null): mixed
+    {
+        if (Val::isNull($substance)) {
+            return $this->prototypeGet('substance');
+        }
+
+        return $this->prototypeSet('substance', $this->prototypeSnapshotValue($substance), 'prototypes.artifact.substance_set');
+    }
+
+    public function materiality(mixed $materiality = null): mixed
+    {
+        if (Val::isNull($materiality)) {
+            return $this->prototypeGet('materiality', 'substantial');
+        }
+
+        return $this->prototypeSet('materiality', $this->prototypeSnapshotValue($materiality), 'prototypes.artifact.materiality_set');
+    }
+}

--- a/src/Prototypes/Blueprint.php
+++ b/src/Prototypes/Blueprint.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
+
+trait Blueprint
+{
+    public function archetype(?string $archetype = null): mixed
+    {
+        $this->prototypeBoot('blueprint');
+        $this->kind('blueprint');
+
+        if (Val::isNull($archetype)) {
+            return (string) $this->prototypeGet('archetype', '');
+        }
+
+        return $this->prototypeSet('archetype', Str::trim($archetype), 'prototypes.blueprint.archetype_set');
+    }
+
+    public function schema(?array $schema = null): mixed
+    {
+        if (Val::isNull($schema)) {
+            return Arr::toArray($this->prototypeGet('schema', []));
+        }
+
+        return $this->prototypeSet('schema', Arr::toArray($schema), 'prototypes.blueprint.schema_set');
+    }
+
+    public function defaults(?array $defaults = null): mixed
+    {
+        if (Val::isNull($defaults)) {
+            return Arr::toArray($this->prototypeGet('defaults', []));
+        }
+
+        return $this->prototypeSet('defaults', Arr::toArray($defaults), 'prototypes.blueprint.defaults_set');
+    }
+
+    public function addConstraint(string $name, mixed $value): static
+    {
+        return $this->prototypeAssocSet('constraints', $name, $value, 'prototypes.blueprint.constraint_added');
+    }
+
+    public function constraints(): array
+    {
+        return Arr::toArray($this->prototypeGet('constraints', []));
+    }
+
+    public function capability(string $name, mixed $level = true): static
+    {
+        return $this->prototypeAssocSet('capabilities', $name, $level, 'prototypes.blueprint.capability_added');
+    }
+
+    public function capabilities(): array
+    {
+        return Arr::toArray($this->prototypeGet('capabilities', []));
+    }
+
+    public function component(string $name, mixed $value): static
+    {
+        return $this->prototypeAssocSet('components', $name, $value, 'prototypes.blueprint.component_added');
+    }
+
+    public function components(): array
+    {
+        return Arr::toArray($this->prototypeGet('components', []));
+    }
+
+    public function instantiate(array $seed = []): array
+    {
+        $instance = $this->prototypeMergeArrays($this->defaults(), $seed);
+        $instance['blueprint'] = $this->protoId() ?: $this->name();
+        $instance['kind'] = $instance['kind'] ?? 'artifact';
+
+        $this->prototypeSignal('prototypes.blueprint.instantiated', ['seed' => $seed, 'instance' => $instance, 'object' => $this]);
+
+        return $instance;
+    }
+}

--- a/src/Prototypes/Blueprint.php
+++ b/src/Prototypes/Blueprint.php
@@ -6,8 +6,21 @@ use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Val;
 
+/**
+ * Blueprint
+ *
+ * Semantic template for artifacts, entities, or agents. A blueprint captures
+ * defaults, constraints, capabilities, and components without implying that a
+ * concrete instance already exists.
+ */
 trait Blueprint
 {
+    /**
+     * Get or assign the archetypal name of the blueprint.
+     *
+     * @param string|null $archetype
+     * @return mixed
+     */
     public function archetype(?string $archetype = null): mixed
     {
         $this->prototypeBoot('blueprint');
@@ -20,6 +33,12 @@ trait Blueprint
         return $this->prototypeSet('archetype', Str::trim($archetype), 'prototypes.blueprint.archetype_set');
     }
 
+    /**
+     * Get or replace the structural schema associated with the blueprint.
+     *
+     * @param array<string, mixed>|null $schema
+     * @return mixed
+     */
     public function schema(?array $schema = null): mixed
     {
         if (Val::isNull($schema)) {
@@ -29,6 +48,12 @@ trait Blueprint
         return $this->prototypeSet('schema', Arr::toArray($schema), 'prototypes.blueprint.schema_set');
     }
 
+    /**
+     * Get or replace default seed data used when instantiating this blueprint.
+     *
+     * @param array<string, mixed>|null $defaults
+     * @return mixed
+     */
     public function defaults(?array $defaults = null): mixed
     {
         if (Val::isNull($defaults)) {
@@ -38,36 +63,78 @@ trait Blueprint
         return $this->prototypeSet('defaults', Arr::toArray($defaults), 'prototypes.blueprint.defaults_set');
     }
 
+    /**
+     * Add one named constraint to the blueprint definition.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return static
+     */
     public function addConstraint(string $name, mixed $value): static
     {
         return $this->prototypeAssocSet('constraints', $name, $value, 'prototypes.blueprint.constraint_added');
     }
 
+    /**
+     * Return all named blueprint constraints.
+     *
+     * @return array<string, mixed>
+     */
     public function constraints(): array
     {
         return Arr::toArray($this->prototypeGet('constraints', []));
     }
 
+    /**
+     * Register a named capability or capability level on the blueprint.
+     *
+     * @param string $name
+     * @param mixed $level
+     * @return static
+     */
     public function capability(string $name, mixed $level = true): static
     {
         return $this->prototypeAssocSet('capabilities', $name, $level, 'prototypes.blueprint.capability_added');
     }
 
+    /**
+     * Return all named blueprint capabilities.
+     *
+     * @return array<string, mixed>
+     */
     public function capabilities(): array
     {
         return Arr::toArray($this->prototypeGet('capabilities', []));
     }
 
+    /**
+     * Register a named component for the blueprint definition.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return static
+     */
     public function component(string $name, mixed $value): static
     {
         return $this->prototypeAssocSet('components', $name, $value, 'prototypes.blueprint.component_added');
     }
 
+    /**
+     * Return all named blueprint components.
+     *
+     * @return array<string, mixed>
+     */
     public function components(): array
     {
         return Arr::toArray($this->prototypeGet('components', []));
     }
 
+    /**
+     * Build an instantiated seed payload from defaults and overrides.
+     *
+     * @param array<string, mixed> $seed
+     * @return array<string, mixed>
+     */
     public function instantiate(array $seed = []): array
     {
         $instance = $this->prototypeMergeArrays($this->defaults(), $seed);

--- a/src/Prototypes/Collective.php
+++ b/src/Prototypes/Collective.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Arr;
+use BlueFission\Collections\Group;
+use BlueFission\Str;
+use BlueFission\Val;
+
+trait Collective
+{
+    protected ?Group $_collectiveMembers = null;
+
+    protected function collectiveRegistry(): Group
+    {
+        if (!$this->_collectiveMembers instanceof Group) {
+            $this->_collectiveMembers = new Group();
+        }
+
+        return $this->_collectiveMembers;
+    }
+
+    public function collectiveKind(?string $kind = null): mixed
+    {
+        $this->prototypeBoot('collective');
+        $this->kind('collective');
+
+        if (Val::isNull($kind)) {
+            return (string) $this->prototypeGet('collective_kind', 'collective');
+        }
+
+        return $this->prototypeSet('collective_kind', Str::trim($kind), 'prototypes.collective.kind_set');
+    }
+
+    public function addMember(mixed $member, ?string $key = null): static
+    {
+        $key = $key ?? (is_object($member) && method_exists($member, 'protoId') ? $member->protoId() : uniqid('member_', true));
+        $this->collectiveRegistry()->add($member, $key);
+
+        return $this->prototypeSet(
+            'collective_members',
+            $this->collectiveRegistry()->map(fn ($item) => $this->prototypeSnapshotValue($item))->toArray(),
+            'prototypes.collective.member_added'
+        );
+    }
+
+    public function members(): array
+    {
+        return Arr::toArray($this->prototypeGet('collective_members', []));
+    }
+
+    public function collectiveRule(string $name, mixed $value = null): mixed
+    {
+        $rules = Arr::toArray($this->prototypeGet('collective_rules', []));
+
+        if (func_num_args() === 1) {
+            return $rules[$name] ?? null;
+        }
+
+        $rules[$name] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet('collective_rules', $rules, 'prototypes.collective.rule_changed');
+    }
+
+    public function collectiveRules(): array
+    {
+        return Arr::toArray($this->prototypeGet('collective_rules', []));
+    }
+
+    public function collectiveState(?string $name = null, mixed $value = null): mixed
+    {
+        $state = Arr::toArray($this->prototypeGet('collective_state', []));
+
+        if (Val::isNull($name)) {
+            return $state;
+        }
+
+        if (func_num_args() === 1) {
+            return $state[$name] ?? null;
+        }
+
+        $state[$name] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet('collective_state', $state, 'prototypes.collective.state_changed');
+    }
+
+    public function sharedDestiny(mixed $destiny = null): mixed
+    {
+        if (Val::isNull($destiny)) {
+            return $this->prototypeGet('collective_destiny');
+        }
+
+        return $this->prototypeSet('collective_destiny', $this->prototypeSnapshotValue($destiny), 'prototypes.collective.destiny_set');
+    }
+}

--- a/src/Prototypes/Collective.php
+++ b/src/Prototypes/Collective.php
@@ -7,10 +7,27 @@ use BlueFission\Collections\Group;
 use BlueFission\Str;
 use BlueFission\Val;
 
+/**
+ * Collective
+ *
+ * Domain-friendly grouping substrate for members that share rules, state,
+ * position, or destiny. It captures semantic grouping without hardcoding a
+ * specific simulation or graph engine.
+ */
 trait Collective
 {
+    /**
+     * Runtime registry of member objects before they are snapshotted into data.
+     *
+     * @var Group|null
+     */
     protected ?Group $_collectiveMembers = null;
 
+    /**
+     * Lazily build the internal member registry.
+     *
+     * @return Group
+     */
     protected function collectiveRegistry(): Group
     {
         if (!$this->_collectiveMembers instanceof Group) {
@@ -20,6 +37,12 @@ trait Collective
         return $this->_collectiveMembers;
     }
 
+    /**
+     * Get or assign the semantic kind of collective.
+     *
+     * @param string|null $kind
+     * @return mixed
+     */
     public function collectiveKind(?string $kind = null): mixed
     {
         $this->prototypeBoot('collective');
@@ -32,6 +55,13 @@ trait Collective
         return $this->prototypeSet('collective_kind', Str::trim($kind), 'prototypes.collective.kind_set');
     }
 
+    /**
+     * Add one member to the collective registry and snapshot store.
+     *
+     * @param mixed $member
+     * @param string|null $key
+     * @return static
+     */
     public function addMember(mixed $member, ?string $key = null): static
     {
         $key = $key ?? (is_object($member) && method_exists($member, 'protoId') ? $member->protoId() : uniqid('member_', true));
@@ -44,11 +74,23 @@ trait Collective
         );
     }
 
+    /**
+     * Return the snapshotted collective members.
+     *
+     * @return array<int|string, mixed>
+     */
     public function members(): array
     {
         return Arr::toArray($this->prototypeGet('collective_members', []));
     }
 
+    /**
+     * Get or assign one named collective rule.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return mixed
+     */
     public function collectiveRule(string $name, mixed $value = null): mixed
     {
         $rules = Arr::toArray($this->prototypeGet('collective_rules', []));
@@ -62,11 +104,23 @@ trait Collective
         return $this->prototypeSet('collective_rules', $rules, 'prototypes.collective.rule_changed');
     }
 
+    /**
+     * Return all collective rules.
+     *
+     * @return array<string, mixed>
+     */
     public function collectiveRules(): array
     {
         return Arr::toArray($this->prototypeGet('collective_rules', []));
     }
 
+    /**
+     * Get the entire shared state bag, one state value, or assign one value.
+     *
+     * @param string|null $name
+     * @param mixed $value
+     * @return mixed
+     */
     public function collectiveState(?string $name = null, mixed $value = null): mixed
     {
         $state = Arr::toArray($this->prototypeGet('collective_state', []));
@@ -84,6 +138,12 @@ trait Collective
         return $this->prototypeSet('collective_state', $state, 'prototypes.collective.state_changed');
     }
 
+    /**
+     * Get or assign the shared destiny/intent descriptor for the collective.
+     *
+     * @param mixed $destiny
+     * @return mixed
+     */
     public function sharedDestiny(mixed $destiny = null): mixed
     {
         if (Val::isNull($destiny)) {

--- a/src/Prototypes/Contracts/Causal.php
+++ b/src/Prototypes/Contracts/Causal.php
@@ -2,17 +2,59 @@
 
 namespace BlueFission\Prototypes\Contracts;
 
+/**
+ * Causal
+ *
+ * Marker interface for prototype carriers that store candidate causes and
+ * effects and can surface filtered inference results.
+ */
 interface Causal
 {
+    /**
+     * Add a causal candidate record or resolver.
+     *
+     * @param mixed $cause
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function addCause(mixed $cause, array $meta = []): static;
 
+    /**
+     * Add an effect record or resolver.
+     *
+     * @param mixed $effect
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function addEffect(mixed $effect, array $meta = []): static;
 
+    /**
+     * Return stored cause candidates.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function causes(): array;
 
+    /**
+     * Return stored effect candidates.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function effects(): array;
 
+    /**
+     * Filter and rank cause candidates against the provided context.
+     *
+     * @param array<string, mixed> $context
+     * @return array<int, array<string, mixed>>
+     */
     public function inferCauses(array $context = []): array;
 
+    /**
+     * Filter and rank effect candidates against the provided context.
+     *
+     * @param array<string, mixed> $context
+     * @return array<int, array<string, mixed>>
+     */
     public function inferEffects(array $context = []): array;
 }

--- a/src/Prototypes/Contracts/Causal.php
+++ b/src/Prototypes/Contracts/Causal.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace BlueFission\Prototypes\Contracts;
+
+interface Causal
+{
+    public function addCause(mixed $cause, array $meta = []): static;
+
+    public function addEffect(mixed $effect, array $meta = []): static;
+
+    public function causes(): array;
+
+    public function effects(): array;
+
+    public function inferCauses(array $context = []): array;
+
+    public function inferEffects(array $context = []): array;
+}

--- a/src/Prototypes/Contracts/CollectiveAware.php
+++ b/src/Prototypes/Contracts/CollectiveAware.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BlueFission\Prototypes\Contracts;
+
+interface CollectiveAware
+{
+    public function joinCollective(mixed $collective, array $meta = []): static;
+
+    public function leaveCollective(mixed $collective): static;
+
+    public function collectives(): array;
+
+    public function inCollective(string $name): bool;
+}

--- a/src/Prototypes/Contracts/CollectiveAware.php
+++ b/src/Prototypes/Contracts/CollectiveAware.php
@@ -2,13 +2,43 @@
 
 namespace BlueFission\Prototypes\Contracts;
 
+/**
+ * CollectiveAware
+ *
+ * Marker interface for prototype carriers that can join or leave shared-fate
+ * groupings such as flocks, fleets, mobs, or clouds.
+ */
 interface CollectiveAware
 {
+    /**
+     * Join a collective membership record.
+     *
+     * @param mixed $collective
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function joinCollective(mixed $collective, array $meta = []): static;
 
+    /**
+     * Remove a collective membership record.
+     *
+     * @param mixed $collective
+     * @return static
+     */
     public function leaveCollective(mixed $collective): static;
 
+    /**
+     * Return all collective memberships.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function collectives(): array;
 
+    /**
+     * Determine whether the carrier belongs to a named collective.
+     *
+     * @param string $name
+     * @return bool
+     */
     public function inCollective(string $name): bool;
 }

--- a/src/Prototypes/Contracts/Conditional.php
+++ b/src/Prototypes/Contracts/Conditional.php
@@ -2,15 +2,51 @@
 
 namespace BlueFission\Prototypes\Contracts;
 
+/**
+ * Conditional
+ *
+ * Marker interface for prototype carriers that expose normalized condition
+ * records and can evaluate them against runtime context.
+ */
 interface Conditional
 {
+    /**
+     * Add a normalized condition record or resolver.
+     *
+     * @param mixed $condition
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function addCondition(mixed $condition, array $meta = []): static;
 
+    /**
+     * Return all normalized condition records.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function conditions(): array;
 
+    /**
+     * Determine whether a named condition is registered.
+     *
+     * @param string $name
+     * @return bool
+     */
     public function hasCondition(string $name): bool;
 
+    /**
+     * Evaluate all registered conditions against the provided context.
+     *
+     * @param array<string, mixed> $context
+     * @return bool
+     */
     public function conditionsMet(array $context = []): bool;
 
+    /**
+     * Return any condition records that are not currently satisfied.
+     *
+     * @param array<string, mixed> $context
+     * @return array<int, array<string, mixed>>
+     */
     public function unmetConditions(array $context = []): array;
 }

--- a/src/Prototypes/Contracts/Conditional.php
+++ b/src/Prototypes/Contracts/Conditional.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BlueFission\Prototypes\Contracts;
+
+interface Conditional
+{
+    public function addCondition(mixed $condition, array $meta = []): static;
+
+    public function conditions(): array;
+
+    public function hasCondition(string $name): bool;
+
+    public function conditionsMet(array $context = []): bool;
+
+    public function unmetConditions(array $context = []): array;
+}

--- a/src/Prototypes/Contracts/DomainAware.php
+++ b/src/Prototypes/Contracts/DomainAware.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BlueFission\Prototypes\Contracts;
+
+interface DomainAware
+{
+    public function domain(mixed $domain = null): mixed;
+}

--- a/src/Prototypes/Contracts/DomainAware.php
+++ b/src/Prototypes/Contracts/DomainAware.php
@@ -2,7 +2,19 @@
 
 namespace BlueFission\Prototypes\Contracts;
 
+/**
+ * DomainAware
+ *
+ * Marker interface for prototype carriers that can be attached to a domain or
+ * shared world context.
+ */
 interface DomainAware
 {
+    /**
+     * Get or set the domain reference or domain snapshot.
+     *
+     * @param mixed $domain
+     * @return mixed
+     */
     public function domain(mixed $domain = null): mixed;
 }

--- a/src/Prototypes/Domain.php
+++ b/src/Prototypes/Domain.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Arr;
+use BlueFission\Collections\Group;
+use BlueFission\Val;
+
+trait Domain
+{
+    protected ?Group $_domainMembers = null;
+    protected ?Group $_domainSubdomains = null;
+    protected ?Group $_domainCollectives = null;
+
+    protected function domainMembersRegistry(): Group
+    {
+        if (!$this->_domainMembers instanceof Group) {
+            $this->_domainMembers = new Group();
+        }
+
+        return $this->_domainMembers;
+    }
+
+    protected function domainSubdomainsRegistry(): Group
+    {
+        if (!$this->_domainSubdomains instanceof Group) {
+            $this->_domainSubdomains = new Group();
+        }
+
+        return $this->_domainSubdomains;
+    }
+
+    protected function domainCollectivesRegistry(): Group
+    {
+        if (!$this->_domainCollectives instanceof Group) {
+            $this->_domainCollectives = new Group();
+        }
+
+        return $this->_domainCollectives;
+    }
+
+    public function domainName(?string $name = null): mixed
+    {
+        $this->prototypeBoot('domain');
+        $this->kind('domain');
+
+        if (Val::isNull($name)) {
+            return (string) $this->prototypeGet('name', '');
+        }
+
+        return $this->name($name);
+    }
+
+    public function addMember(mixed $member, ?string $key = null): static
+    {
+        $key = $key ?? (is_object($member) && method_exists($member, 'protoId') ? $member->protoId() : uniqid('member_', true));
+        $this->domainMembersRegistry()->add($member, $key);
+
+        return $this->prototypeSet(
+            'domain_members',
+            $this->domainMembersRegistry()->map(fn ($item) => $this->prototypeSnapshotValue($item))->toArray(),
+            'prototypes.domain.member_added'
+        );
+    }
+
+    public function members(): array
+    {
+        return Arr::toArray($this->prototypeGet('domain_members', []));
+    }
+
+    public function addSubdomain(mixed $domain, ?string $key = null): static
+    {
+        $key = $key ?? (is_object($domain) && method_exists($domain, 'protoId') ? $domain->protoId() : uniqid('subdomain_', true));
+        $this->domainSubdomainsRegistry()->add($domain, $key);
+
+        return $this->prototypeSet(
+            'domain_subdomains',
+            $this->domainSubdomainsRegistry()->map(fn ($item) => $this->prototypeSnapshotValue($item))->toArray(),
+            'prototypes.domain.subdomain_added'
+        );
+    }
+
+    public function subdomains(): array
+    {
+        return Arr::toArray($this->prototypeGet('domain_subdomains', []));
+    }
+
+    public function addCollective(mixed $collective, ?string $key = null): static
+    {
+        $key = $key ?? (is_object($collective) && method_exists($collective, 'protoId') ? $collective->protoId() : uniqid('collective_', true));
+        $this->domainCollectivesRegistry()->add($collective, $key);
+
+        return $this->prototypeSet(
+            'domain_collectives',
+            $this->domainCollectivesRegistry()->map(fn ($item) => $this->prototypeSnapshotValue($item))->toArray(),
+            'prototypes.domain.collective_added'
+        );
+    }
+
+    public function collectives(): array
+    {
+        return Arr::toArray($this->prototypeGet('domain_collectives', []));
+    }
+
+    public function rule(string $name, mixed $value = null): mixed
+    {
+        $rules = Arr::toArray($this->prototypeGet('domain_rules', []));
+
+        if (func_num_args() === 1) {
+            return $rules[$name] ?? null;
+        }
+
+        $rules[$name] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet('domain_rules', $rules, 'prototypes.domain.rule_changed');
+    }
+
+    public function rules(): array
+    {
+        return Arr::toArray($this->prototypeGet('domain_rules', []));
+    }
+
+    public function defaultValue(string $name, mixed $value = null): mixed
+    {
+        $defaults = Arr::toArray($this->prototypeGet('domain_defaults', []));
+
+        if (func_num_args() === 1) {
+            return $defaults[$name] ?? null;
+        }
+
+        $defaults[$name] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet('domain_defaults', $defaults, 'prototypes.domain.default_changed');
+    }
+
+    public function defaults(): array
+    {
+        return Arr::toArray($this->prototypeGet('domain_defaults', []));
+    }
+
+    public function domainState(?string $name = null, mixed $value = null): mixed
+    {
+        $state = Arr::toArray($this->prototypeGet('domain_state', []));
+
+        if (Val::isNull($name)) {
+            return $state;
+        }
+
+        if (func_num_args() === 1) {
+            return $state[$name] ?? null;
+        }
+
+        $state[$name] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet('domain_state', $state, 'prototypes.domain.state_changed');
+    }
+
+    public function context(): array
+    {
+        return [
+            'rules' => $this->rules(),
+            'defaults' => $this->defaults(),
+            'state' => $this->domainState(),
+            'members' => $this->members(),
+            'subdomains' => $this->subdomains(),
+            'collectives' => $this->collectives(),
+        ];
+    }
+}

--- a/src/Prototypes/Domain.php
+++ b/src/Prototypes/Domain.php
@@ -6,12 +6,41 @@ use BlueFission\Arr;
 use BlueFission\Collections\Group;
 use BlueFission\Val;
 
+/**
+ * Domain
+ *
+ * Shared world or context model for members, subdomains, collectives, rules,
+ * defaults, and state. This is meant to be a universal substrate for app,
+ * workflow, simulation, and world-model contexts.
+ */
 trait Domain
 {
+    /**
+     * Runtime registry of direct domain members.
+     *
+     * @var Group|null
+     */
     protected ?Group $_domainMembers = null;
+
+    /**
+     * Runtime registry of nested subdomains.
+     *
+     * @var Group|null
+     */
     protected ?Group $_domainSubdomains = null;
+
+    /**
+     * Runtime registry of collectives associated with the domain.
+     *
+     * @var Group|null
+     */
     protected ?Group $_domainCollectives = null;
 
+    /**
+     * Lazily build the member registry.
+     *
+     * @return Group
+     */
     protected function domainMembersRegistry(): Group
     {
         if (!$this->_domainMembers instanceof Group) {
@@ -21,6 +50,11 @@ trait Domain
         return $this->_domainMembers;
     }
 
+    /**
+     * Lazily build the subdomain registry.
+     *
+     * @return Group
+     */
     protected function domainSubdomainsRegistry(): Group
     {
         if (!$this->_domainSubdomains instanceof Group) {
@@ -30,6 +64,11 @@ trait Domain
         return $this->_domainSubdomains;
     }
 
+    /**
+     * Lazily build the collective registry.
+     *
+     * @return Group
+     */
     protected function domainCollectivesRegistry(): Group
     {
         if (!$this->_domainCollectives instanceof Group) {
@@ -39,6 +78,12 @@ trait Domain
         return $this->_domainCollectives;
     }
 
+    /**
+     * Get or assign the human-readable domain name.
+     *
+     * @param string|null $name
+     * @return mixed
+     */
     public function domainName(?string $name = null): mixed
     {
         $this->prototypeBoot('domain');
@@ -51,6 +96,13 @@ trait Domain
         return $this->name($name);
     }
 
+    /**
+     * Add one member to the domain registry and snapshot store.
+     *
+     * @param mixed $member
+     * @param string|null $key
+     * @return static
+     */
     public function addMember(mixed $member, ?string $key = null): static
     {
         $key = $key ?? (is_object($member) && method_exists($member, 'protoId') ? $member->protoId() : uniqid('member_', true));
@@ -63,11 +115,23 @@ trait Domain
         );
     }
 
+    /**
+     * Return all snapshotted domain members.
+     *
+     * @return array<int|string, mixed>
+     */
     public function members(): array
     {
         return Arr::toArray($this->prototypeGet('domain_members', []));
     }
 
+    /**
+     * Add one nested subdomain to the registry and snapshot store.
+     *
+     * @param mixed $domain
+     * @param string|null $key
+     * @return static
+     */
     public function addSubdomain(mixed $domain, ?string $key = null): static
     {
         $key = $key ?? (is_object($domain) && method_exists($domain, 'protoId') ? $domain->protoId() : uniqid('subdomain_', true));
@@ -80,11 +144,23 @@ trait Domain
         );
     }
 
+    /**
+     * Return all snapshotted subdomains.
+     *
+     * @return array<int|string, mixed>
+     */
     public function subdomains(): array
     {
         return Arr::toArray($this->prototypeGet('domain_subdomains', []));
     }
 
+    /**
+     * Add one collective to the domain registry and snapshot store.
+     *
+     * @param mixed $collective
+     * @param string|null $key
+     * @return static
+     */
     public function addCollective(mixed $collective, ?string $key = null): static
     {
         $key = $key ?? (is_object($collective) && method_exists($collective, 'protoId') ? $collective->protoId() : uniqid('collective_', true));
@@ -97,11 +173,23 @@ trait Domain
         );
     }
 
+    /**
+     * Return all snapshotted collectives in the domain.
+     *
+     * @return array<int|string, mixed>
+     */
     public function collectives(): array
     {
         return Arr::toArray($this->prototypeGet('domain_collectives', []));
     }
 
+    /**
+     * Get or assign one named domain rule.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return mixed
+     */
     public function rule(string $name, mixed $value = null): mixed
     {
         $rules = Arr::toArray($this->prototypeGet('domain_rules', []));
@@ -115,11 +203,23 @@ trait Domain
         return $this->prototypeSet('domain_rules', $rules, 'prototypes.domain.rule_changed');
     }
 
+    /**
+     * Return all named domain rules.
+     *
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return Arr::toArray($this->prototypeGet('domain_rules', []));
     }
 
+    /**
+     * Get or assign one named default value shared by the domain.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return mixed
+     */
     public function defaultValue(string $name, mixed $value = null): mixed
     {
         $defaults = Arr::toArray($this->prototypeGet('domain_defaults', []));
@@ -133,11 +233,23 @@ trait Domain
         return $this->prototypeSet('domain_defaults', $defaults, 'prototypes.domain.default_changed');
     }
 
+    /**
+     * Return all named domain defaults.
+     *
+     * @return array<string, mixed>
+     */
     public function defaults(): array
     {
         return Arr::toArray($this->prototypeGet('domain_defaults', []));
     }
 
+    /**
+     * Get the full domain state bag, one value, or assign one value.
+     *
+     * @param string|null $name
+     * @param mixed $value
+     * @return mixed
+     */
     public function domainState(?string $name = null, mixed $value = null): mixed
     {
         $state = Arr::toArray($this->prototypeGet('domain_state', []));
@@ -155,6 +267,11 @@ trait Domain
         return $this->prototypeSet('domain_state', $state, 'prototypes.domain.state_changed');
     }
 
+    /**
+     * Return a normalized domain context payload for downstream consumers.
+     *
+     * @return array<string, mixed>
+     */
     public function context(): array
     {
         return [

--- a/src/Prototypes/Entity.php
+++ b/src/Prototypes/Entity.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+trait Entity
+{
+    public function reactive(?bool $reactive = null): mixed
+    {
+        $this->prototypeBoot('entity');
+        $this->kind('entity');
+
+        if ($reactive === null) {
+            return (bool) $this->prototypeGet('reactive', true);
+        }
+
+        return $this->prototypeSet('reactive', $reactive, 'prototypes.entity.reactivity_set');
+    }
+
+    public function react(mixed $stimulus, array $meta = []): static
+    {
+        $this->record('reaction', [
+            'stimulus' => $this->prototypeSnapshotValue($stimulus),
+            'meta' => $this->prototypeSnapshotValue($meta),
+        ]);
+
+        $this->prototypeSignal('prototypes.entity.reacted', [
+            'stimulus' => $this->prototypeSnapshotValue($stimulus),
+            'meta' => $this->prototypeSnapshotValue($meta),
+            'object' => $this,
+        ]);
+
+        return $this;
+    }
+}

--- a/src/Prototypes/Entity.php
+++ b/src/Prototypes/Entity.php
@@ -2,8 +2,20 @@
 
 namespace BlueFission\Prototypes;
 
+/**
+ * Entity
+ *
+ * Reactionary artifact that can respond to events, stimuli, conditions, and
+ * changes in domain context without implying independent strategic control.
+ */
 trait Entity
 {
+    /**
+     * Get or assign whether the entity is considered reactive.
+     *
+     * @param bool|null $reactive
+     * @return mixed
+     */
     public function reactive(?bool $reactive = null): mixed
     {
         $this->prototypeBoot('entity');
@@ -16,6 +28,13 @@ trait Entity
         return $this->prototypeSet('reactive', $reactive, 'prototypes.entity.reactivity_set');
     }
 
+    /**
+     * Record a reaction event for the entity and emit a prototype signal.
+     *
+     * @param mixed $stimulus
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function react(mixed $stimulus, array $meta = []): static
     {
         $this->record('reaction', [

--- a/src/Prototypes/HasCollectives.php
+++ b/src/Prototypes/HasCollectives.php
@@ -6,8 +6,21 @@ use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Prototypes\Contracts\CollectiveAware;
 
+/**
+ * HasCollectives
+ *
+ * Tracks membership in one or more collectives while keeping membership data
+ * snapshot-friendly for storage, tracing, and downstream world modeling.
+ */
 trait HasCollectives
 {
+    /**
+     * Join a collective and optionally attach membership metadata.
+     *
+     * @param mixed $collective
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function joinCollective(mixed $collective, array $meta = []): static
     {
         $memberships = Arr::toArray($this->prototypeGet('collective_memberships', []));
@@ -19,6 +32,12 @@ trait HasCollectives
         return $this->prototypeSet('collective_memberships', $memberships, 'prototypes.collectives.joined');
     }
 
+    /**
+     * Remove one collective membership by matching the collective snapshot.
+     *
+     * @param mixed $collective
+     * @return static
+     */
     public function leaveCollective(mixed $collective): static
     {
         $needle = $this->prototypeSnapshotValue($collective);
@@ -34,11 +53,22 @@ trait HasCollectives
         return $this->prototypeSet('collective_memberships', $memberships, 'prototypes.collectives.left');
     }
 
+    /**
+     * Return all collective membership records.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function collectives(): array
     {
         return Arr::toArray($this->prototypeGet('collective_memberships', []));
     }
 
+    /**
+     * Determine whether the carrier belongs to a named collective.
+     *
+     * @param string $name
+     * @return bool
+     */
     public function inCollective(string $name): bool
     {
         $name = Str::trim($name);

--- a/src/Prototypes/HasCollectives.php
+++ b/src/Prototypes/HasCollectives.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Prototypes\Contracts\CollectiveAware;
+
+trait HasCollectives
+{
+    public function joinCollective(mixed $collective, array $meta = []): static
+    {
+        $memberships = Arr::toArray($this->prototypeGet('collective_memberships', []));
+        $normalized = $this->prototypeMergeArrays([
+            'collective' => $this->prototypeSnapshotValue($collective),
+        ], $meta);
+        $memberships[] = $normalized;
+
+        return $this->prototypeSet('collective_memberships', $memberships, 'prototypes.collectives.joined');
+    }
+
+    public function leaveCollective(mixed $collective): static
+    {
+        $needle = $this->prototypeSnapshotValue($collective);
+        $memberships = [];
+
+        foreach (Arr::toArray($this->prototypeGet('collective_memberships', [])) as $membership) {
+            if (($membership['collective'] ?? null) === $needle) {
+                continue;
+            }
+            $memberships[] = $membership;
+        }
+
+        return $this->prototypeSet('collective_memberships', $memberships, 'prototypes.collectives.left');
+    }
+
+    public function collectives(): array
+    {
+        return Arr::toArray($this->prototypeGet('collective_memberships', []));
+    }
+
+    public function inCollective(string $name): bool
+    {
+        $name = Str::trim($name);
+
+        foreach ($this->collectives() as $membership) {
+            $collective = $membership['collective'] ?? null;
+
+            if (is_array($collective)) {
+                if (($collective['id'] ?? null) === $name || ($collective['name'] ?? null) === $name) {
+                    return true;
+                }
+            } elseif ((string) $collective === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Prototypes/HasConditions.php
+++ b/src/Prototypes/HasConditions.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\DevElation as Dev;
+use BlueFission\Prototypes\Contracts\Conditional;
+
+trait HasConditions
+{
+    public function addCondition(mixed $condition, array $meta = []): static
+    {
+        $conditions = Arr::toArray($this->prototypeGet('conditions', []));
+        $conditions[] = $this->normalizeConditionRecord($condition, $meta);
+
+        return $this->prototypeSet('conditions', $conditions, 'prototypes.conditions.added');
+    }
+
+    public function conditions(): array
+    {
+        return Arr::toArray($this->prototypeGet('conditions', []));
+    }
+
+    public function hasCondition(string $name): bool
+    {
+        $name = Str::trim($name);
+        foreach ($this->conditions() as $condition) {
+            if (($condition['name'] ?? '') === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function conditionsMet(array $context = []): bool
+    {
+        foreach ($this->conditions() as $condition) {
+            if (!$this->prototypeEvaluateConditionRecord($condition, $context)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function unmetConditions(array $context = []): array
+    {
+        $unmet = [];
+
+        foreach ($this->conditions() as $condition) {
+            if (!$this->prototypeEvaluateConditionRecord($condition, $context)) {
+                $unmet[] = $condition;
+            }
+        }
+
+        return $unmet;
+    }
+
+    protected function normalizeConditionRecord(mixed $condition, array $meta = []): array
+    {
+        if (is_callable($condition)) {
+            return $this->prototypeMergeArrays([
+                'name' => 'condition_' . uniqid(),
+                'resolver' => $condition,
+                'operator' => 'resolver',
+                'confidence' => 1.0,
+            ], $meta);
+        }
+
+        if (is_array($condition)) {
+            return $this->prototypeMergeArrays([
+                'name' => (string) ($condition['name'] ?? 'condition_' . uniqid()),
+                'path' => $condition['path'] ?? $condition['property'] ?? null,
+                'expected' => $condition['expected'] ?? ($condition['value'] ?? true),
+                'operator' => $condition['operator'] ?? 'requires',
+                'confidence' => (float) ($condition['confidence'] ?? 1.0),
+            ], $condition, $meta);
+        }
+
+        return $this->prototypeMergeArrays([
+            'name' => (string) $condition,
+            'path' => (string) $condition,
+            'expected' => true,
+            'operator' => 'requires',
+            'confidence' => 1.0,
+        ], $meta);
+    }
+
+    protected function prototypeEvaluateConditionRecord(array $condition, array $context = []): bool
+    {
+        $condition = Dev::apply('prototypes.conditions.evaluate.in', $condition);
+
+        if (isset($condition['resolver']) && is_callable($condition['resolver'])) {
+            return (bool) call_user_func($condition['resolver'], $context, $this, $condition);
+        }
+
+        $path = $condition['path'] ?? null;
+        $expected = $condition['expected'] ?? true;
+        $operator = (string) ($condition['operator'] ?? 'requires');
+
+        if ($path && is_string($path)) {
+            $actual = $this->prototypeContextValue($context, $path, null);
+
+            if ($actual === null && method_exists($this, 'property')) {
+                $actual = $this->property($path);
+            }
+
+            if ($actual === null) {
+                $state = $this->prototypeGet('state', []);
+                if (is_array($state) && Arr::hasKey($state, $path)) {
+                    $actual = $state[$path];
+                }
+            }
+
+            return $this->prototypeCompare($actual, $expected, $operator);
+        }
+
+        return $this->prototypeCompare(true, $expected, $operator);
+    }
+}

--- a/src/Prototypes/HasConditions.php
+++ b/src/Prototypes/HasConditions.php
@@ -7,8 +7,22 @@ use BlueFission\Str;
 use BlueFission\DevElation as Dev;
 use BlueFission\Prototypes\Contracts\Conditional;
 
+/**
+ * HasConditions
+ *
+ * Provides normalized condition registration and lightweight evaluation
+ * against runtime context, state, and object properties. This is intentionally
+ * generic so downstream systems can layer richer reasoning on top.
+ */
 trait HasConditions
 {
+    /**
+     * Add one condition record, shorthand string, or resolver callback.
+     *
+     * @param mixed $condition
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function addCondition(mixed $condition, array $meta = []): static
     {
         $conditions = Arr::toArray($this->prototypeGet('conditions', []));
@@ -17,11 +31,22 @@ trait HasConditions
         return $this->prototypeSet('conditions', $conditions, 'prototypes.conditions.added');
     }
 
+    /**
+     * Return all normalized condition records.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function conditions(): array
     {
         return Arr::toArray($this->prototypeGet('conditions', []));
     }
 
+    /**
+     * Determine whether a named condition is registered.
+     *
+     * @param string $name
+     * @return bool
+     */
     public function hasCondition(string $name): bool
     {
         $name = Str::trim($name);
@@ -34,6 +59,12 @@ trait HasConditions
         return false;
     }
 
+    /**
+     * Determine whether every registered condition is satisfied.
+     *
+     * @param array<string, mixed> $context
+     * @return bool
+     */
     public function conditionsMet(array $context = []): bool
     {
         foreach ($this->conditions() as $condition) {
@@ -45,6 +76,12 @@ trait HasConditions
         return true;
     }
 
+    /**
+     * Return only the conditions that are not satisfied by the current context.
+     *
+     * @param array<string, mixed> $context
+     * @return array<int, array<string, mixed>>
+     */
     public function unmetConditions(array $context = []): array
     {
         $unmet = [];
@@ -58,6 +95,13 @@ trait HasConditions
         return $unmet;
     }
 
+    /**
+     * Normalize shorthand conditions into a common record structure.
+     *
+     * @param mixed $condition
+     * @param array<string, mixed> $meta
+     * @return array<string, mixed>
+     */
     protected function normalizeConditionRecord(mixed $condition, array $meta = []): array
     {
         if (is_callable($condition)) {
@@ -88,6 +132,13 @@ trait HasConditions
         ], $meta);
     }
 
+    /**
+     * Evaluate one normalized condition record against runtime context.
+     *
+     * @param array<string, mixed> $condition
+     * @param array<string, mixed> $context
+     * @return bool
+     */
     protected function prototypeEvaluateConditionRecord(array $condition, array $context = []): bool
     {
         $condition = Dev::apply('prototypes.conditions.evaluate.in', $condition);

--- a/src/Prototypes/IsCausal.php
+++ b/src/Prototypes/IsCausal.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Arr;
+use BlueFission\DevElation as Dev;
+use BlueFission\Prototypes\Contracts\Causal;
+
+trait IsCausal
+{
+    public function addCause(mixed $cause, array $meta = []): static
+    {
+        $causes = Arr::toArray($this->prototypeGet('causes', []));
+        $causes[] = $this->normalizeCausalRecord($cause, $meta);
+
+        return $this->prototypeSet('causes', $causes, 'prototypes.causal.cause_added');
+    }
+
+    public function addEffect(mixed $effect, array $meta = []): static
+    {
+        $effects = Arr::toArray($this->prototypeGet('effects', []));
+        $effects[] = $this->normalizeCausalRecord($effect, $meta);
+
+        return $this->prototypeSet('effects', $effects, 'prototypes.causal.effect_added');
+    }
+
+    public function because(mixed $cause, mixed $effect = null, array $meta = []): static
+    {
+        $this->addCause($cause, $meta);
+
+        if ($effect !== null) {
+            $this->addEffect($effect, $meta);
+        }
+
+        return $this;
+    }
+
+    public function causes(): array
+    {
+        return Arr::toArray($this->prototypeGet('causes', []));
+    }
+
+    public function effects(): array
+    {
+        return Arr::toArray($this->prototypeGet('effects', []));
+    }
+
+    public function inferCauses(array $context = []): array
+    {
+        return $this->prototypeInferCausalRecords($this->causes(), $context, 'prototypes.causal.causes_inferred');
+    }
+
+    public function inferEffects(array $context = []): array
+    {
+        return $this->prototypeInferCausalRecords($this->effects(), $context, 'prototypes.causal.effects_inferred');
+    }
+
+    protected function normalizeCausalRecord(mixed $record, array $meta = []): array
+    {
+        if (is_callable($record)) {
+            return $this->prototypeMergeArrays([
+                'name' => 'causal_' . uniqid(),
+                'resolver' => $record,
+                'weight' => 1.0,
+                'confidence' => 1.0,
+                'conditions' => [],
+            ], $meta);
+        }
+
+        if (is_array($record)) {
+            return $this->prototypeMergeArrays([
+                'name' => (string) ($record['name'] ?? 'causal_' . uniqid()),
+                'weight' => (float) ($record['weight'] ?? 1.0),
+                'confidence' => (float) ($record['confidence'] ?? 1.0),
+                'conditions' => Arr::toArray($record['conditions'] ?? []),
+            ], $record, $meta);
+        }
+
+        return $this->prototypeMergeArrays([
+            'name' => (string) $record,
+            'weight' => 1.0,
+            'confidence' => 1.0,
+            'conditions' => [],
+        ], $meta);
+    }
+
+    protected function prototypeInferCausalRecords(array $records, array $context, string $hook): array
+    {
+        $records = Dev::apply('prototypes.causal.infer.in', $records);
+        $matches = [];
+
+        foreach ($records as $record) {
+            if (isset($record['resolver']) && is_callable($record['resolver'])) {
+                $result = call_user_func($record['resolver'], $context, $this, $record);
+                if (is_array($result)) {
+                    $matches[] = $this->prototypeMergeArrays($record, $result);
+                    continue;
+                }
+                if ($result) {
+                    $matches[] = $record;
+                }
+                continue;
+            }
+
+            $conditions = Arr::toArray($record['conditions'] ?? []);
+            $valid = true;
+
+            if (!empty($conditions) && method_exists($this, 'prototypeEvaluateConditionRecord')) {
+                foreach ($conditions as $condition) {
+                    if (!$this->prototypeEvaluateConditionRecord($condition, $context)) {
+                        $valid = false;
+                        break;
+                    }
+                }
+            }
+
+            if ($valid) {
+                $matches[] = $record;
+            }
+        }
+
+        $matches = $this->prototypeSortByWeight($matches);
+        $this->prototypeSignal($hook, ['context' => $context, 'matches' => $matches, 'object' => $this]);
+
+        return $matches;
+    }
+}

--- a/src/Prototypes/IsCausal.php
+++ b/src/Prototypes/IsCausal.php
@@ -6,8 +6,21 @@ use BlueFission\Arr;
 use BlueFission\DevElation as Dev;
 use BlueFission\Prototypes\Contracts\Causal;
 
+/**
+ * IsCausal
+ *
+ * Records candidate causes and effects and exposes deterministic filtering
+ * hooks so more advanced inference systems can consume the same metadata later.
+ */
 trait IsCausal
 {
+    /**
+     * Add one possible cause record.
+     *
+     * @param mixed $cause
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function addCause(mixed $cause, array $meta = []): static
     {
         $causes = Arr::toArray($this->prototypeGet('causes', []));
@@ -16,6 +29,13 @@ trait IsCausal
         return $this->prototypeSet('causes', $causes, 'prototypes.causal.cause_added');
     }
 
+    /**
+     * Add one possible effect record.
+     *
+     * @param mixed $effect
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function addEffect(mixed $effect, array $meta = []): static
     {
         $effects = Arr::toArray($this->prototypeGet('effects', []));
@@ -24,6 +44,14 @@ trait IsCausal
         return $this->prototypeSet('effects', $effects, 'prototypes.causal.effect_added');
     }
 
+    /**
+     * Link one cause and optional effect in a single call.
+     *
+     * @param mixed $cause
+     * @param mixed $effect
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function because(mixed $cause, mixed $effect = null, array $meta = []): static
     {
         $this->addCause($cause, $meta);
@@ -35,26 +63,55 @@ trait IsCausal
         return $this;
     }
 
+    /**
+     * Return all registered cause records.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function causes(): array
     {
         return Arr::toArray($this->prototypeGet('causes', []));
     }
 
+    /**
+     * Return all registered effect records.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function effects(): array
     {
         return Arr::toArray($this->prototypeGet('effects', []));
     }
 
+    /**
+     * Filter and rank candidate causes against the supplied context.
+     *
+     * @param array<string, mixed> $context
+     * @return array<int, array<string, mixed>>
+     */
     public function inferCauses(array $context = []): array
     {
         return $this->prototypeInferCausalRecords($this->causes(), $context, 'prototypes.causal.causes_inferred');
     }
 
+    /**
+     * Filter and rank candidate effects against the supplied context.
+     *
+     * @param array<string, mixed> $context
+     * @return array<int, array<string, mixed>>
+     */
     public function inferEffects(array $context = []): array
     {
         return $this->prototypeInferCausalRecords($this->effects(), $context, 'prototypes.causal.effects_inferred');
     }
 
+    /**
+     * Normalize shorthand causal values or resolvers into a standard record.
+     *
+     * @param mixed $record
+     * @param array<string, mixed> $meta
+     * @return array<string, mixed>
+     */
     protected function normalizeCausalRecord(mixed $record, array $meta = []): array
     {
         if (is_callable($record)) {
@@ -84,6 +141,14 @@ trait IsCausal
         ], $meta);
     }
 
+    /**
+     * Apply condition-aware filtering and weight sorting to causal candidates.
+     *
+     * @param array<int, array<string, mixed>> $records
+     * @param array<string, mixed> $context
+     * @param string $hook
+     * @return array<int, array<string, mixed>>
+     */
     protected function prototypeInferCausalRecords(array $records, array $context, string $hook): array
     {
         $records = Dev::apply('prototypes.causal.infer.in', $records);

--- a/src/Prototypes/Position.php
+++ b/src/Prototypes/Position.php
@@ -5,8 +5,22 @@ namespace BlueFission\Prototypes;
 use BlueFission\Arr;
 use BlueFission\Val;
 
+/**
+ * Position
+ *
+ * Multi-dimensional locator substrate that can describe physical, conceptual,
+ * or workflow-relative placement without hardcoding a specific coordinate
+ * system.
+ */
 trait Position
 {
+    /**
+     * Define metadata for one named position dimension.
+     *
+     * @param string $name
+     * @param array<string, mixed> $descriptor
+     * @return static
+     */
     public function defineDimension(string $name, array $descriptor = []): static
     {
         $dimensions = Arr::toArray($this->prototypeGet('dimensions', []));
@@ -23,11 +37,23 @@ trait Position
         return $this->prototypeSet('dimensions', $dimensions, 'prototypes.position.dimension_defined');
     }
 
+    /**
+     * Return all defined position dimensions.
+     *
+     * @return array<string, array<string, mixed>>
+     */
     public function dimensions(): array
     {
         return Arr::toArray($this->prototypeGet('dimensions', []));
     }
 
+    /**
+     * Get or assign one coordinate value.
+     *
+     * @param string $dimension
+     * @param mixed $value
+     * @return mixed
+     */
     public function coordinate(string $dimension, mixed $value = null): mixed
     {
         $coordinates = Arr::toArray($this->prototypeGet('coordinates', []));
@@ -41,11 +67,22 @@ trait Position
         return $this->prototypeSet('coordinates', $coordinates, 'prototypes.position.coordinate_changed');
     }
 
+    /**
+     * Return the complete coordinate bag.
+     *
+     * @return array<string, mixed>
+     */
     public function coordinates(): array
     {
         return Arr::toArray($this->prototypeGet('coordinates', []));
     }
 
+    /**
+     * Get or assign the frame of reference used by the position.
+     *
+     * @param mixed $frame
+     * @return mixed
+     */
     public function frame(mixed $frame = null): mixed
     {
         if (Val::isNull($frame)) {
@@ -55,6 +92,12 @@ trait Position
         return $this->prototypeSet('frame', $this->prototypeSnapshotValue($frame), 'prototypes.position.frame_set');
     }
 
+    /**
+     * Get or assign an anchor value for relative positioning.
+     *
+     * @param mixed $anchor
+     * @return mixed
+     */
     public function anchor(mixed $anchor = null): mixed
     {
         if (Val::isNull($anchor)) {
@@ -64,6 +107,12 @@ trait Position
         return $this->prototypeSet('anchor', $this->prototypeSnapshotValue($anchor), 'prototypes.position.anchor_set');
     }
 
+    /**
+     * Translate current coordinates by a delta payload.
+     *
+     * @param array<string, mixed> $delta
+     * @return static
+     */
     public function translate(array $delta): static
     {
         $coordinates = $this->coordinates();
@@ -83,6 +132,13 @@ trait Position
         return $this;
     }
 
+    /**
+     * Calculate numeric distance or per-dimension deltas to another position.
+     *
+     * @param mixed $other
+     * @param array<int, string>|null $dimensions
+     * @return float|array<string, mixed>|null
+     */
     public function distanceTo(mixed $other, ?array $dimensions = null): float|array|null
     {
         $otherCoordinates = [];

--- a/src/Prototypes/Position.php
+++ b/src/Prototypes/Position.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Arr;
+use BlueFission\Val;
+
+trait Position
+{
+    public function defineDimension(string $name, array $descriptor = []): static
+    {
+        $dimensions = Arr::toArray($this->prototypeGet('dimensions', []));
+        $dimensions[$name] = $this->prototypeMergeArrays([
+            'label' => $name,
+            'kind' => 'relative',
+            'absolute' => false,
+            'unit' => null,
+            'default' => null,
+            'comparable' => true,
+            'directionality' => 'bidirectional',
+        ], $descriptor);
+
+        return $this->prototypeSet('dimensions', $dimensions, 'prototypes.position.dimension_defined');
+    }
+
+    public function dimensions(): array
+    {
+        return Arr::toArray($this->prototypeGet('dimensions', []));
+    }
+
+    public function coordinate(string $dimension, mixed $value = null): mixed
+    {
+        $coordinates = Arr::toArray($this->prototypeGet('coordinates', []));
+
+        if (func_num_args() === 1) {
+            return $coordinates[$dimension] ?? null;
+        }
+
+        $coordinates[$dimension] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet('coordinates', $coordinates, 'prototypes.position.coordinate_changed');
+    }
+
+    public function coordinates(): array
+    {
+        return Arr::toArray($this->prototypeGet('coordinates', []));
+    }
+
+    public function frame(mixed $frame = null): mixed
+    {
+        if (Val::isNull($frame)) {
+            return $this->prototypeGet('frame');
+        }
+
+        return $this->prototypeSet('frame', $this->prototypeSnapshotValue($frame), 'prototypes.position.frame_set');
+    }
+
+    public function anchor(mixed $anchor = null): mixed
+    {
+        if (Val::isNull($anchor)) {
+            return $this->prototypeGet('anchor');
+        }
+
+        return $this->prototypeSet('anchor', $this->prototypeSnapshotValue($anchor), 'prototypes.position.anchor_set');
+    }
+
+    public function translate(array $delta): static
+    {
+        $coordinates = $this->coordinates();
+
+        foreach ($delta as $dimension => $amount) {
+            $current = $coordinates[$dimension] ?? 0;
+            if (is_numeric($current) && is_numeric($amount)) {
+                $coordinates[$dimension] = $current + $amount;
+            } else {
+                $coordinates[$dimension] = $amount;
+            }
+        }
+
+        $this->prototypeSet('coordinates', $coordinates, 'prototypes.position.translated');
+        $this->position($coordinates);
+
+        return $this;
+    }
+
+    public function distanceTo(mixed $other, ?array $dimensions = null): float|array|null
+    {
+        $otherCoordinates = [];
+
+        if (is_object($other) && method_exists($other, 'coordinates')) {
+            $otherCoordinates = $other->coordinates();
+        } elseif (is_array($other)) {
+            $otherCoordinates = $other;
+        } else {
+            return null;
+        }
+
+        $dimensions = $dimensions ?? array_keys($this->prototypeMergeArrays($this->coordinates(), $otherCoordinates));
+        $squared = 0.0;
+        $deltas = [];
+        $numeric = true;
+
+        foreach ($dimensions as $dimension) {
+            $left = $this->coordinate($dimension);
+            $right = $otherCoordinates[$dimension] ?? null;
+
+            if (is_numeric($left) && is_numeric($right)) {
+                $diff = (float) $right - (float) $left;
+                $deltas[$dimension] = $diff;
+                $squared += ($diff * $diff);
+                continue;
+            }
+
+            $numeric = false;
+            $deltas[$dimension] = [
+                'from' => $left,
+                'to' => $right,
+            ];
+        }
+
+        return $numeric ? sqrt($squared) : $deltas;
+    }
+}

--- a/src/Prototypes/Proto.php
+++ b/src/Prototypes/Proto.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace BlueFission\Prototypes;
+
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
+use BlueFission\DevElation as Dev;
+use BlueFission\Prototypes\Support\PrototypeTools;
+
+trait Proto
+{
+    use PrototypeTools;
+
+    public function protoId(?string $id = null): mixed
+    {
+        $this->prototypeBoot('proto');
+
+        if (Val::isNull($id)) {
+            return (string) $this->prototypeGet('id', '');
+        }
+
+        $id = Str::trim($id);
+        return $this->prototypeSet('id', $id, 'prototypes.proto.id_set');
+    }
+
+    public function kind(?string $kind = null): mixed
+    {
+        $this->prototypeBoot('proto');
+
+        if (Val::isNull($kind)) {
+            return (string) $this->prototypeGet('kind', 'proto');
+        }
+
+        return $this->prototypeSet('kind', Str::trim($kind), 'prototypes.proto.kind_set');
+    }
+
+    public function name(?string $name = null): mixed
+    {
+        $this->prototypeBoot('proto');
+
+        if (Val::isNull($name)) {
+            return (string) $this->prototypeGet('name', '');
+        }
+
+        return $this->prototypeSet('name', Str::trim($name), 'prototypes.proto.name_set');
+    }
+
+    public function labels(?array $labels = null): mixed
+    {
+        $this->prototypeBoot('proto');
+
+        if (Val::isNull($labels)) {
+            return Arr::toArray($this->prototypeGet('labels', []));
+        }
+
+        return $this->prototypeSet('labels', Arr::toArray($labels), 'prototypes.proto.labels_set');
+    }
+
+    public function addLabel(string $label): static
+    {
+        $label = Str::trim($label);
+        if ($label === '') {
+            return $this;
+        }
+
+        return $this->prototypeAppend('labels', $label, true, 'prototypes.proto.label_added');
+    }
+
+    public function traits(?array $traits = null): mixed
+    {
+        $this->prototypeBoot('proto');
+
+        if (Val::isNull($traits)) {
+            return Arr::toArray($this->prototypeGet('traits', []));
+        }
+
+        return $this->prototypeSet('traits', Arr::toArray($traits), 'prototypes.proto.traits_set');
+    }
+
+    public function addTrait(string $trait, mixed $value = true): static
+    {
+        $trait = Str::trim($trait);
+        if ($trait === '') {
+            return $this;
+        }
+
+        return $this->prototypeAssocSet('traits', $trait, $value, 'prototypes.proto.trait_added');
+    }
+
+    public function stateValue(?string $key = null, mixed $value = null): mixed
+    {
+        $this->prototypeBoot('proto');
+        $state = Arr::toArray($this->prototypeGet('state', []));
+
+        if (Val::isNull($key)) {
+            return $state;
+        }
+
+        if (func_num_args() === 1) {
+            return $state[$key] ?? null;
+        }
+
+        $state[$key] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet('state', $state, 'prototypes.proto.state_changed');
+    }
+
+    public function property(string $name, mixed $value = null): mixed
+    {
+        $this->prototypeBoot('proto');
+        $properties = Arr::toArray($this->prototypeGet('properties', []));
+
+        if (func_num_args() === 1) {
+            return $properties[$name] ?? null;
+        }
+
+        $properties[$name] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet('properties', $properties, 'prototypes.proto.property_changed');
+    }
+
+    public function properties(?array $properties = null): mixed
+    {
+        $this->prototypeBoot('proto');
+
+        if (Val::isNull($properties)) {
+            return Arr::toArray($this->prototypeGet('properties', []));
+        }
+
+        return $this->prototypeSet('properties', Arr::toArray($properties), 'prototypes.proto.properties_set');
+    }
+
+    public function measure(string $name, mixed $value = null): mixed
+    {
+        $this->prototypeBoot('proto');
+        $measures = Arr::toArray($this->prototypeGet('measures', []));
+
+        if (func_num_args() === 1) {
+            return $measures[$name] ?? null;
+        }
+
+        $measures[$name] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet('measures', $measures, 'prototypes.proto.measure_changed');
+    }
+
+    public function measures(?array $measures = null): mixed
+    {
+        $this->prototypeBoot('proto');
+
+        if (Val::isNull($measures)) {
+            return Arr::toArray($this->prototypeGet('measures', []));
+        }
+
+        return $this->prototypeSet('measures', Arr::toArray($measures), 'prototypes.proto.measures_set');
+    }
+
+    public function relate(string $relation, mixed $target, array $meta = []): static
+    {
+        $relation = Str::trim($relation);
+        if ($relation === '') {
+            return $this;
+        }
+
+        $relations = Arr::toArray($this->prototypeGet('relations', []));
+        $relations[$relation] = $relations[$relation] ?? [];
+        $relations[$relation][] = [
+            'target' => $this->prototypeSnapshotValue($target),
+            'meta' => $this->prototypeSnapshotValue($meta),
+        ];
+
+        return $this->prototypeSet('relations', $relations, 'prototypes.proto.related');
+    }
+
+    public function relations(?string $relation = null): array
+    {
+        $relations = Arr::toArray($this->prototypeGet('relations', []));
+
+        if (Val::isNull($relation)) {
+            return $relations;
+        }
+
+        return Arr::toArray($relations[$relation] ?? []);
+    }
+
+    public function confidence(?float $confidence = null): mixed
+    {
+        if (Val::isNull($confidence)) {
+            return (float) $this->prototypeGet('confidence', 0.0);
+        }
+
+        return $this->prototypeSet('confidence', $confidence, 'prototypes.proto.confidence_changed');
+    }
+
+    public function domain(mixed $domain = null): mixed
+    {
+        if (Val::isNull($domain)) {
+            return $this->prototypeGet('domain');
+        }
+
+        return $this->prototypeSet('domain', $this->prototypeSnapshotValue($domain), 'prototypes.proto.domain_assigned');
+    }
+
+    public function position(mixed $position = null): mixed
+    {
+        if (Val::isNull($position)) {
+            return Arr::toArray($this->prototypeGet('position', []));
+        }
+
+        return $this->prototypeSet('position', Arr::toArray($this->prototypeSnapshotValue($position)), 'prototypes.proto.position_set');
+    }
+
+    public function record(mixed $event, array $meta = []): static
+    {
+        $history = Arr::toArray($this->prototypeGet('history', []));
+        $history[] = [
+            'event' => $this->prototypeSnapshotValue($event),
+            'meta' => $this->prototypeSnapshotValue($meta),
+        ];
+
+        return $this->prototypeSet('history', $history, 'prototypes.proto.history_recorded');
+    }
+
+    public function history(): array
+    {
+        return Arr::toArray($this->prototypeGet('history', []));
+    }
+
+    public function summary(?string $summary = null): mixed
+    {
+        if (Val::isNull($summary)) {
+            return (string) $this->prototypeGet('summary', '');
+        }
+
+        return $this->prototypeSet('summary', $summary, 'prototypes.proto.summary_set');
+    }
+
+    public function snapshot(): array
+    {
+        $this->prototypeBoot('proto');
+
+        $snapshot = [
+            'id' => $this->protoId(),
+            'kind' => $this->kind(),
+            'name' => $this->name(),
+            'labels' => $this->labels(),
+            'traits' => $this->traits(),
+            'state' => $this->stateValue(),
+            'properties' => $this->properties(),
+            'measures' => $this->measures(),
+            'relations' => $this->relations(),
+            'conditions' => Arr::toArray($this->prototypeGet('conditions', [])),
+            'causes' => Arr::toArray($this->prototypeGet('causes', [])),
+            'effects' => Arr::toArray($this->prototypeGet('effects', [])),
+            'confidence' => $this->confidence(),
+            'history' => $this->history(),
+            'summary' => (string) $this->prototypeGet('summary', ''),
+            'domain' => $this->prototypeSnapshotValue($this->prototypeGet('domain')),
+            'position' => Arr::toArray($this->prototypeGet('position', [])),
+            'collectives' => Arr::toArray($this->prototypeGet('collective_memberships', [])),
+        ];
+
+        foreach ([
+            'blueprint',
+            'archetype',
+            'schema',
+            'defaults',
+            'constraints',
+            'capabilities',
+            'components',
+            'substance',
+            'materiality',
+            'autonomy',
+            'control',
+            'goals',
+            'criteria',
+            'strategies',
+            'lastDecision',
+            'dimensions',
+            'coordinates',
+            'frame',
+            'anchor',
+            'domain_rules',
+            'domain_defaults',
+            'domain_members',
+            'domain_subdomains',
+            'domain_collectives',
+            'collective_kind',
+            'collective_members',
+            'collective_rules',
+            'collective_state',
+            'collective_destiny',
+        ] as $key) {
+            if (Arr::hasKey($this->_data, $key)) {
+                $snapshot[$key] = $this->prototypeSnapshotValue($this->_data[$key]);
+            }
+        }
+
+        $snapshot = Dev::apply('prototypes.proto.snapshot', $snapshot);
+
+        return $snapshot;
+    }
+
+    public function explain(): string
+    {
+        $snapshot = $this->snapshot();
+        $counts = [
+            'relations' => count($snapshot['relations'] ?? []),
+            'conditions' => count($snapshot['conditions'] ?? []),
+            'causes' => count($snapshot['causes'] ?? []),
+            'effects' => count($snapshot['effects'] ?? []),
+            'history' => count($snapshot['history'] ?? []),
+        ];
+
+        if (isset($snapshot['goals']) && Arr::is($snapshot['goals'])) {
+            $counts['goals'] = count($snapshot['goals']);
+        }
+
+        if (isset($snapshot['domain_members']) && Arr::is($snapshot['domain_members'])) {
+            $counts['members'] = count($snapshot['domain_members']);
+        }
+
+        if (isset($snapshot['collective_members']) && Arr::is($snapshot['collective_members'])) {
+            $counts['members'] = count($snapshot['collective_members']);
+        }
+
+        $summary = sprintf(
+            '%s[%s] relations=%d conditions=%d causes=%d effects=%d history=%d',
+            $snapshot['kind'] ?: 'proto',
+            $snapshot['id'] ?: ($snapshot['name'] ?: 'unidentified'),
+            $counts['relations'],
+            $counts['conditions'],
+            $counts['causes'],
+            $counts['effects'],
+            $counts['history']
+        );
+
+        if (Arr::hasKey($counts, 'goals')) {
+            $summary .= sprintf(' goals=%d', $counts['goals']);
+        }
+
+        if (Arr::hasKey($counts, 'members')) {
+            $summary .= sprintf(' members=%d', $counts['members']);
+        }
+
+        $this->prototypeSet('summary', $summary, 'prototypes.proto.explained');
+
+        return $summary;
+    }
+}

--- a/src/Prototypes/Proto.php
+++ b/src/Prototypes/Proto.php
@@ -8,10 +8,23 @@ use BlueFission\Val;
 use BlueFission\DevElation as Dev;
 use BlueFission\Prototypes\Support\PrototypeTools;
 
+/**
+ * Proto
+ *
+ * Base prototype substrate for objects that need stable identity, metadata,
+ * state, relations, and snapshot-friendly records that other Develation
+ * systems can inspect without knowing domain-specific logic.
+ */
 trait Proto
 {
     use PrototypeTools;
 
+    /**
+     * Get or assign the stable prototype identifier.
+     *
+     * @param string|null $id
+     * @return mixed
+     */
     public function protoId(?string $id = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -24,6 +37,12 @@ trait Proto
         return $this->prototypeSet('id', $id, 'prototypes.proto.id_set');
     }
 
+    /**
+     * Get or assign the semantic kind of prototype carrier.
+     *
+     * @param string|null $kind
+     * @return mixed
+     */
     public function kind(?string $kind = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -35,6 +54,12 @@ trait Proto
         return $this->prototypeSet('kind', Str::trim($kind), 'prototypes.proto.kind_set');
     }
 
+    /**
+     * Get or assign the human-readable prototype name.
+     *
+     * @param string|null $name
+     * @return mixed
+     */
     public function name(?string $name = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -46,6 +71,12 @@ trait Proto
         return $this->prototypeSet('name', Str::trim($name), 'prototypes.proto.name_set');
     }
 
+    /**
+     * Get or replace the flat label list carried by the prototype.
+     *
+     * @param array<int, string>|null $labels
+     * @return mixed
+     */
     public function labels(?array $labels = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -57,6 +88,12 @@ trait Proto
         return $this->prototypeSet('labels', Arr::toArray($labels), 'prototypes.proto.labels_set');
     }
 
+    /**
+     * Add a distinct label to the prototype metadata.
+     *
+     * @param string $label
+     * @return static
+     */
     public function addLabel(string $label): static
     {
         $label = Str::trim($label);
@@ -67,6 +104,12 @@ trait Proto
         return $this->prototypeAppend('labels', $label, true, 'prototypes.proto.label_added');
     }
 
+    /**
+     * Get or replace named traits/capabilities associated with the prototype.
+     *
+     * @param array<string|int, mixed>|null $traits
+     * @return mixed
+     */
     public function traits(?array $traits = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -78,6 +121,13 @@ trait Proto
         return $this->prototypeSet('traits', Arr::toArray($traits), 'prototypes.proto.traits_set');
     }
 
+    /**
+     * Add or update a named trait marker on the prototype.
+     *
+     * @param string $trait
+     * @param mixed $value
+     * @return static
+     */
     public function addTrait(string $trait, mixed $value = true): static
     {
         $trait = Str::trim($trait);
@@ -88,6 +138,13 @@ trait Proto
         return $this->prototypeAssocSet('traits', $trait, $value, 'prototypes.proto.trait_added');
     }
 
+    /**
+     * Get the full state bag, a specific state value, or set one state value.
+     *
+     * @param string|null $key
+     * @param mixed $value
+     * @return mixed
+     */
     public function stateValue(?string $key = null, mixed $value = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -106,6 +163,13 @@ trait Proto
         return $this->prototypeSet('state', $state, 'prototypes.proto.state_changed');
     }
 
+    /**
+     * Get or assign one arbitrary property.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return mixed
+     */
     public function property(string $name, mixed $value = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -120,6 +184,12 @@ trait Proto
         return $this->prototypeSet('properties', $properties, 'prototypes.proto.property_changed');
     }
 
+    /**
+     * Get or replace the entire property bag.
+     *
+     * @param array<string, mixed>|null $properties
+     * @return mixed
+     */
     public function properties(?array $properties = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -131,6 +201,13 @@ trait Proto
         return $this->prototypeSet('properties', Arr::toArray($properties), 'prototypes.proto.properties_set');
     }
 
+    /**
+     * Get or assign one measurable numeric or descriptive metric.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return mixed
+     */
     public function measure(string $name, mixed $value = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -145,6 +222,12 @@ trait Proto
         return $this->prototypeSet('measures', $measures, 'prototypes.proto.measure_changed');
     }
 
+    /**
+     * Get or replace the entire measurement bag.
+     *
+     * @param array<string, mixed>|null $measures
+     * @return mixed
+     */
     public function measures(?array $measures = null): mixed
     {
         $this->prototypeBoot('proto');
@@ -156,6 +239,14 @@ trait Proto
         return $this->prototypeSet('measures', Arr::toArray($measures), 'prototypes.proto.measures_set');
     }
 
+    /**
+     * Record a relation between this prototype and another target.
+     *
+     * @param string $relation
+     * @param mixed $target
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function relate(string $relation, mixed $target, array $meta = []): static
     {
         $relation = Str::trim($relation);
@@ -173,6 +264,12 @@ trait Proto
         return $this->prototypeSet('relations', $relations, 'prototypes.proto.related');
     }
 
+    /**
+     * Return all relations, or only relations for a named channel.
+     *
+     * @param string|null $relation
+     * @return array<string|int, mixed>
+     */
     public function relations(?string $relation = null): array
     {
         $relations = Arr::toArray($this->prototypeGet('relations', []));
@@ -184,6 +281,12 @@ trait Proto
         return Arr::toArray($relations[$relation] ?? []);
     }
 
+    /**
+     * Get or assign a confidence score for the prototype snapshot.
+     *
+     * @param float|null $confidence
+     * @return mixed
+     */
     public function confidence(?float $confidence = null): mixed
     {
         if (Val::isNull($confidence)) {
@@ -193,6 +296,12 @@ trait Proto
         return $this->prototypeSet('confidence', $confidence, 'prototypes.proto.confidence_changed');
     }
 
+    /**
+     * Get or assign the current domain reference for this prototype.
+     *
+     * @param mixed $domain
+     * @return mixed
+     */
     public function domain(mixed $domain = null): mixed
     {
         if (Val::isNull($domain)) {
@@ -202,6 +311,12 @@ trait Proto
         return $this->prototypeSet('domain', $this->prototypeSnapshotValue($domain), 'prototypes.proto.domain_assigned');
     }
 
+    /**
+     * Get or assign the current position payload for this prototype.
+     *
+     * @param mixed $position
+     * @return mixed
+     */
     public function position(mixed $position = null): mixed
     {
         if (Val::isNull($position)) {
@@ -211,6 +326,13 @@ trait Proto
         return $this->prototypeSet('position', Arr::toArray($this->prototypeSnapshotValue($position)), 'prototypes.proto.position_set');
     }
 
+    /**
+     * Append an event record to the prototype history.
+     *
+     * @param mixed $event
+     * @param array<string, mixed> $meta
+     * @return static
+     */
     public function record(mixed $event, array $meta = []): static
     {
         $history = Arr::toArray($this->prototypeGet('history', []));
@@ -222,11 +344,22 @@ trait Proto
         return $this->prototypeSet('history', $history, 'prototypes.proto.history_recorded');
     }
 
+    /**
+     * Return the normalized history stream for the prototype.
+     *
+     * @return array<int, array<string, mixed>>
+     */
     public function history(): array
     {
         return Arr::toArray($this->prototypeGet('history', []));
     }
 
+    /**
+     * Get or assign a human-readable summary string.
+     *
+     * @param string|null $summary
+     * @return mixed
+     */
     public function summary(?string $summary = null): mixed
     {
         if (Val::isNull($summary)) {
@@ -236,6 +369,11 @@ trait Proto
         return $this->prototypeSet('summary', $summary, 'prototypes.proto.summary_set');
     }
 
+    /**
+     * Produce the canonical array representation of the prototype.
+     *
+     * @return array<string, mixed>
+     */
     public function snapshot(): array
     {
         $this->prototypeBoot('proto');
@@ -302,6 +440,11 @@ trait Proto
         return $snapshot;
     }
 
+    /**
+     * Build a concise human-readable explanation of the prototype state.
+     *
+     * @return string
+     */
     public function explain(): string
     {
         $snapshot = $this->snapshot();

--- a/src/Prototypes/Support/PrototypeTools.php
+++ b/src/Prototypes/Support/PrototypeTools.php
@@ -12,8 +12,20 @@ use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\Meta;
 use LogicException;
 
+/**
+ * PrototypeTools
+ *
+ * Internal helper trait shared by the public prototype traits. It provides
+ * `Obj`-backed storage helpers, normalization, hook emission, and optional
+ * behavioral dispatch without introducing constructor coupling.
+ */
 trait PrototypeTools
 {
+    /**
+     * Ensure prototype traits are only used on `Obj` carriers.
+     *
+     * @return void
+     */
     protected function prototypeAssertCarrier(): void
     {
         if (!$this instanceof Obj) {
@@ -23,6 +35,12 @@ trait PrototypeTools
         }
     }
 
+    /**
+     * Seed the carrier with default prototype fields and optional kind.
+     *
+     * @param string|null $kind
+     * @return void
+     */
     protected function prototypeBoot(?string $kind = null): void
     {
         $this->prototypeAssertCarrier();
@@ -58,6 +76,13 @@ trait PrototypeTools
         }
     }
 
+    /**
+     * Read one prototype field from the underlying `Obj` data payload.
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
     protected function prototypeGet(string $key, mixed $default = null): mixed
     {
         $this->prototypeBoot();
@@ -75,6 +100,14 @@ trait PrototypeTools
         return $value;
     }
 
+    /**
+     * Set one prototype field and emit the matching hooks/events.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param string|null $hook
+     * @return static
+     */
     protected function prototypeSet(string $key, mixed $value, ?string $hook = null): static
     {
         $this->prototypeBoot();
@@ -86,6 +119,15 @@ trait PrototypeTools
         return $this;
     }
 
+    /**
+     * Append a value to a list-like prototype field.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param bool $distinct
+     * @param string|null $hook
+     * @return static
+     */
     protected function prototypeAppend(string $key, mixed $value, bool $distinct = false, ?string $hook = null): static
     {
         $values = Arr::toArray($this->prototypeGet($key, []));
@@ -98,6 +140,15 @@ trait PrototypeTools
         return $this->prototypeSet($key, $values, $hook);
     }
 
+    /**
+     * Set one named entry on an associative prototype field.
+     *
+     * @param string $key
+     * @param string $name
+     * @param mixed $value
+     * @param string|null $hook
+     * @return static
+     */
     protected function prototypeAssocSet(string $key, string $name, mixed $value, ?string $hook = null): static
     {
         $values = Arr::toArray($this->prototypeGet($key, []));
@@ -106,6 +157,13 @@ trait PrototypeTools
         return $this->prototypeSet($key, $values, $hook);
     }
 
+    /**
+     * Emit a DevElation hook and optional behavioral events for prototype changes.
+     *
+     * @param string $hook
+     * @param array<string, mixed> $data
+     * @return void
+     */
     protected function prototypeSignal(string $hook, array $data = []): void
     {
         Dev::do($hook, $data);
@@ -119,6 +177,12 @@ trait PrototypeTools
         }
     }
 
+    /**
+     * Normalize values into snapshot-safe scalars or arrays.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     protected function prototypeSnapshotValue(mixed $value): mixed
     {
         if ($value instanceof IVal) {
@@ -150,11 +214,27 @@ trait PrototypeTools
         return $value;
     }
 
+    /**
+     * Resolve a dotted path from a runtime context payload.
+     *
+     * @param array<string, mixed> $context
+     * @param string $path
+     * @param mixed $default
+     * @return mixed
+     */
     protected function prototypeContextValue(array $context, string $path, mixed $default = null): mixed
     {
         return Arr::getPath($context, $path, $default);
     }
 
+    /**
+     * Compare actual and expected values using a normalized operator string.
+     *
+     * @param mixed $actual
+     * @param mixed $expected
+     * @param string $operator
+     * @return bool
+     */
     protected function prototypeCompare(mixed $actual, mixed $expected, string $operator = 'requires'): bool
     {
         return match ($operator) {
@@ -173,6 +253,12 @@ trait PrototypeTools
         };
     }
 
+    /**
+     * Sort weighted records in descending weight/confidence order.
+     *
+     * @param array<int, array<string, mixed>> $records
+     * @return array<int, array<string, mixed>>
+     */
     protected function prototypeSortByWeight(array $records): array
     {
         usort($records, function (array $a, array $b): int {
@@ -185,6 +271,12 @@ trait PrototypeTools
         return $records;
     }
 
+    /**
+     * Merge array payloads recursively while preserving unique list members.
+     *
+     * @param array<string|int, mixed> ...$arrays
+     * @return array<string|int, mixed>
+     */
     protected function prototypeMergeArrays(array ...$arrays): array
     {
         $merged = [];

--- a/src/Prototypes/Support/PrototypeTools.php
+++ b/src/Prototypes/Support/PrototypeTools.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace BlueFission\Prototypes\Support;
+
+use BlueFission\Arr;
+use BlueFission\IVal;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+use BlueFission\DevElation as Dev;
+use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\Behavioral\Behaviors\Meta;
+use LogicException;
+
+trait PrototypeTools
+{
+    protected function prototypeAssertCarrier(): void
+    {
+        if (!$this instanceof Obj) {
+            throw new LogicException(
+                sprintf('%s must extend %s to use prototype traits.', get_class($this), Obj::class)
+            );
+        }
+    }
+
+    protected function prototypeBoot(?string $kind = null): void
+    {
+        $this->prototypeAssertCarrier();
+
+        $defaults = [
+            'id' => '',
+            'kind' => $kind ?? 'proto',
+            'labels' => [],
+            'traits' => [],
+            'state' => [],
+            'properties' => [],
+            'measures' => [],
+            'relations' => [],
+            'conditions' => [],
+            'causes' => [],
+            'effects' => [],
+            'confidence' => 0.0,
+            'history' => [],
+            'summary' => '',
+            'domain' => null,
+            'position' => [],
+            'collective_memberships' => [],
+        ];
+
+        foreach ($defaults as $key => $value) {
+            if (!Arr::hasKey($this->_data, $key) || Val::isNull($this->_data[$key])) {
+                $this->_data[$key] = $value;
+            }
+        }
+
+        if ($kind !== null && Str::isEmpty((string) ($this->_data['kind'] ?? ''))) {
+            $this->_data['kind'] = $kind;
+        }
+    }
+
+    protected function prototypeGet(string $key, mixed $default = null): mixed
+    {
+        $this->prototypeBoot();
+
+        if (!Arr::hasKey($this->_data, $key)) {
+            return $default;
+        }
+
+        $value = $this->_data[$key];
+
+        if ($value instanceof IVal) {
+            return $value->val();
+        }
+
+        return $value;
+    }
+
+    protected function prototypeSet(string $key, mixed $value, ?string $hook = null): static
+    {
+        $this->prototypeBoot();
+        $this->_data[$key] = $value;
+
+        $payload = ['key' => $key, 'value' => $this->prototypeSnapshotValue($value), 'object' => $this];
+        $this->prototypeSignal($hook ?? 'prototypes.changed', $payload);
+
+        return $this;
+    }
+
+    protected function prototypeAppend(string $key, mixed $value, bool $distinct = false, ?string $hook = null): static
+    {
+        $values = Arr::toArray($this->prototypeGet($key, []));
+        $candidate = $this->prototypeSnapshotValue($value);
+
+        if (!$distinct || !Arr::contains($values, $candidate, true)) {
+            $values[] = $candidate;
+        }
+
+        return $this->prototypeSet($key, $values, $hook);
+    }
+
+    protected function prototypeAssocSet(string $key, string $name, mixed $value, ?string $hook = null): static
+    {
+        $values = Arr::toArray($this->prototypeGet($key, []));
+        $values[$name] = $this->prototypeSnapshotValue($value);
+
+        return $this->prototypeSet($key, $values, $hook);
+    }
+
+    protected function prototypeSignal(string $hook, array $data = []): void
+    {
+        Dev::do($hook, $data);
+
+        if (method_exists($this, 'dispatch')) {
+            $this->dispatch($hook, new Meta(data: $data, src: $this));
+        }
+
+        if (method_exists($this, 'trigger')) {
+            $this->trigger(Event::CHANGE, new Meta(data: $data, src: $this));
+        }
+    }
+
+    protected function prototypeSnapshotValue(mixed $value): mixed
+    {
+        if ($value instanceof IVal) {
+            return $value->val();
+        }
+
+        if (is_array($value)) {
+            $normalized = [];
+            foreach ($value as $key => $item) {
+                $normalized[$key] = $this->prototypeSnapshotValue($item);
+            }
+            return $normalized;
+        }
+
+        if (is_object($value)) {
+            if (method_exists($value, 'snapshot')) {
+                return $value->snapshot();
+            }
+
+            if (method_exists($value, 'toArray')) {
+                return $value->toArray();
+            }
+
+            if (method_exists($value, '__toString')) {
+                return (string) $value;
+            }
+        }
+
+        return $value;
+    }
+
+    protected function prototypeContextValue(array $context, string $path, mixed $default = null): mixed
+    {
+        return Arr::getPath($context, $path, $default);
+    }
+
+    protected function prototypeCompare(mixed $actual, mixed $expected, string $operator = 'requires'): bool
+    {
+        return match ($operator) {
+            'eq', 'equals', 'is' => $actual == $expected,
+            'strict', '===' => $actual === $expected,
+            'neq', 'not_equals', 'is_not' => $actual != $expected,
+            'gt', '>' => is_numeric($actual) && is_numeric($expected) && $actual > $expected,
+            'gte', '>=' => is_numeric($actual) && is_numeric($expected) && $actual >= $expected,
+            'lt', '<' => is_numeric($actual) && is_numeric($expected) && $actual < $expected,
+            'lte', '<=' => is_numeric($actual) && is_numeric($expected) && $actual <= $expected,
+            'in' => is_array($expected) && Arr::contains($expected, $actual, true),
+            'not_in' => is_array($expected) && !Arr::contains($expected, $actual, true),
+            'truthy' => (bool) $actual,
+            'falsy' => !(bool) $actual,
+            default => (bool) $actual,
+        };
+    }
+
+    protected function prototypeSortByWeight(array $records): array
+    {
+        usort($records, function (array $a, array $b): int {
+            $left = (float) ($a['weight'] ?? $a['confidence'] ?? 0.0);
+            $right = (float) ($b['weight'] ?? $b['confidence'] ?? 0.0);
+
+            return $right <=> $left;
+        });
+
+        return $records;
+    }
+
+    protected function prototypeMergeArrays(array ...$arrays): array
+    {
+        $merged = [];
+
+        foreach ($arrays as $array) {
+            foreach ($array as $key => $value) {
+                if (
+                    is_array($value)
+                    && Arr::hasKey($merged, $key)
+                    && is_array($merged[$key])
+                ) {
+                    $merged[$key] = $this->prototypeMergeArrays($merged[$key], $value);
+                    continue;
+                }
+
+                if (is_int($key)) {
+                    if (!Arr::contains($merged, $value, true)) {
+                        $merged[] = $value;
+                    }
+                    continue;
+                }
+
+                $merged[$key] = $value;
+            }
+        }
+
+        return $merged;
+    }
+}

--- a/tests/Prototypes/PrototypeSubstrateTest.php
+++ b/tests/Prototypes/PrototypeSubstrateTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace BlueFission\Tests\Prototypes;
+
+use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\Obj;
+use BlueFission\Prototypes\Agent;
+use BlueFission\Prototypes\Artifact;
+use BlueFission\Prototypes\Blueprint;
+use BlueFission\Prototypes\Collective;
+use BlueFission\Prototypes\Domain;
+use BlueFission\Prototypes\Entity;
+use BlueFission\Prototypes\HasCollectives;
+use BlueFission\Prototypes\HasConditions;
+use BlueFission\Prototypes\IsCausal;
+use BlueFission\Prototypes\Position;
+use BlueFission\Prototypes\Proto;
+use PHPUnit\Framework\TestCase;
+
+final class PrototypeSubstrateTest extends TestCase
+{
+    public function testProtoSnapshotCapturesCoreMetadata(): void
+    {
+        $object = new PrototypeFixture();
+        $object->protoId('dog_01')
+            ->name('Scout')
+            ->kind('entity')
+            ->addLabel('dog')
+            ->addTrait('animal')
+            ->property('color', 'brown')
+            ->measure('speed', 4)
+            ->confidence(0.75)
+            ->record('observed', ['by' => 'camera']);
+
+        $snapshot = $object->snapshot();
+
+        $this->assertSame('dog_01', $snapshot['id']);
+        $this->assertSame('Scout', $snapshot['name']);
+        $this->assertSame('entity', $snapshot['kind']);
+        $this->assertSame('brown', $snapshot['properties']['color']);
+        $this->assertSame(4, $snapshot['measures']['speed']);
+        $this->assertCount(1, $snapshot['history']);
+    }
+
+    public function testBlueprintArtifactEntityAndAgentExposeDistinctMetadata(): void
+    {
+        $blueprint = new BlueprintFixture();
+        $blueprint->protoId('bp.dog')
+            ->name('Dog Blueprint')
+            ->archetype('animal')
+            ->capability('move', 1)
+            ->addConstraint('requires_food', true)
+            ->component('tail', ['count' => 1]);
+
+        $artifact = new ArtifactFixture();
+        $artifact->protoId('artifact.dog.bowl')
+            ->blueprint($blueprint)
+            ->substance('steel')
+            ->materiality('substantial');
+
+        $entity = new EntityFixture();
+        $entity->protoId('entity.dog.scout')
+            ->name('Scout')
+            ->reactive(true)
+            ->property('species', 'dog');
+
+        $agent = new AgentFixture();
+        $agent->protoId('agent.handler')
+            ->name('Handler')
+            ->role('operator')
+            ->scope('local')
+            ->awareness('room')
+            ->efficacy('can_act')
+            ->autonomy('externally_controlled')
+            ->addGoal('Feed dog')
+            ->addCriterion('safety', 5, 'avoid harm')
+            ->addStrategy('open_door', 2, 'exit')
+            ->decide(['recommendation' => 'open kitchen door']);
+
+        $this->assertSame('animal', $blueprint->archetype());
+        $this->assertSame('steel', $artifact->substance());
+        $this->assertSame('dog', $entity->property('species'));
+        $this->assertSame('operator', $agent->role());
+        $this->assertCount(1, $agent->goals());
+        $this->assertSame('open kitchen door', $agent->snapshot()['lastDecision']['recommendation']);
+    }
+
+    public function testPositionTraitSupportsCoordinatesAndDistances(): void
+    {
+        $left = new PositionedFixture();
+        $right = new PositionedFixture();
+
+        $left->defineDimension('x', ['kind' => 'spatial', 'absolute' => true])
+            ->defineDimension('y', ['kind' => 'spatial', 'absolute' => true])
+            ->coordinate('x', 0)
+            ->coordinate('y', 0);
+
+        $right->defineDimension('x', ['kind' => 'spatial', 'absolute' => true])
+            ->defineDimension('y', ['kind' => 'spatial', 'absolute' => true])
+            ->coordinate('x', 3)
+            ->coordinate('y', 4);
+
+        $this->assertSame(5.0, $left->distanceTo($right));
+    }
+
+    public function testConditionsAndCausalityCanFilterCandidateCauses(): void
+    {
+        $entity = new ConditionalEntityFixture();
+        $entity->protoId('entity.dog.scout')
+            ->name('Scout')
+            ->addCondition([
+                'name' => 'hungry',
+                'path' => 'states.hungry',
+                'expected' => true,
+                'operator' => 'equals',
+            ])
+            ->addCause([
+                'name' => 'entered_for_food',
+                'weight' => 0.9,
+                'conditions' => [[
+                    'name' => 'food_smell',
+                    'path' => 'signals.food_smell',
+                    'expected' => true,
+                    'operator' => 'equals',
+                ]],
+            ])
+            ->addCause([
+                'name' => 'entered_randomly',
+                'weight' => 0.2,
+            ]);
+
+        $context = [
+            'states' => ['hungry' => true],
+            'signals' => ['food_smell' => true],
+        ];
+
+        $this->assertTrue($entity->conditionsMet($context));
+
+        $causes = $entity->inferCauses($context);
+
+        $this->assertSame('entered_for_food', $causes[0]['name']);
+        $this->assertCount(2, $causes);
+    }
+
+    public function testDomainOwnsMembersSubdomainsAndCollectives(): void
+    {
+        $house = new DomainFixture();
+        $house->protoId('domain.house')
+            ->domainName('House')
+            ->rule('entry_requires_opening', true)
+            ->defaultValue('food_source', 'kitchen')
+            ->domainState('occupied', true);
+
+        $room = new DomainFixture();
+        $room->protoId('domain.house.kitchen')->domainName('Kitchen');
+
+        $dog = new EntityFixture();
+        $dog->protoId('entity.dog.scout')->name('Scout');
+
+        $pack = new CollectiveFixture();
+        $pack->protoId('collective.pack')->name('Pack')->collectiveKind('pack')->sharedDestiny('stay_together');
+        $pack->addMember($dog, 'scout');
+
+        $house->addSubdomain($room, 'kitchen');
+        $house->addMember($dog, 'scout');
+        $house->addCollective($pack, 'pack');
+
+        $snapshot = $house->snapshot();
+
+        $this->assertSame('House', $snapshot['name']);
+        $this->assertCount(1, $snapshot['domain_members']);
+        $this->assertCount(1, $snapshot['domain_subdomains']);
+        $this->assertCount(1, $snapshot['domain_collectives']);
+        $this->assertSame('kitchen', $snapshot['domain_defaults']['food_source']);
+    }
+
+    public function testCollectiveMembershipCanBeTrackedOnEntities(): void
+    {
+        $dog = new SocialEntityFixture();
+        $dog->protoId('entity.dog.scout')->name('Scout');
+
+        $flock = [
+            'id' => 'collective.flock',
+            'name' => 'Flock',
+        ];
+
+        $dog->joinCollective($flock, ['role' => 'member']);
+
+        $this->assertTrue($dog->inCollective('collective.flock'));
+        $this->assertCount(1, $dog->collectives());
+    }
+
+    public function testBehavioralCarrierDispatchesPrototypeEvents(): void
+    {
+        $entity = new PrototypeFixture();
+        $called = false;
+
+        $entity->when('prototypes.proto.property_changed', function ($behavior, $args) use (&$called): void {
+            $called = $args instanceof Meta;
+        });
+
+        $entity->property('species', 'dog');
+
+        $this->assertTrue($called);
+    }
+}
+
+final class PrototypeFixture extends Obj
+{
+    use Proto;
+}
+
+final class BlueprintFixture extends Obj
+{
+    use Proto;
+    use Blueprint;
+}
+
+final class ArtifactFixture extends Obj
+{
+    use Proto;
+    use Artifact;
+}
+
+final class EntityFixture extends Obj
+{
+    use Proto;
+    use Artifact;
+    use Entity;
+}
+
+final class AgentFixture extends Obj
+{
+    use Proto;
+    use Artifact;
+    use Entity;
+    use Agent;
+}
+
+final class PositionedFixture extends Obj
+{
+    use Proto;
+    use Position;
+}
+
+final class ConditionalEntityFixture extends Obj
+{
+    use Proto;
+    use Entity;
+    use HasConditions;
+    use IsCausal;
+}
+
+final class DomainFixture extends Obj
+{
+    use Proto;
+    use Domain;
+}
+
+final class CollectiveFixture extends Obj
+{
+    use Proto;
+    use Collective;
+}
+
+final class SocialEntityFixture extends Obj
+{
+    use Proto;
+    use Entity;
+    use HasCollectives;
+}


### PR DESCRIPTION
## Intent
Add a Develation-native prototypes substrate for world-modeling, shared context, collectives, conditions, and causal hooks without baking in Automata-specific reasoning.

## Linked Issue
- Closes #92

## Summary Of Changes
- adds `src/Prototypes/` traits for:
  - `Proto`
  - `Blueprint`
  - `Artifact`
  - `Entity`
  - `Agent`
  - `Position`
  - `Domain`
  - `Collective`
  - `HasConditions`
  - `IsCausal`
  - `HasCollectives`
- adds contracts for:
  - `Conditional`
  - `Causal`
  - `DomainAware`
  - `CollectiveAware`
- adds `PrototypeTools` support helpers for:
  - `Obj`-backed metadata normalization
  - optional behavior dispatch
  - hook emission
  - consistent snapshot normalization
- adds `prototypes.md` with:
  - semantic model
  - normalized metadata
  - condition/causal intent
  - domain/collective registry design
  - forward compatibility notes for Automata and `jenss-interpreter`
- updates `README.md` to link the new prototypes documentation
- adds `tests/Prototypes/PrototypeSubstrateTest.php` covering:
  - core snapshot metadata
  - blueprint/artifact/entity/agent distinctions
  - position coordinates and distance
  - condition evaluation and cause filtering
  - domain membership/subdomains/collectives
  - collective membership tracking
  - behavioral event dispatch

## Key Files
- `src/Prototypes/*`
- `src/Prototypes/Support/PrototypeTools.php`
- `tests/Prototypes/PrototypeSubstrateTest.php`
- `prototypes.md`
- `README.md`

## Validation
```powershell
php -l tests\Prototypes\PrototypeSubstrateTest.php
Get-ChildItem src\Prototypes -Recurse -Filter *.php | ForEach-Object { php -l $_.FullName }
vendor\bin\phpunit --do-not-cache-result tests\Prototypes\PrototypeSubstrateTest.php
vendor\bin\phpunit --do-not-cache-result tests\StrTest.php
vendor\bin\phpunit --do-not-cache-result
```

Result:
- targeted prototype suite passed
- adjacent `Str` suite passed
- full suite passed: `606 tests`, `3933 assertions`, `35 skipped`

## Notes
- this pass intentionally stops at substrate, metadata, and hook surfaces
- it does not introduce graph search, theorem proving, or simulation logic
- the design stays compatible with later Automata and `jenss-interpreter` adapters without forcing new grammar first
