### PR TITLE
Add HTTP path segment helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Helper API notes:
 
 - Use `Arr::has($array, $value)` for value checks. Use `Arr::hasKey($array, $key)` for key checks, and `Arr::hasValue($array, $value, true)` or `Arr::contains($array, $value, true)` when strict value matching matters.
 - Use `Arr::merge($base, $next)` when associative keys should be replaced recursively and numeric list values should be appended when unique. Use `Arr::append($base, $next)` for append-only numeric list behavior.
+- Use `Arr::values($array)` to reindex list values while preserving order, and `BlueFission\Net\HTTP::pathSegment($segment)` to encode a single URL path segment.
 - Use `Str::strRepeat($value, $times)` as the canonical static helper for `str_repeat`-style behavior. Existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
 - `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without constructing a `FileSystem` helper directly. These checks do not create missing paths.
 

--- a/src/Net/HTTP.php
+++ b/src/Net/HTTP.php
@@ -13,6 +13,19 @@ use BlueFission\Num;
 class HTTP {
 
 	/**
+	 * Encode a single URL path segment.
+	 *
+	 * @param string $segment
+	 * @return string
+	 */
+	static function pathSegment(string $segment): string
+	{
+		$segment = trim(trim($segment), '/');
+
+		return rawurlencode($segment);
+	}
+
+	/**
 	 * Query function to build a query string from an array of key-value pairs
 	 * 
 	 * @param array $formdata An array of key-value pairs to be used as the query

--- a/tests/Net/HTTPTest.php
+++ b/tests/Net/HTTPTest.php
@@ -9,6 +9,15 @@ require_once __DIR__ . '/../Support/TestEnvironment.php';
 
 class HTTPTest extends TestCase {
 
+    public function testPathSegmentEncodesReservedCharacters() {
+        $this->assertSame('tenant%2Fwith%3Freserved%23chars', HTTP::pathSegment('tenant/with?reserved#chars'));
+    }
+
+    public function testPathSegmentTrimsWhitespaceAndPathSeparators() {
+        $this->assertSame('tenant%20id', HTTP::pathSegment(' /tenant id/ '));
+        $this->assertSame('', HTTP::pathSegment(' / '));
+    }
+
     public function testQuery() {
         $formdata = [
             'key1' => 'value1',


### PR DESCRIPTION
## Intent summary

Add `HTTP::pathSegment()` for encoding a single URL path segment, and document the existing `Arr::values()` helper path for list reindexing.

Closes #115.

## User stories / acceptance criteria

- As a PHP developer, I can encode a URL path segment without calling `rawurlencode()` directly.
- Reserved path characters are encoded instead of treated as separators or query/fragment syntax.
- Whitespace and wrapper slashes around a segment are trimmed consistently.
- `Arr::values()` is documented as the list reindexing helper already available on `master`.

## Key files changed

- `src/Net/HTTP.php`: adds `HTTP::pathSegment()`.
- `tests/Net/HTTPTest.php`: covers reserved-character encoding and trimming.
- `README.md`: documents `Arr::values()` and `HTTP::pathSegment()` in helper notes.

## How to test

- `php -l src/Net/HTTP.php`
- `php -l tests/Net/HTTPTest.php`
- `composer validate --strict`
- `vendor/bin/phpunit --do-not-cache-result tests/Net/HTTPTest.php`
- `git diff --check`

## QA checklist

- [x] Reserved path characters are encoded.
- [x] Leading/trailing whitespace is trimmed.
- [x] Leading/trailing path separators are trimmed for a single segment.
- [x] Focused HTTP tests pass locally.
- [x] GitHub Actions pass on the PR branch.

## Approval conditions

- Maintainers agree `pathSegment` is the right helper name and trim behavior.
- CI passes on the PR branch.
