### PR TITLE
Address helper API gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ A collection of wrapper classes around PHP's primitive data types that offer enh
 
 Static helpers: most `Val`/`Obj`-based classes expose their underscored instance helpers as static shorthand. For example, `Str` has an internal `_pluralize()` instance method which can be invoked statically via `Str::pluralize('comment')` thanks to `Val::__callStatic`. This pattern is used throughout the library and examples.
 
+Helper API notes:
+
+- Use `Arr::has($array, $value)` for value checks. Use `Arr::hasKey($array, $key)` for key checks, and `Arr::hasValue($array, $value, true)` or `Arr::contains($array, $value, true)` when strict value matching matters.
+- Use `Arr::merge($base, $next)` when associative keys should be replaced recursively and numeric list values should be appended when unique. Use `Arr::append($base, $next)` for append-only numeric list behavior.
+- Use `Str::strRepeat($value, $times)` as the canonical static helper for `str_repeat`-style behavior. Existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
+- `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without constructing a `FileSystem` helper directly. These checks do not create missing paths.
+
 ### DateTime Handling
 Sophisticated date and time manipulation with object-oriented principles, extending PHP's native `DateTime` class.
 

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -506,6 +506,7 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
         if (!$this->is($this->_data)) {
             return $this;
         }
+
         $array = $this->_data;
         foreach ($arrays as $arg) {
             if ($arg instanceof Arr) {
@@ -513,19 +514,41 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
             }
 
             if (is_array($arg)) {
-                foreach ($arg as $key => $value) {
-                    if (is_array($value) && isset($array[$key]) && is_array($array[$key])) {
-                        $array[$key] = $this->_merge($array[$key], $value);
-                    } elseif (is_numeric($key) && !in_array($value, $array)) {
-                        $array[] = $value;
-                    } else {
-                        $array[$key] = $value;
-                    }
-                }
+                $array = $this->mergeArrays($array, $arg);
             }
         }
 
+        $this->alter($array);
+
         return $this;
+    }
+
+    /**
+     * Recursively merge arrays using Arr::merge semantics.
+     *
+     * @param array $base
+     * @param array $incoming
+     * @return array
+     */
+    private function mergeArrays(array $base, array $incoming): array
+    {
+        foreach ($incoming as $key => $value) {
+            if (is_array($value) && isset($base[$key]) && is_array($base[$key])) {
+                $base[$key] = $this->mergeArrays($base[$key], $value);
+                continue;
+            }
+
+            if (is_numeric($key)) {
+                if (!in_array($value, $base)) {
+                    $base[] = $value;
+                }
+                continue;
+            }
+
+            $base[$key] = $value;
+        }
+
+        return $base;
     }
 
     /**

--- a/src/Data/Directory.php
+++ b/src/Data/Directory.php
@@ -5,6 +5,7 @@ namespace BlueFission\Data;
 use BlueFission\Collections\Hierarchical;
 use BlueFission\Collections\ICollection;
 use BlueFission\Data\IData;
+use BlueFission\Val;
 
 /**
  * Class Directory
@@ -35,5 +36,52 @@ abstract class Directory extends Hierarchical implements ICollection
     {
         parent::__construct(); // Call the parent constructor to set up hierarchy
         $this->_root = $storage; // Store the provided data backend
+    }
+
+    /**
+     * Check whether a filesystem directory target exists without creating it.
+     *
+     * @param string|null $path
+     * @return bool
+     */
+    public function exists(?string $path = null): bool
+    {
+        $target = $this->targetPath($path);
+
+        return Val::isNotNull($target) && is_dir($target);
+    }
+
+    /**
+     * Check whether a filesystem directory target exists and is readable.
+     *
+     * @param string|null $path
+     * @return bool
+     */
+    public function isReachable(?string $path = null): bool
+    {
+        $target = $this->targetPath($path);
+
+        return Val::isNotNull($target) && is_dir($target) && is_readable($target);
+    }
+
+    /**
+     * Resolve the explicit path or the hierarchical label path.
+     *
+     * @param string|null $path
+     * @return string|null
+     */
+    private function targetPath(?string $path = null): ?string
+    {
+        if (Val::isNotNull($path)) {
+            return $path;
+        }
+
+        $segments = array_filter($this->path(), fn ($segment) => Val::isNotNull($segment) && $segment !== '');
+
+        if (empty($segments)) {
+            return null;
+        }
+
+        return implode(DIRECTORY_SEPARATOR, $segments);
     }
 }

--- a/src/Data/File.php
+++ b/src/Data/File.php
@@ -64,6 +64,53 @@ class File extends Hierarchical implements IDispatcher
     }
 
     /**
+     * Check whether a filesystem file target exists without creating it.
+     *
+     * @param string|null $path
+     * @return bool
+     */
+    public function exists(?string $path = null): bool
+    {
+        $target = $this->targetPath($path);
+
+        return Val::isNotNull($target) && is_file($target);
+    }
+
+    /**
+     * Check whether a filesystem file target exists and is readable.
+     *
+     * @param string|null $path
+     * @return bool
+     */
+    public function isReachable(?string $path = null): bool
+    {
+        $target = $this->targetPath($path);
+
+        return Val::isNotNull($target) && is_file($target) && is_readable($target);
+    }
+
+    /**
+     * Resolve the explicit path or the hierarchical label path.
+     *
+     * @param string|null $path
+     * @return string|null
+     */
+    private function targetPath(?string $path = null): ?string
+    {
+        if (Val::isNotNull($path)) {
+            return $path;
+        }
+
+        $segments = array_filter($this->path(), fn ($segment) => Val::isNotNull($segment) && $segment !== '');
+
+        if (empty($segments)) {
+            return null;
+        }
+
+        return implode(static::PATH_SEPARATOR, $segments);
+    }
+
+    /**
      * Append content to the file.
      *
      * @param string $data Content to append.

--- a/src/Str.php
+++ b/src/Str.php
@@ -299,6 +299,17 @@ class Str extends Val implements IVal {
 	}
 
 	/**
+	 * Canonical PHP-style alias for repeating the current string.
+	 *
+	 * @param int $times The number of times to repeat the string
+	 *
+	 * @return IVal
+	 */
+	public function _strRepeat(int $times): IVal {
+		return $this->_repeat($times);
+	}
+
+	/**
 	 * Append a value to the end of the current string.
 	 *
 	 * @param mixed $suffix

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -116,6 +116,21 @@ class ArrTest extends ValTest {
 		$this->assertEquals(['foo', 'bar'], static::$classname::values(['first' => 'foo', 'second' => 'bar']));
 	}
 
+	public function testMergePreservesListAppendsStatically()
+	{
+		$this->assertEquals(['foo', 'bar'], static::$classname::merge(['foo'], ['bar']));
+	}
+
+	public function testMergeRecursesAssociativeArraysAndAppendsNestedLists()
+	{
+		$merged = static::$classname::merge(
+			['meta' => ['tags' => ['alpha'], 'status' => 'draft']],
+			['meta' => ['tags' => ['beta'], 'status' => 'ready']]
+		);
+
+		$this->assertEquals(['meta' => ['tags' => ['alpha', 'beta'], 'status' => 'ready']], $merged);
+	}
+
 	public function testsRemovesDuplicates()
 	{
 		$object = new static::$classname(['foo', 'bar', 'foo']);

--- a/tests/Data/FileDirectoryExistenceTest.php
+++ b/tests/Data/FileDirectoryExistenceTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace BlueFission\Tests\Data;
+
+use BlueFission\Data\Directory;
+use BlueFission\Data\File;
+use BlueFission\Data\FileSystem;
+use BlueFission\Tests\Support\TestEnvironment;
+
+require_once __DIR__ . '/../Support/TestEnvironment.php';
+
+class FileDirectoryExistenceTest extends \PHPUnit\Framework\TestCase
+{
+    private string $testdirectory;
+
+    public function setUp(): void
+    {
+        $this->testdirectory = TestEnvironment::tempDir('bf_file_dir_exists');
+    }
+
+    public function tearDown(): void
+    {
+        TestEnvironment::removeDir($this->testdirectory);
+    }
+
+    public function testFileReportsExistingAndMissingPathsWithoutCreatingFiles()
+    {
+        $path = $this->testdirectory . DIRECTORY_SEPARATOR . 'sample.txt';
+        $missing = $this->testdirectory . DIRECTORY_SEPARATOR . 'missing.txt';
+        touch($path);
+
+        $file = new File();
+
+        $this->assertTrue($file->exists($path));
+        $this->assertTrue($file->isReachable($path));
+        $this->assertFalse($file->exists($missing));
+        $this->assertFalse($file->isReachable($missing));
+        $this->assertFileDoesNotExist($missing);
+    }
+
+    public function testFileCanUseItsHierarchicalLabelAsPath()
+    {
+        $path = $this->testdirectory . DIRECTORY_SEPARATOR . 'labelled.txt';
+        touch($path);
+
+        $file = new File();
+        $file->label($path);
+
+        $this->assertTrue($file->exists());
+    }
+
+    public function testDirectoryReportsExistingAndMissingPathsWithoutCreatingDirectories()
+    {
+        $missing = $this->testdirectory . DIRECTORY_SEPARATOR . 'missing';
+        $directory = new class(new FileSystem(['root' => $this->testdirectory, 'filter' => []])) extends Directory {};
+
+        $this->assertTrue($directory->exists($this->testdirectory));
+        $this->assertTrue($directory->isReachable($this->testdirectory));
+        $this->assertFalse($directory->exists($missing));
+        $this->assertFalse($directory->isReachable($missing));
+        $this->assertDirectoryDoesNotExist($missing);
+    }
+
+    public function testDirectoryCanUseItsHierarchicalLabelAsPath()
+    {
+        $directory = new class(new FileSystem(['root' => $this->testdirectory, 'filter' => []])) extends Directory {};
+        $directory->label($this->testdirectory);
+
+        $this->assertTrue($directory->exists());
+    }
+}

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -143,6 +143,20 @@ class StrTest extends ValTest {
 		$this->assertFalse(Str::contains('orchestrate', 'matrix'));
 	}
 
+	public function testStrRepeatProvidesCanonicalStaticHelper()
+	{
+		$this->assertSame('ababab', Str::strRepeat('ab', 3));
+		$this->assertSame('', Str::strRepeat('ab', 0));
+	}
+
+	public function testStrRepeatInstanceAliasKeepsRepeatBehavior()
+	{
+		$object = new Str('ha');
+
+		$this->assertSame($object, $object->strRepeat(2));
+		$this->assertSame('haha', $object->val());
+	}
+
 	public function testAppendPrependAndConcatMutateString()
 	{
 		$object = new Str('john');


### PR DESCRIPTION
## Intent summary

Address bounded helper API requests from Keryx suggestions #149, #146, and #49.

This PR adds safe File/Directory existence helpers, documents canonical helper semantics, adds `Str::strRepeat()`, and fixes `Arr::merge()` so static list-style merges preserve appended values.

## User stories / acceptance criteria

- As a downstream library maintainer, I can call `File::exists()` / `File::isReachable()` or `Directory::exists()` / `Directory::isReachable()` without constructing `FileSystem` manually.
- As a downstream library maintainer, I can use `Str::strRepeat($value, $times)` instead of raw `str_repeat()`.
- As an Arr helper consumer, I can call `Arr::merge(['foo'], ['bar'])` and get `['foo', 'bar']`.
- As a developer reading docs, I can distinguish `Arr::has()` value checks from `Arr::hasKey()` key checks.

## Key files changed

- `src/Arr.php`: fixes recursive merge behavior and writes merged results back to the value object.
- `src/Str.php`: adds `_strRepeat()` as a canonical alias over `_repeat()`.
- `src/Data/File.php`: adds `exists()` and `isReachable()`.
- `src/Data/Directory.php`: adds `exists()` and `isReachable()`.
- `README.md`: documents helper API semantics.
- `tests/ArrTest.php`, `tests/StrTest.php`, `tests/Data/FileDirectoryExistenceTest.php`: add regression coverage.

## How to test

- `php -l src/Arr.php`
- `php -l src/Str.php`
- `php -l src/Data/File.php`
- `php -l src/Data/Directory.php`
- `php -l tests/Data/FileDirectoryExistenceTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/ArrTest.php tests/StrTest.php tests/Data/FileDirectoryExistenceTest.php`
- `vendor/bin/phpunit --do-not-cache-result`
- `composer validate --strict`
- `git diff --check`

## QA checklist

- [x] File/Directory existence checks do not create missing paths.
- [x] File/Directory reachability checks require readable existing targets.
- [x] `Str::strRepeat()` supports normal and zero repeat counts.
- [x] `Arr::merge()` preserves static list-style appends and recursive associative replacement.
- [x] Full PHPUnit suite passes locally.

## Approval conditions

- CI passes on the PR branch.
- Maintainer confirms `Str::strRepeat()` is the desired canonical static alias.
- Maintainer confirms `Arr::merge()` recursive list semantics match downstream expectations.

Closes #106.

