### PR TITLE
Add recursive array merge helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Helper API notes:
 
 - Use `Arr::has($array, $value)` for value checks. Use `Arr::hasKey($array, $key)` for key checks, and `Arr::hasValue($array, $value, true)` or `Arr::contains($array, $value, true)` when strict value matching matters.
 - Use `Arr::merge($base, $next)` when associative keys should be replaced recursively and numeric list values should be appended when unique. Use `Arr::append($base, $next)` for append-only numeric list behavior.
+- Use `Arr::mergeConfig($base, $next)` for configuration arrays where associative keys should be replaced recursively and numeric lists should append in order while preserving duplicates.
 - Use `Str::strRepeat($value, $times)` as the canonical static helper for `str_repeat`-style behavior. Existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
 - `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without constructing a `FileSystem` helper directly. These checks do not create missing paths.
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Helper API notes:
 
 - Use `Arr::has($array, $value)` for value checks. Use `Arr::hasKey($array, $key)` for key checks, and `Arr::hasValue($array, $value, true)` or `Arr::contains($array, $value, true)` when strict value matching matters.
 - Use `Arr::merge($base, $next)` when associative keys should be replaced recursively and numeric list values should be appended when unique. Use `Arr::append($base, $next)` for append-only numeric list behavior.
-- Use `Arr::mergeConfig($base, $next)` for configuration arrays where associative keys should be replaced recursively and numeric lists should append in order while preserving duplicates.
-- Use `Str::strRepeat($value, $times)` as the canonical static helper for `str_repeat`-style behavior. Existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
+- Use `Arr::mergeRecursive($base, $next)` when associative keys should be replaced recursively and numeric lists should append in order while preserving duplicates.
+- Use `Str::repeat($value, $times)` as the canonical static helper for `str_repeat`-style behavior. Existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
 - `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without constructing a `FileSystem` helper directly. These checks do not create missing paths.
 
 ### DateTime Handling

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -569,6 +569,83 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
     }
 
     /**
+     * Merge configuration arrays recursively while preserving list semantics.
+     *
+     * Associative keys are replaced recursively. List values are appended in
+     * order and duplicates are preserved.
+     *
+     * @param array|Arr ...$arrays
+     * @return IVal
+     */
+    public function _mergeConfig(...$arrays): IVal
+    {
+        if (!$this->is($this->_data)) {
+            return $this;
+        }
+
+        $array = $this->_data;
+        foreach ($arrays as $arg) {
+            if ($arg instanceof Arr) {
+                $arg = $arg->toArray();
+            }
+
+            if (is_array($arg)) {
+                $array = $this->mergeConfigArrays($array, $arg);
+            }
+        }
+
+        $this->alter($array);
+
+        return $this;
+    }
+
+    /**
+     * Recursively merge arrays using configuration semantics.
+     *
+     * @param array $base
+     * @param array $incoming
+     * @return array
+     */
+    private function mergeConfigArrays(array $base, array $incoming): array
+    {
+        if (array_is_list($base) && array_is_list($incoming)) {
+            return array_merge($base, $incoming);
+        }
+
+        foreach ($incoming as $key => $value) {
+            if (array_key_exists($key, $base)) {
+                $base[$key] = $this->mergeConfigValue($base[$key], $value);
+                continue;
+            }
+
+            if (is_int($key)) {
+                $base[] = $value;
+                continue;
+            }
+
+            $base[$key] = $value;
+        }
+
+        return $base;
+    }
+
+    /**
+     * Merge one configuration value into another.
+     *
+     * @param mixed $base
+     * @param mixed $incoming
+     * @return mixed
+     */
+    private function mergeConfigValue(mixed $base, mixed $incoming): mixed
+    {
+        if (is_array($base) && is_array($incoming)) {
+            return $this->mergeConfigArrays($base, $incoming);
+        }
+
+        return $incoming;
+    }
+
+    /**
      * Appends other arrays to local $_data array
      * @param array ...$arrays
      *

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -569,7 +569,7 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Merge configuration arrays recursively while preserving list semantics.
+     * Merge arrays recursively while preserving list semantics.
      *
      * Associative keys are replaced recursively. List values are appended in
      * order and duplicates are preserved.
@@ -577,7 +577,7 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
      * @param array|Arr ...$arrays
      * @return IVal
      */
-    public function _mergeConfig(...$arrays): IVal
+    public function _mergeRecursive(...$arrays): IVal
     {
         if (!$this->is($this->_data)) {
             return $this;
@@ -590,7 +590,7 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
             }
 
             if (is_array($arg)) {
-                $array = $this->mergeConfigArrays($array, $arg);
+                $array = $this->mergeRecursiveArrays($array, $arg);
             }
         }
 
@@ -600,13 +600,13 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Recursively merge arrays using configuration semantics.
+     * Recursively merge arrays while appending list values.
      *
      * @param array $base
      * @param array $incoming
      * @return array
      */
-    private function mergeConfigArrays(array $base, array $incoming): array
+    private function mergeRecursiveArrays(array $base, array $incoming): array
     {
         if (array_is_list($base) && array_is_list($incoming)) {
             return array_merge($base, $incoming);
@@ -614,7 +614,7 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
 
         foreach ($incoming as $key => $value) {
             if (array_key_exists($key, $base)) {
-                $base[$key] = $this->mergeConfigValue($base[$key], $value);
+                $base[$key] = $this->mergeRecursiveValue($base[$key], $value);
                 continue;
             }
 
@@ -630,16 +630,16 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Merge one configuration value into another.
+     * Merge one recursive value into another.
      *
      * @param mixed $base
      * @param mixed $incoming
      * @return mixed
      */
-    private function mergeConfigValue(mixed $base, mixed $incoming): mixed
+    private function mergeRecursiveValue(mixed $base, mixed $incoming): mixed
     {
         if (is_array($base) && is_array($incoming)) {
-            return $this->mergeConfigArrays($base, $incoming);
+            return $this->mergeRecursiveArrays($base, $incoming);
         }
 
         return $incoming;

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -131,6 +131,80 @@ class ArrTest extends ValTest {
 		$this->assertEquals(['meta' => ['tags' => ['alpha', 'beta'], 'status' => 'ready']], $merged);
 	}
 
+	public function testMergeConfigReplacesNestedAssociativeValues()
+	{
+		$merged = static::$classname::mergeConfig(
+			['db' => ['host' => 'localhost', 'options' => ['timeout' => 10]]],
+			['db' => ['host' => 'mysql', 'options' => ['charset' => 'utf8mb4']]]
+		);
+
+		$this->assertEquals(
+			['db' => ['host' => 'mysql', 'options' => ['timeout' => 10, 'charset' => 'utf8mb4']]],
+			$merged
+		);
+	}
+
+	public function testMergeConfigAppendsNumericListsAndPreservesDuplicates()
+	{
+		$merged = static::$classname::mergeConfig(
+			['middleware' => ['auth', 'csrf']],
+			['middleware' => ['csrf', 'audit']]
+		);
+
+		$this->assertEquals(['middleware' => ['auth', 'csrf', 'csrf', 'audit']], $merged);
+	}
+
+	public function testMergeConfigHandlesMixedConfigPayloads()
+	{
+		$merged = static::$classname::mergeConfig(
+			[
+				'routes' => [
+					['method' => 'GET', 'path' => '/health'],
+				],
+				'cache' => [
+					'stores' => [
+						'array' => ['driver' => 'array'],
+					],
+				],
+			],
+			[
+				'routes' => [
+					['method' => 'POST', 'path' => '/jobs'],
+				],
+				'cache' => [
+					'stores' => [
+						'redis' => ['driver' => 'redis'],
+					],
+				],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				'routes' => [
+					['method' => 'GET', 'path' => '/health'],
+					['method' => 'POST', 'path' => '/jobs'],
+				],
+				'cache' => [
+					'stores' => [
+						'array' => ['driver' => 'array'],
+						'redis' => ['driver' => 'redis'],
+					],
+				],
+			],
+			$merged
+		);
+	}
+
+	public function testMergeConfigWorksOnInstanceWithArrArguments()
+	{
+		$object = new static::$classname(['features' => ['alpha']]);
+		$next = static::$classname::make(['features' => ['beta']]);
+
+		$this->assertSame($object, $object->mergeConfig($next));
+		$this->assertEquals(['features' => ['alpha', 'beta']], $object->val());
+	}
+
 	public function testReversesValues()
 	{
 		$object = new static::$classname(['foo', 'bar', 'baz']);

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -131,9 +131,9 @@ class ArrTest extends ValTest {
 		$this->assertEquals(['meta' => ['tags' => ['alpha', 'beta'], 'status' => 'ready']], $merged);
 	}
 
-	public function testMergeConfigReplacesNestedAssociativeValues()
+	public function testMergeRecursiveReplacesNestedAssociativeValues()
 	{
-		$merged = static::$classname::mergeConfig(
+		$merged = static::$classname::mergeRecursive(
 			['db' => ['host' => 'localhost', 'options' => ['timeout' => 10]]],
 			['db' => ['host' => 'mysql', 'options' => ['charset' => 'utf8mb4']]]
 		);
@@ -144,9 +144,9 @@ class ArrTest extends ValTest {
 		);
 	}
 
-	public function testMergeConfigAppendsNumericListsAndPreservesDuplicates()
+	public function testMergeRecursiveAppendsNumericListsAndPreservesDuplicates()
 	{
-		$merged = static::$classname::mergeConfig(
+		$merged = static::$classname::mergeRecursive(
 			['middleware' => ['auth', 'csrf']],
 			['middleware' => ['csrf', 'audit']]
 		);
@@ -154,9 +154,9 @@ class ArrTest extends ValTest {
 		$this->assertEquals(['middleware' => ['auth', 'csrf', 'csrf', 'audit']], $merged);
 	}
 
-	public function testMergeConfigHandlesMixedConfigPayloads()
+	public function testMergeRecursiveHandlesMixedPayloads()
 	{
-		$merged = static::$classname::mergeConfig(
+		$merged = static::$classname::mergeRecursive(
 			[
 				'routes' => [
 					['method' => 'GET', 'path' => '/health'],
@@ -196,12 +196,12 @@ class ArrTest extends ValTest {
 		);
 	}
 
-	public function testMergeConfigWorksOnInstanceWithArrArguments()
+	public function testMergeRecursiveWorksOnInstanceWithArrArguments()
 	{
 		$object = new static::$classname(['features' => ['alpha']]);
 		$next = static::$classname::make(['features' => ['beta']]);
 
-		$this->assertSame($object, $object->mergeConfig($next));
+		$this->assertSame($object, $object->mergeRecursive($next));
 		$this->assertEquals(['features' => ['alpha', 'beta']], $object->val());
 	}
 


### PR DESCRIPTION
## Intent summary

Add `Arr::mergeRecursive()` for recursive array merges where associative keys replace recursively and numeric lists append in order while preserving duplicates.

Closes #108.

## User stories / acceptance criteria

- As a PHP developer, I can merge nested arrays without sparse numeric-list replacement.
- As a DevElation consumer, I can choose between `Arr::merge()` for unique numeric appends, `Arr::append()` for append-only numeric behavior, and `Arr::mergeRecursive()` for duplicate-preserving recursive list merges.
- Nested associative replacement, numeric list appends, mixed payloads, and instance/static usage are covered by tests.

## Key files changed

- `src/Arr.php`: adds `mergeRecursive` dynamic helper and private recursive merge helpers.
- `tests/ArrTest.php`: adds coverage for nested replacement, list append semantics, duplicate preservation, mixed payloads, and `Arr` argument handling.
- `README.md`: documents when to use `Arr::mergeRecursive()` and corrects the repeat helper reference.

## How to test

- `php -l src/Arr.php`
- `php -l tests/ArrTest.php`
- `composer validate --strict`
- `vendor/bin/phpunit --do-not-cache-result tests/ArrTest.php`
- `git diff --check`

Note: a local full-suite retry progressed into the broader suite but exceeded the local 20-minute command timeout. GitHub Actions is the full-suite gate for this update.

## QA checklist

- [x] Nested associative keys replace recursively.
- [x] Numeric lists append in order.
- [x] Duplicate list entries are preserved.
- [x] Existing `Arr::merge()` behavior is unchanged.
- [x] Focused PHPUnit suite passes locally.
- [x] GitHub Actions pass on the PR branch after review updates.

## Approval conditions

- Maintainers agree `mergeRecursive` is the right helper name.
- Maintainers agree duplicate-preserving list append is the expected recursive merge behavior.
- CI passes on the PR branch.
