### PR TITLE
Add string match ignore-case mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Helper API notes:
 - Use `Arr::values($array)` to reindex list values while preserving order, and `BlueFission\Net\HTTP::pathSegment($segment)` to encode a single URL path segment.
 - Use `Arr::mergeRecursive($base, $next)` when associative keys should be replaced recursively and numeric lists should append in order while preserving duplicates.
 - Use `Str::repeat($value, $times)` as the canonical static helper for `str_repeat`-style behavior. Existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
+- Use `Str::equalsIgnoreCase($left, $right)` for case-insensitive equality checks. Values are string-cast before comparison and whitespace remains significant.
 - `BlueFission\Data\FileSystem::fileExists($path)` checks concrete file paths without initializing storage state. `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without creating missing paths.
 
 ### DateTime Handling

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Helper API notes:
 - Use `Arr::values($array)` to reindex list values while preserving order, and `BlueFission\Net\HTTP::pathSegment($segment)` to encode a single URL path segment.
 - Use `Arr::mergeRecursive($base, $next)` when associative keys should be replaced recursively and numeric lists should append in order while preserving duplicates.
 - Use `Str::repeat($value, $times)` as the canonical static helper for `str_repeat`-style behavior. Existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
-- Use `Str::equalsIgnoreCase($left, $right)` for case-insensitive equality checks. Values are string-cast before comparison and whitespace remains significant.
+- Use `Str::match($left, $right, Str::IGNORE_CASE)` for case-insensitive equality checks. Values are string-cast before comparison and whitespace remains significant.
 - `BlueFission\Data\FileSystem::fileExists($path)` checks concrete file paths without initializing storage state. `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without creating missing paths.
 
 ### DateTime Handling

--- a/src/Str.php
+++ b/src/Str.php
@@ -169,6 +169,19 @@ class Str extends Val implements IVal {
 	}
 
 	/**
+	 * Check if the current string equals another string, ignoring ASCII case.
+	 *
+	 * Values are string-cast before comparison. Whitespace remains significant.
+	 *
+	 * @param string $string The string to compare with
+	 * @return bool
+	 */
+	public function _equalsIgnoreCase(string $string): bool
+	{
+		return strcasecmp((string)$this->_data, (string)$string) === 0;
+	}
+
+	/**
 	 * Encrypt a string
 	 *
 	 * @param string $mode The encryption mode to use. Can be 'md5' or 'sha1'. Default is 'md5'

--- a/src/Str.php
+++ b/src/Str.php
@@ -21,6 +21,20 @@ class Str extends Val implements IVal {
      */
     const SHA = 'sha1';
 
+	/**
+	 * Default exact match mode.
+	 *
+	 * @var int
+	 */
+	const MATCH_EXACT = 0;
+
+	/**
+	 * Case-insensitive match mode.
+	 *
+	 * @var int
+	 */
+	const IGNORE_CASE = 1;
+
     /**
 	 * Constructor to initialize value of the class
 	 *
@@ -159,26 +173,20 @@ class Str extends Val implements IVal {
 	 * Check if the current string matches the input string
 	 *
 	 * @param string $str2 The string to compare with the current string
+	 * @param int $mode The match mode. Use Str::IGNORE_CASE for case-insensitive comparison.
 	 *
 	 * @return bool True if the two strings match, false otherwise
 	 */
-	public function _match(string $str2): bool
+	public function _match(string $str2, int $mode = self::MATCH_EXACT): bool
 	{
-		$str1 = $this->_data;
-		return ($str1 == $str2);
-	}
+		$str1 = (string)$this->_data;
+		$str2 = (string)$str2;
 
-	/**
-	 * Check if the current string equals another string, ignoring ASCII case.
-	 *
-	 * Values are string-cast before comparison. Whitespace remains significant.
-	 *
-	 * @param string $string The string to compare with
-	 * @return bool
-	 */
-	public function _equalsIgnoreCase(string $string): bool
-	{
-		return strcasecmp((string)$this->_data, (string)$string) === 0;
+		if (($mode & self::IGNORE_CASE) === self::IGNORE_CASE) {
+			return strcasecmp($str1, $str2) === 0;
+		}
+
+		return ($str1 == $str2);
 	}
 
 	/**

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -157,25 +157,25 @@ class StrTest extends ValTest {
 		$this->assertSame('haha', $object->val());
 	}
 
-	public function testEqualsIgnoreCaseComparesStringsWithoutMutating()
+	public function testMatchSupportsIgnoreCaseMode()
 	{
 		$object = new Str('Content-Type');
 
-		$this->assertTrue($object->equalsIgnoreCase('content-type'));
+		$this->assertTrue($object->match('content-type', Str::IGNORE_CASE));
 		$this->assertSame('Content-Type', $object->val());
-		$this->assertTrue(Str::equalsIgnoreCase('ACCEPT', 'accept'));
-		$this->assertFalse(Str::equalsIgnoreCase('Accept', 'Accept-Encoding'));
+		$this->assertTrue(Str::match('ACCEPT', 'accept', Str::IGNORE_CASE));
+		$this->assertFalse(Str::match('Accept', 'Accept-Encoding', Str::IGNORE_CASE));
 	}
 
-	public function testEqualsIgnoreCaseKeepsWhitespaceSignificant()
+	public function testMatchIgnoreCaseKeepsWhitespaceSignificant()
 	{
-		$this->assertFalse(Str::equalsIgnoreCase('Accept', ' accept '));
+		$this->assertFalse(Str::match('Accept', ' accept ', Str::IGNORE_CASE));
 	}
 
-	public function testEqualsIgnoreCaseCastsInputValues()
+	public function testMatchCastsInputValues()
 	{
-		$this->assertTrue(Str::equalsIgnoreCase(123, '123'));
-		$this->assertFalse(Str::equalsIgnoreCase('', 0));
+		$this->assertTrue(Str::match(123, '123'));
+		$this->assertFalse(Str::match('', 0));
 	}
 
 	public function testAppendPrependAndConcatMutateString()

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -157,6 +157,27 @@ class StrTest extends ValTest {
 		$this->assertSame('haha', $object->val());
 	}
 
+	public function testEqualsIgnoreCaseComparesStringsWithoutMutating()
+	{
+		$object = new Str('Content-Type');
+
+		$this->assertTrue($object->equalsIgnoreCase('content-type'));
+		$this->assertSame('Content-Type', $object->val());
+		$this->assertTrue(Str::equalsIgnoreCase('ACCEPT', 'accept'));
+		$this->assertFalse(Str::equalsIgnoreCase('Accept', 'Accept-Encoding'));
+	}
+
+	public function testEqualsIgnoreCaseKeepsWhitespaceSignificant()
+	{
+		$this->assertFalse(Str::equalsIgnoreCase('Accept', ' accept '));
+	}
+
+	public function testEqualsIgnoreCaseCastsInputValues()
+	{
+		$this->assertTrue(Str::equalsIgnoreCase(123, '123'));
+		$this->assertFalse(Str::equalsIgnoreCase('', 0));
+	}
+
 	public function testAppendPrependAndConcatMutateString()
 	{
 		$object = new Str('john');


### PR DESCRIPTION
## Intent summary

Add a first-party case-insensitive mode for `Str::match()` using `Str::IGNORE_CASE`, keeping string equality behavior under the existing `match` naming convention.

## User stories / acceptance criteria

- As a consumer, I can compare header-style strings without calling native `strcasecmp()` directly.
- The helper remains `Str::match()` instead of introducing a separate equality method.
- `Str::IGNORE_CASE` provides an explicit mode for case-insensitive comparison.
- Values are string-cast before comparison.
- Whitespace remains significant and is documented.

Closes #119.

## Key files changed

- `src/Str.php`
- `tests/StrTest.php`
- `README.md`

## How to test

- `php -l src\Str.php`
- `php -l tests\StrTest.php`
- `.\vendor\bin\phpunit.bat --do-not-cache-result tests\StrTest.php`
- `composer validate --strict`
- `git diff --check`

## QA checklist

- [x] Static `Str::match()` usage is covered.
- [x] Instance `match()` usage is covered.
- [x] Default match behavior remains available.
- [x] `Str::IGNORE_CASE` behavior is covered.
- [x] False cases are covered.
- [x] Whitespace behavior is covered.
- [x] String-cast behavior is covered.

## Approval conditions

- CI passes across the PHP matrix.
- Review confirms the mode constant approach fits the existing `Str` API.
