### PR TITLE
Harden FileSystem read-only exists probes

### DIFF
--- a/src/Data/FileSystem.php
+++ b/src/Data/FileSystem.php
@@ -567,11 +567,15 @@ class FileSystem extends Data implements IData {
 	 */
 	public function exists($path = null): bool
 	{
-		$path = $path ?? null;
 		$file = Val::isNotNull($path) ? basename($path) : $this->file();
-		$directory = Val::isNotNull($path) ? realpath( dirname($path) ) : $this->path();
-		
-		$path = realpath( join(DIRECTORY_SEPARATOR, [$directory, $file] ) );
+		$directory = Val::isNotNull($path) ? dirname($path) : $this->path();
+		$directory = realpath($directory);
+
+		if (!$file || !$directory) {
+			return false;
+		}
+
+		$path = join(DIRECTORY_SEPARATOR, [$directory, $file]);
 
 		if (!$this->allowedDir($path)) {
 			$this->status("Location is outside of allowed path.");

--- a/tests/Data/FileSystemTest.php
+++ b/tests/Data/FileSystemTest.php
@@ -73,4 +73,21 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse(FileSystem::fileExists($this->testdirectory));
 		$this->assertFileDoesNotExist($missing);
 	}
+
+	public function testReadOnlyExistsProbeAcceptsAssociativeConfigArray()
+	{
+		$path = $this->testdirectory.DIRECTORY_SEPARATOR.'existing.txt';
+		$missing = $this->testdirectory.DIRECTORY_SEPARATOR.'missing.txt';
+		touch($path);
+
+		$filesystem = new FileSystem([
+			'root' => $this->testdirectory,
+			'filter' => [],
+			'doNotConfirm' => true,
+		]);
+
+		$this->assertTrue($filesystem->exists($path));
+		$this->assertFalse($filesystem->exists($missing));
+		$this->assertFileDoesNotExist($missing);
+	}
 }


### PR DESCRIPTION
## Intent summary

Harden `FileSystem::exists()` so read-only existence probes work when `FileSystem` is constructed from an associative config array and the target path may not exist yet.

Closes #122.

## User stories / acceptance criteria

- As a package consumer, I can instantiate `FileSystem` with `['root' => ..., 'filter' => [], 'doNotConfirm' => true]` for read-only checks.
- Existing paths return `true`.
- Missing paths return `false` deterministically.
- Missing paths are not created as a side effect of checking existence.

## Key files changed

- `src/Data/FileSystem.php`
- `tests/Data/FileSystemTest.php`

## How to test

```bash
php -l src/Data/FileSystem.php
php -l tests/Data/FileSystemTest.php
vendor/bin/phpunit --do-not-cache-result tests/Data/FileSystemTest.php
composer validate --strict
git diff --check
```

## QA checklist

- [x] Focused FileSystem tests pass.
- [x] Syntax checks pass.
- [x] Composer metadata validates.
- [x] Whitespace check passes.
- [x] No files are created by missing-path existence checks.

## Approval conditions

- Confirm the config-array constructor path remains compatible.
- Confirm missing-path existence probes return `false` without side effects.
