### PR TITLE
Harden string repeat helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Helper API notes:
 - Use `Arr::merge($base, $next)` when associative keys should be replaced recursively and numeric list values should be appended when unique. Use `Arr::append($base, $next)` for append-only numeric list behavior.
 - Use `Arr::values($array)` to reindex list values while preserving order, and `BlueFission\Net\HTTP::pathSegment($segment)` to encode a single URL path segment.
 - Use `Arr::mergeRecursive($base, $next)` when associative keys should be replaced recursively and numeric lists should append in order while preserving duplicates.
-- Use `Str::repeat($value, $times)` as the canonical static helper for `str_repeat`-style behavior. Existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
+- Use `Str::repeat($value, $times)` or the explicit `Str::strRepeat($value, $times)` alias as the canonical static helper for `str_repeat`-style behavior. Repeat counts must be non-negative; existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
 - Use `Str::match($left, $right, Str::IGNORE_CASE)` for case-insensitive equality checks. Values are string-cast before comparison and whitespace remains significant.
 - `BlueFission\Data\FileSystem::fileExists($path)` checks concrete file paths without initializing storage state. `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without creating missing paths.
 

--- a/src/Str.php
+++ b/src/Str.php
@@ -312,6 +312,10 @@ class Str extends Val implements IVal {
 	 * @return IVal
 	 */
 	public function _repeat(int $times): IVal {
+		if ($times < 0) {
+			throw new \InvalidArgumentException('Repeat count must be non-negative.');
+		}
+
 		$string = str_repeat($this->_data, $times);
 
 		$this->alter($string);

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -145,8 +145,17 @@ class StrTest extends ValTest {
 
 	public function testStrRepeatProvidesCanonicalStaticHelper()
 	{
+		$this->assertSame('ababab', Str::repeat('ab', 3));
 		$this->assertSame('ababab', Str::strRepeat('ab', 3));
 		$this->assertSame('', Str::strRepeat('ab', 0));
+	}
+
+	public function testStrRepeatRejectsNegativeCounts()
+	{
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Repeat count must be non-negative.');
+
+		Str::repeat('ab', -1);
 	}
 
 	public function testStrRepeatInstanceAliasKeepsRepeatBehavior()


### PR DESCRIPTION
## Intent summary

Finish the canonical string-repeat helper contract by making negative repeat counts explicit, covering both static helper names, and documenting the supported usage.

Closes #129.

## User stories / acceptance criteria

- As a package consumer, I can call `Str::repeat($value, $times)` for `str_repeat`-style behavior.
- As a package consumer, I can call the explicit `Str::strRepeat($value, $times)` alias.
- Zero repeat counts return an empty string.
- Negative repeat counts fail with a clear DevElation-side exception.
- Existing instance repeat behavior remains compatible.

## Key files changed

- `src/Str.php`
- `tests/StrTest.php`
- `README.md`

## How to test

```bash
php -l src/Str.php
php -l tests/StrTest.php
vendor/bin/phpunit --do-not-cache-result tests/StrTest.php
composer validate --strict
git diff --check
```

## QA checklist

- [x] Syntax checks pass.
- [x] Focused `Str` tests pass.
- [x] Composer metadata validates.
- [x] Whitespace check passes.
- [x] README documents the canonical static helper path.

## Approval conditions

- Confirm `InvalidArgumentException` is the intended negative-count failure mode.
- Confirm `Str::repeat()` and `Str::strRepeat()` should both remain documented static paths.
