### PR TITLE
Add Arr reverse helper

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -405,6 +405,23 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
     }
 
     /**
+     * Reverse the array.
+     *
+     * @param bool $preserve_keys Whether numeric keys should be preserved.
+     * @return IVal
+    */
+    public function _reverse(bool $preserve_keys = false): IVal
+    {
+        if (!$this->is($this->_data)) {
+            return $this;
+        }
+
+        $this->alter(array_reverse($this->_data, $preserve_keys));
+
+        return $this;
+    }
+
+    /**
      * get the largest integer value from an array
      * @return int
      */

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -116,6 +116,24 @@ class ArrTest extends ValTest {
 		$this->assertEquals(['foo', 'bar'], static::$classname::values(['first' => 'foo', 'second' => 'bar']));
 	}
 
+	public function testReversesValues()
+	{
+		$object = new static::$classname(['foo', 'bar', 'baz']);
+
+		$this->assertSame($object, $object->reverse());
+		$this->assertEquals(['baz', 'bar', 'foo'], $object->val());
+	}
+
+	public function testReversesValuesStatically()
+	{
+		$this->assertEquals(['baz', 'bar', 'foo'], static::$classname::reverse(['foo', 'bar', 'baz']));
+	}
+
+	public function testReversesAndPreservesNumericKeys()
+	{
+		$this->assertEquals([5 => 'five', 2 => 'two'], static::$classname::reverse([2 => 'two', 5 => 'five'], true));
+	}
+
 	public function testsRemovesDuplicates()
 	{
 		$object = new static::$classname(['foo', 'bar', 'foo']);


### PR DESCRIPTION
## Intent summary

Add an `Arr::reverse()` helper that mirrors PHP `array_reverse()` through DevElation's existing Arr dynamic helper surface.

## User stories / acceptance criteria

- As a DevElation consumer, I can call `Arr::reverse(['a', 'b', 'c'])` and receive `['c', 'b', 'a']`.
- As a DevElation consumer, I can call `Arr::reverse($array, true)` to preserve numeric keys.
- As a DevElation consumer, I can call `Arr::make($array)->reverse()->val()` and continue chaining Arr helpers.
- Existing Arr and value-object behavior remains unchanged.

## Key files changed

- `src/Arr.php`: adds `_reverse(bool $preserve_keys = false): IVal`.
- `tests/ArrTest.php`: adds instance, static, and preserve-key coverage.

## How to test

- `php -l src/Arr.php`
- `php -l tests/ArrTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/ArrTest.php`
- `vendor/bin/phpunit --do-not-cache-result`
- `composer validate --strict`
- `git diff --check`

## QA checklist

- [x] Instance helper returns the Arr object for chaining.
- [x] Static helper unwraps to the reversed PHP array.
- [x] Preserve-key behavior is covered.
- [x] Full PHPUnit suite passes locally.

## Approval conditions

- CI passes on the PR branch.
- Maintainer confirms mutating instance behavior matches Arr helper expectations.
- Maintainer confirms `preserve_keys` naming is acceptable for PHP-style parity.

Closes #104.

