### PR TITLE
Tighten core substrate health coverage

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,46 @@
+## Purpose
+
+Issue `#95` is a maintenance sweep focused on repository health after a large set of parser, datatype, and prototype updates. The goal is not to add new product features. The goal is to improve confidence, clarity, and maintainability without changing public contracts.
+
+## Scope
+
+- review current test health on the branch
+- inspect recently active and core library surfaces for obvious test gaps
+- inspect public/core classes for missing or inconsistent explanatory docblocks where they materially aid maintenance
+- keep changes non-breaking and compatible with current CI and release expectations
+
+## In Scope
+
+- targeted test additions for existing behavior
+- small comment/docblock improvements for public or shared internals
+- low-risk refactors that only clarify behavior or align tests with current contracts
+- broader validation where touched areas justify it
+
+## Out of Scope
+
+- new feature development unrelated to maintenance
+- dependency changes
+- environment or CI reconfiguration
+- broad architectural rewrites
+
+## Acceptance Criteria
+
+- the branch documents the maintenance intent clearly
+- concrete health findings are identified from a read-only sweep before code changes
+- only high-signal, low-risk fixes are implemented
+- targeted tests pass for touched areas
+- a broader validation pass is run and any limits or timeouts are reported plainly
+
+## Candidate Focus Areas
+
+- core datatypes: `Val`, `Arr`, `Str`
+- parsing/runtime files touched by recent issue work
+- prototype substrate files and their supporting tests
+- test files whose expectations may lag current helper semantics
+
+## Validation Plan
+
+1. run the full suite to establish a baseline on the branch
+2. run targeted suites while iterating on touched areas
+3. rerun the affected suites after changes
+4. rerun the full suite before closeout if feasible within the repo's known runtime envelope

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -709,7 +709,8 @@ class Arr extends Val implements IVal, ArrayAccess, Countable, IteratorAggregate
     }
 
     /**
-     * flip the keys and values of the $_data array
+     * Flip the keys and values of the current array.
+     *
      * @return Arr
      */
     public function _flip(): Arr
@@ -724,7 +725,8 @@ class Arr extends Val implements IVal, ArrayAccess, Countable, IteratorAggregate
     }
 
     /**
-     * get the keys of the $_data array
+     * Return the keys of the current array as a new Arr value object.
+     *
      * @return Arr
      */
     public function _keys(): Arr

--- a/src/Func.php
+++ b/src/Func.php
@@ -4,6 +4,13 @@ namespace BlueFission;
 
 use BlueFission\Behavioral\Behaviors\Event;
 
+/**
+ * Func
+ *
+ * Callable value object with optional signature metadata and support for
+ * runtime-bound closures. It exposes reflection-friendly helper methods around
+ * existing callables rather than acting as a full compiler.
+ */
 class Func extends Val implements IVal {
 	/**
 	 *
@@ -54,6 +61,12 @@ class Func extends Val implements IVal {
 		return $this;
 	}
 
+	/**
+	 * Define the expected parameter signature metadata.
+	 *
+	 * @param array<int, string|array<string, mixed>> $params
+	 * @return self
+	 */
 	public function signature(array $params): self
 	{
 	    $this->_signature = array_map(function($param) {
@@ -63,19 +76,39 @@ class Func extends Val implements IVal {
 	    return $this;
 	}
 
+	/**
+	 * Define the expected return type metadata.
+	 *
+	 * @param string $type
+	 * @return self
+	 */
 	public function type(string $type): self
 	{
 	    $this->_returnType = $type;
 	    return $this;
 	}
 
+    /**
+     * Set the callable body from a closure or trusted string body.
+     *
+     * @param callable|string $logic
+     * @return self
+     */
     public function body(callable|string $logic): self
     {
         if (is_callable($logic)) {
             $this->_data = \Closure::fromCallable($logic);
         } elseif (is_string($logic)) {
             // Create closure from string-based body using eval (only for trusted input).
-            $paramList = implode(', ', array_map(fn($p) => $p['name'], $this->_signature));
+            $paramList = implode(', ', array_map(function ($param) {
+                $name = (string) ($param['name'] ?? '');
+
+                if (Str::startsWith($name, '$')) {
+                    return $name;
+                }
+
+                return '$' . $name;
+            }, $this->_signature));
             $return = $this->_returnType ? ": {$this->_returnType}" : '';
             $code = "return function($paramList)$return { $logic };";
 
@@ -85,6 +118,11 @@ class Func extends Val implements IVal {
 	    return $this;
 	}
 
+	/**
+	 * Restore a previously compiled callable if one has been stored.
+	 *
+	 * @return self
+	 */
 	public function compile(): self
 	{
 	    if (!$this->_data && $this->_compiled) {
@@ -93,6 +131,11 @@ class Func extends Val implements IVal {
 	    return $this;
 	}
 
+	/**
+	 * Return the explicit parameter metadata if one was provided.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
 	public function parameters(): array
 	{
 	    return $this->_signature;
@@ -158,6 +201,12 @@ class Func extends Val implements IVal {
 	    return null;
 	}
 
+	/**
+	 * Invoke the callable with argument forwarding and reference preservation.
+	 *
+	 * @return mixed
+	 * @throws \Exception
+	 */
 	public function call()
 	{
 		$args = func_get_args();

--- a/src/Obj.php
+++ b/src/Obj.php
@@ -14,6 +14,13 @@ use BlueFission\Behavioral\Behaves;
 use BlueFission\Behavioral\IDispatcher;
 use BlueFission\Behavioral\IBehavioral;
 
+/**
+ * Obj
+ *
+ * Dynamic object substrate backed by Arr and optional IVal field typing. It is
+ * intended as a lightweight structured carrier that still participates in
+ * Develation behavioral events.
+ */
 class Obj implements IObj, IDispatcher, IBehavioral
 {
     use Behaves {
@@ -154,7 +161,7 @@ class Obj implements IObj, IDispatcher, IBehavioral
     }
 
     /**
-     * This method is used to get the data.
+     * Return the underlying data payload, unwrapping IVal-backed storage.
      *
      * @return mixed
      */
@@ -190,7 +197,7 @@ class Obj implements IObj, IDispatcher, IBehavioral
     }
 
     /**
-     * Method to expose IVal members when called as methods
+     * Expose field-backed callables or IVal members when called as methods.
      *
      * @param string $method
      * @param array $args
@@ -272,7 +279,7 @@ class Obj implements IObj, IDispatcher, IBehavioral
         return $this->_type;
     }  
 
-     /**
+    /**
      * Convert the object data into an array
      * 
      * @return array The object data as an array

--- a/src/Str.php
+++ b/src/Str.php
@@ -61,11 +61,17 @@ class Str extends Val implements IVal {
      * 
      * @return bool
      */
-    public function _is( ): bool
+	public function _is( ): bool
     {
     	return is_string($this->_data);
 	}
 
+	/**
+	 * Split the string into an Arr using the provided delimiter.
+	 *
+	 * @param string $delimiter
+	 * @return Arr
+	 */
 	public function _split( $delimiter = ' ' ): Arr
 	{
 		$string = $this->_data;

--- a/src/Val.php
+++ b/src/Val.php
@@ -80,8 +80,12 @@ class Val implements IVal, IDispatcher {
 	}
 
 	/**
-	 * Check the value of the var against multiple functions
+	 * Check the value against one or more validator names or callables.
 	 *
+	 * Accepts internal helper names, public method names, global function names,
+	 * or arbitrary callables. Evaluation stops on the first failing validator.
+	 *
+	 * @param mixed $functions
 	 * @return bool
 	 */
 	public function _check($functions = null): bool

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -72,6 +72,22 @@ class ArrTest extends ValTest {
 		$this->assertTrue($this->object->isAssoc());
 	}
 
+	public function testReturnsKeysAsArrayObject()
+	{
+		$object = new static::$classname(['first' => 'foo', 'second' => 'bar']);
+
+		$this->assertEquals(['first', 'second'], $object->keys()->val());
+		$this->assertEquals(['first', 'second'], static::$classname::keys(['first' => 'foo', 'second' => 'bar']));
+	}
+
+	public function testFlipsKeysAndValues()
+	{
+		$object = new static::$classname(['first' => 'foo', 'second' => 'bar']);
+
+		$this->assertEquals(['foo' => 'first', 'bar' => 'second'], $object->flip()->val());
+		$this->assertEquals(['foo' => 'first', 'bar' => 'second'], static::$classname::flip(['first' => 'foo', 'second' => 'bar']));
+	}
+
 	public function testsRemovesDuplicates()
 	{
 		$object = new static::$classname(['foo', 'bar', 'foo']);

--- a/tests/FuncTest.php
+++ b/tests/FuncTest.php
@@ -131,4 +131,27 @@ class FuncTest extends ValTest
         $func = new Func(function (): int { return 1; });
         $this->assertEquals('int', (string) $func->returns());
     }
+
+    public function testSignatureAndParametersExposeMetadata()
+    {
+        $func = (new Func(function ($value) {
+            return $value;
+        }))->signature([
+            ['name' => 'value', 'type' => 'string'],
+        ]);
+
+        $this->assertSame([['name' => 'value', 'type' => 'string']], $func->parameters());
+        $this->assertSame([['name' => 'value', 'type' => 'string']], $func->expects());
+    }
+
+    public function testBodyCanBuildCallableFromTrustedString()
+    {
+        $func = (new Func())
+            ->signature(['value'])
+            ->type('string')
+            ->body('return strtoupper($value);');
+
+        $this->assertSame('HELLO', $func->call('hello'));
+        $this->assertSame('string', $func->returns());
+    }
 }

--- a/tests/ObjTest.php
+++ b/tests/ObjTest.php
@@ -2,6 +2,7 @@
 namespace BlueFission\Tests;
 
 use BlueFission\Obj;
+use BlueFission\Str;
  
 class ObjTest extends \PHPUnit\Framework\TestCase {
  
@@ -30,5 +31,40 @@ class ObjTest extends \PHPUnit\Framework\TestCase {
 
 		$this->object->clear();
 		$this->assertEquals(null, $this->object->testValue);
+	}
+
+	public function testAssignImportsAssociativeArrays()
+	{
+		$this->object->assign(['name' => 'Ada', 'role' => 'Engineer']);
+
+		$this->assertSame('Ada', $this->object->name);
+		$this->assertSame('Engineer', $this->object->role);
+	}
+
+	public function testAssignRejectsNonAssociativeArrays()
+	{
+		$this->expectException(\InvalidArgumentException::class);
+		$this->object->assign(['Ada', 'Engineer']);
+	}
+
+	public function testExposeValueObjectReturnsUnderlyingValueObject()
+	{
+		$object = new class extends Obj {
+			protected $_types = ['name' => \BlueFission\DataTypes::STRING];
+		};
+
+		$object->field('name', 'Ada');
+		$this->assertSame('Ada', $object->field('name'));
+
+		$object->exposeValueObject();
+		$this->assertInstanceOf(Str::class, $object->field('name'));
+	}
+
+	public function testToArrayAndToJsonExposeAssignedValues()
+	{
+		$this->object->assign(['name' => 'Ada', 'role' => 'Engineer']);
+
+		$this->assertSame(['name' => 'Ada', 'role' => 'Engineer'], $this->object->toArray());
+		$this->assertSame('{"name":"Ada","role":"Engineer"}', $this->object->toJson());
 	}
 }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -38,6 +38,12 @@ class StrTest extends ValTest {
 		$this->assertTrue($sim < 1);
 	}
 
+	public function testSplitReturnsArrayValueObject()
+	{
+		$this->assertEquals(['My', 'Name', 'Is', 'John'], $this->object->split()->val());
+		$this->assertEquals(['a', 'b', 'c'], Str::split('a,b,c', ','));
+	}
+
 	public function testSetsValue()
 	{
 		$object = new static::$classname();

--- a/tests/ValTest.php
+++ b/tests/ValTest.php
@@ -191,6 +191,17 @@ class ValTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($trueResult);
     }
 
+    public function testCheckSupportsInternalAndCallableValidators()
+    {
+        $truthy = new Val(1);
+        $emptyString = new Val('');
+        $blank = new Val();
+
+        $this->assertTrue($truthy->check(['isNotNull', 'isTruthy']));
+        $this->assertTrue($emptyString->check(fn ($value) => is_string($value)));
+        $this->assertFalse($blank->check(['isNotNull', fn ($value) => !is_null($value)]));
+    }
+
     // Static Empty Test
     public function testRecognizesBlankAsEmptyStatically()
     {


### PR DESCRIPTION
## Intent
Close out issue #95 with a focused health and coverage sweep on Develation's core substrate.

## Linked Issues
- Closes #95

## User story / outcome supported
As a maintainer, I want stronger direct coverage and clearer intent around the library's core datatype and object substrate, so that future changes land against better tests and clearer contracts.

## Summary of changes
- adds a branch `SPEC.md` for the health sweep scope and acceptance criteria
- strengthens direct test coverage for existing `Val`, `Arr`, and `Str` helper behavior
- adds direct `Obj` coverage for assignment, invalid assignment rejection, value-object exposure, and serialization-friendly exports
- adds direct `Func` coverage for signature metadata and string-body compilation
- fixes `Func::body()` string compilation so generated closure parameters are emitted correctly
- tightens touched helper/class docblocks where they materially improve maintenance clarity

## Key files / areas touched (callouts)
- `SPEC.md` - maintenance scope for issue #95
- `src/Val.php`, `src/Arr.php`, `src/Str.php` - touched helper docs and covered existing helper behavior directly
- `src/Obj.php` - clarified class/method intent for the dynamic object substrate
- `src/Func.php` - fixed string-body callable compilation and documented the touched callable metadata surface
- `tests/ValTest.php`, `tests/ArrTest.php`, `tests/StrTest.php`, `tests/ObjTest.php`, `tests/FuncTest.php` - direct health/coverage additions

## QA / Validation checklist
### Manual QA
- [ ] Review the helper and substrate changes for contract compatibility
- [ ] Confirm no new behavior was added outside the documented `Func::body()` fix

### Automated checks
- [x] Unit tests added/updated
- [x] Lint/syntax checks pass on touched files
- [x] Full PHPUnit suite passes locally

## Unit tests (specific)
- `vendor/bin/phpunit --do-not-cache-result tests/ValTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/ArrTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/StrTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/ObjTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/FuncTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/ObjTest.php tests/FuncTest.php tests/ValTest.php tests/ArrTest.php tests/StrTest.php`
- `vendor/bin/phpunit --do-not-cache-result`

## Risk and rollout
- Risk level: low
- What could break?
  - Code that depended on undocumented quirks in `Func::body()` string compilation, though the prior behavior was invalid PHP output for named parameters.
- Backward compatibility notes:
  - The sweep is intended to be non-breaking; most changes are tests and documentation.
  - The `Func::body()` fix corrects a defective existing path rather than changing a stable contract.
- Rollback plan:
  - Revert this PR if a downstream consumer relied on the broken string-body compilation path.

## Notes / discussion
A numeric primitive sanity pass (`Num` and nearby numeric helpers) was intentionally left out of this PR so it can be reviewed separately if needed.
