### PR TITLE
Add safe FileSystem file existence helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Helper API notes:
 - Use `Arr::has($array, $value)` for value checks. Use `Arr::hasKey($array, $key)` for key checks, and `Arr::hasValue($array, $value, true)` or `Arr::contains($array, $value, true)` when strict value matching matters.
 - Use `Arr::merge($base, $next)` when associative keys should be replaced recursively and numeric list values should be appended when unique. Use `Arr::append($base, $next)` for append-only numeric list behavior.
 - Use `Str::strRepeat($value, $times)` as the canonical static helper for `str_repeat`-style behavior. Existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
-- `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without constructing a `FileSystem` helper directly. These checks do not create missing paths.
+- `BlueFission\Data\FileSystem::fileExists($path)` checks concrete file paths without initializing storage state. `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without creating missing paths.
 
 ### DateTime Handling
 Sophisticated date and time manipulation with object-oriented principles, extending PHP's native `DateTime` class.

--- a/src/Data/FileSystem.php
+++ b/src/Data/FileSystem.php
@@ -582,6 +582,24 @@ class FileSystem extends Data implements IData {
 	}
 
 	/**
+	 * Check whether a concrete file path exists without initializing storage state.
+	 *
+	 * @param string|null $path
+	 * @return bool
+	 */
+	public static function fileExists(?string $path): bool
+	{
+		if (Val::isNull($path) || $path === '') {
+			return (bool)Dev::apply('_out', false);
+		}
+
+		$path = Dev::apply('_in', $path);
+		$exists = is_string($path) && is_file($path);
+
+		return (bool)Dev::apply('_out', $exists);
+	}
+
+	/**
 	 * Upload a file
 	 * 
 	 * @param array $document The file to be uploaded

--- a/tests/Data/FileSystemTest.php
+++ b/tests/Data/FileSystemTest.php
@@ -61,4 +61,16 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertTrue(file_exists($this->testdirectory.DIRECTORY_SEPARATOR.'testfile.txt'));
 	}
+
+	public function testStaticFileExistsChecksConcretePathWithoutConstructingStorage()
+	{
+		$path = $this->testdirectory.DIRECTORY_SEPARATOR.'wrapper.php';
+		$missing = $this->testdirectory.DIRECTORY_SEPARATOR.'missing.php';
+		touch($path);
+
+		$this->assertTrue(FileSystem::fileExists($path));
+		$this->assertFalse(FileSystem::fileExists($missing));
+		$this->assertFalse(FileSystem::fileExists($this->testdirectory));
+		$this->assertFileDoesNotExist($missing);
+	}
 }


### PR DESCRIPTION
## Intent summary

Add `FileSystem::fileExists()` as a static, side-effect-free helper for concrete file path existence checks.

Closes #114.

## User stories / acceptance criteria

- As a PHP developer, I can check whether a concrete wrapper or script file exists without instantiating storage state.
- Existing files return `true`; missing files return `false`.
- Directories do not pass the file helper.
- The helper applies DevElation input/output filters and does not create missing paths.

## Key files changed

- `src/Data/FileSystem.php`: adds the static `fileExists()` helper.
- `tests/Data/FileSystemTest.php`: covers existing, missing, and directory paths.
- `README.md`: documents the safe static file path check alongside file/directory instance helpers.

## How to test

- `php -l src/Data/FileSystem.php`
- `php -l tests/Data/FileSystemTest.php`
- `composer validate --strict`
- `vendor/bin/phpunit --do-not-cache-result tests/Data/FileSystemTest.php tests/Data/FileDirectoryExistenceTest.php`
- `git diff --check`

## QA checklist

- [x] Static usage does not instantiate `FileSystem`.
- [x] Existing concrete files return `true`.
- [x] Missing files return `false`.
- [x] Directories return `false`.
- [x] Missing paths are not created.
- [x] GitHub Actions pass on the PR branch.

## Approval conditions

- Maintainers agree `fileExists` is the right helper name for concrete file checks.
- CI passes on the PR branch.
