### PR TITLE
Fix Collection filter constant lookup

### DIFF
--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -349,7 +349,7 @@ class Collection implements ICollection, ArrayAccess, IteratorAggregate {
 		$reflectionFunction = new \ReflectionFunction($callback);
 		$numberOfParameters = $reflectionFunction->getNumberOfRequiredParameters();
 
-		$filterOption = $numberOfParameters > 1 ? ARRAY_FILTER_USE_BOTH : 0;
+		$filterOption = $numberOfParameters > 1 ? \ARRAY_FILTER_USE_BOTH : 0;
 
 		$list = array_filter( $this->contents(), $callback, $filterOption );
 		return new Collection( $list );

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -70,4 +70,26 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(4, $i);
     }
+
+    public function testFilterUsesValueCallback()
+    {
+        $object = new Collection([1, 2, 3]);
+
+        $filtered = $object->filter(fn ($value) => $value > 1);
+
+        $this->assertEquals([1 => 2, 2 => 3], $filtered->toArray());
+    }
+
+    public function testFilterUsesValueAndKeyCallback()
+    {
+        $object = new Collection([
+            'first' => 1,
+            'second' => 2,
+            'third' => 3,
+        ]);
+
+        $filtered = $object->filter(fn ($value, $key) => $value > 1 && $key !== 'second');
+
+        $this->assertEquals(['third' => 3], $filtered->toArray());
+    }
 }


### PR DESCRIPTION
## Intent summary

Fix `Collection::filter()` so it uses PHP's global `ARRAY_FILTER_USE_BOTH` constant instead of resolving the constant inside the `BlueFission\Collections` namespace.

## User stories / acceptance criteria

- As a consumer, I can call `Collection::filter()` with a value-only callback without native PHP constant lookup failures.
- As a consumer, I can call `Collection::filter()` with a value/key callback and receive both arguments.
- Callers can safely replace common `array_filter()` usage with `Collection::filter()`.

Closes #121.

## Key files changed

- `src/Collections/Collection.php`
- `tests/Collections/CollectionTest.php`

## How to test

- `php -l src\Collections\Collection.php`
- `php -l tests\Collections\CollectionTest.php`
- `.\vendor\bin\phpunit.bat --do-not-cache-result tests\Collections\CollectionTest.php`
- `composer validate --strict`
- `git diff --check`

## QA checklist

- [x] Global PHP constant is explicitly referenced.
- [x] Value-only callback behavior is covered.
- [x] Value/key callback behavior is covered.
- [x] Existing Collection behavior remains focused and unchanged outside filtering.

## Approval conditions

- CI passes across the PHP matrix.
- Review confirms the helper keeps existing key-preserving `array_filter()` behavior.

## Notes

The full local PHPUnit suite was started but exceeded a five-minute local timeout after reaching 189 of 675 tests. The focused Collection suite passed and CI should provide full-matrix coverage.
