### PR TITLE
Harden numeric primitive coverage

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,22 @@
+## Purpose
+
+Issue `#97` is a narrow maintenance sweep for Develation's `Num` primitive. The goal is to improve confidence in existing numeric helper behavior without expanding the primitive surface or changing stable contracts.
+
+## Scope
+
+- review `src/Num.php` against `tests/NumTest.php`
+- add focused coverage for existing arithmetic, conversion, and formatting helpers
+- apply only low-risk fixes if a concrete defect is exposed by the new tests
+
+## Out of Scope
+
+- adding new numeric primitives
+- broad refactors of datatype architecture
+- dependency, environment, or CI changes
+
+## Acceptance Criteria
+
+- the branch is linked to issue `#97`
+- `Num` helper behavior is covered more directly than inherited `Val` behavior alone
+- any implementation change is justified by a failing test
+- targeted `Num` tests pass after the sweep

--- a/src/Num.php
+++ b/src/Num.php
@@ -395,7 +395,7 @@ class Num extends Val implements IVal {
     public function _dec(): mixed
     {
     	$values = func_get_args();
-    	if ( Arr::count($values) ) {
+    	if ( Arr::size($values) ) {
     		$this->_data = $values[0];
     		return $this;
     	}
@@ -411,7 +411,7 @@ class Num extends Val implements IVal {
     public function _bin(): string|Num
     {
     	$values = func_get_args();
-    	if ( Arr::count($values) ) {
+    	if ( Arr::size($values) ) {
 			$this->_data = bindec($values[0]);
 			return $this;
 		}
@@ -427,7 +427,7 @@ class Num extends Val implements IVal {
 	public function _hex(): string|Num
 	{
 		$values = func_get_args();
-		if ( Arr::count($values) ) {
+		if ( Arr::size($values) ) {
 			$this->_data = hexdec($values[0]);
 			return $this;
 		}
@@ -443,7 +443,7 @@ class Num extends Val implements IVal {
 	public function _oct(): string|Num
 	{
 		$values = func_get_args();
-		if ( Arr::count($values) ) {
+		if ( Arr::size($values) ) {
 			$this->_data = octdec($values[0]);
 			return $this;
 		}

--- a/tests/NumTest.php
+++ b/tests/NumTest.php
@@ -135,4 +135,65 @@ class NumTest extends ValTest
         $roman = Num::rom(756);
         $this->assertEquals('DCCLVI', $roman);
     }
+
+    public function testArithmeticHelpersMutateValue()
+    {
+        $number = new Num(10);
+
+        $this->assertEquals(15, $number->add(5)->val());
+        $this->assertEquals(12, $number->sub(3)->val());
+        $this->assertEquals(24, $number->multiply(2)->val());
+        $this->assertEquals(6, $number->divide(4)->val());
+    }
+
+    public function testPowerAndRootHelpersMutateValue()
+    {
+        $number = new Num(9);
+
+        $this->assertEquals(81, $number->sq()->val());
+        $this->assertEquals(9, $number->sqrt()->val());
+        $this->assertEquals(729, $number->pow(3)->val());
+        $this->assertEquals(log(729), $number->log()->val());
+        $this->assertEquals(exp(log(729)), $number->exp()->val());
+    }
+
+    public function testAbsoluteRoundAndIntegerHelpers()
+    {
+        $number = new Num(-12.75);
+
+        $this->assertSame(12.75, $number->abs()->val());
+        $this->assertSame(12.8, $number->round(1)->val());
+        $this->assertSame(12, $number->int());
+    }
+
+    public function testIncrementAndDecrementHelpers()
+    {
+        $number = new Num(3);
+
+        $this->assertSame(4, $number->increment()->val());
+        $this->assertSame(3, $number->decrement()->val());
+    }
+
+    public function testBaseConversionHelpersRoundTrip()
+    {
+        $number = new Num(42);
+
+        $this->assertSame('101010', $number->bin());
+        $this->assertSame('2a', $number->hex());
+        $this->assertSame('52', $number->oct());
+
+        $this->assertSame(42, (new Num())->bin('101010')->val());
+        $this->assertSame(42, (new Num())->hex('2a')->val());
+        $this->assertSame(42, (new Num())->oct('52')->val());
+        $this->assertSame(42, (new Num())->rom('XLII')->val());
+    }
+
+    public function testFormattingAffectsStringOutput()
+    {
+        $number = new Num(1234.5);
+
+        $this->assertSame('1,234.50', (string)$number);
+        $this->assertSame('1 234,5', (string)$number->precision(1)->decimal(',')->thousands(' '));
+        $this->assertSame('1234.500', (string)$number->format('%.3f'));
+    }
 }


### PR DESCRIPTION
## Intent
Close out issue #97 with a narrow sanity and coverage sweep for the `Num` primitive.

## Linked Issues
- Closes #97

## User story / outcome supported
As a maintainer, I want the numeric primitive to have direct coverage around its helper surface, so that arithmetic and conversion regressions are caught early and the primitive remains trustworthy as shared substrate.

## Summary of changes
- adds a branch `SPEC.md` for the numeric sanity sweep
- strengthens direct `Num` coverage for arithmetic, powers/roots, formatting, base conversions, and increment/decrement behavior
- fixes `Num` conversion helpers to use a valid array-size check instead of invalid static `Arr::count(...)` calls
- keeps the pass narrowly scoped to the existing `Num` surface

## Key files / areas touched (callouts)
- `SPEC.md` - scope and acceptance criteria for issue #97
- `src/Num.php` - low-risk fix in the conversion helper argument check path
- `tests/NumTest.php` - direct coverage for existing numeric helper behavior

## QA / Validation checklist
### Manual QA
- [ ] Review the `Num` helper changes for contract compatibility
- [ ] Confirm the implementation change is limited to the conversion helper argument check path

### Automated checks
- [x] Targeted numeric tests pass locally
- [x] Full PHPUnit suite passes locally

## Unit tests (specific)
- `vendor/bin/phpunit --do-not-cache-result tests/NumTest.php`
- `vendor/bin/phpunit --do-not-cache-result`

## Risk and rollout
- Risk level: low
- What could break?
  - Very little; the implementation change corrects an invalid static helper call in the conversion path.
- Backward compatibility notes:
  - This pass is intended to be non-breaking and mostly test-driven.
  - The `Num` code change fixes a defective internal call rather than altering public helper semantics.
- Rollback plan:
  - Revert this PR if any downstream consumer unexpectedly relied on the broken conversion path.

## Notes / discussion
This pass intentionally stops at `Num`. Other datatype sweeps should be separate if needed.
