### PR TITLE
Add safe Stdio input helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Helper API notes:
 - Use `Str::repeat($value, $times)` or the explicit `Str::strRepeat($value, $times)` alias as the canonical static helper for `str_repeat`-style behavior. Repeat counts must be non-negative; existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
 - Use `Str::match($left, $right, Str::IGNORE_CASE)` for case-insensitive equality checks. Values are string-cast before comparison and whitespace remains significant.
 - `BlueFission\Data\FileSystem::fileExists($path)` checks concrete file paths without initializing storage state. `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without creating missing paths.
+- Use `BlueFission\Connections\Stdio::input()` or `Stdio::readInput()` to read request/body streams without interactive `stream_select()` polling. Empty or unreadable input returns an empty string.
 
 ### DateTime Handling
 Sophisticated date and time manipulation with object-oriented principles, extending PHP's native `DateTime` class.

--- a/src/Connections/IO.php
+++ b/src/Connections/IO.php
@@ -51,6 +51,14 @@ class IO
     }
 
     /**
+     * Read request/body input without using non-interactive stream polling.
+     */
+    public static function input(mixed $source = null): string
+    {
+        return (string)self::applyFilters(Stdio::input($source));
+    }
+
+    /**
      * Fetch remote data via HTTP.
      */
     public static function fetch(string $url, array $config = []): mixed

--- a/src/Connections/Stdio.php
+++ b/src/Connections/Stdio.php
@@ -10,6 +10,7 @@ use BlueFission\Behavioral\IConfigurable;
 use BlueFission\Val;
 use BlueFission\Arr;
 use BlueFission\IObj;
+use BlueFission\DevElation as Dev;
 
 /**
  * Class Stdio
@@ -40,6 +41,53 @@ class Stdio extends Connection implements IConfigurable
         if (Arr::is($config)) {
             $this->config($config);
         }
+    }
+
+    /**
+     * Read request/body input without using stream_select().
+     *
+     * @param mixed $source Null for php://input, a stream resource, or a readable stream/path string.
+     * @return string
+     */
+    public static function readInput(mixed $source = null): string
+    {
+        $source = Val::isNull($source) ? 'php://input' : Dev::apply('_in', $source);
+        $handle = null;
+        $shouldClose = false;
+
+        if (is_resource($source)) {
+            $handle = $source;
+        } elseif (is_string($source) && $source !== '') {
+            $handle = @fopen($source, 'r');
+            $shouldClose = is_resource($handle);
+        }
+
+        if (!is_resource($handle)) {
+            return (string)Dev::apply('_out', '');
+        }
+
+        $contents = stream_get_contents($handle);
+
+        if ($shouldClose) {
+            fclose($handle);
+        }
+
+        if ($contents === false) {
+            $contents = '';
+        }
+
+        return (string)Dev::apply('_out', $contents);
+    }
+
+    /**
+     * Alias for readInput().
+     *
+     * @param mixed $source Null for php://input, a stream resource, or a readable stream/path string.
+     * @return string
+     */
+    public static function input(mixed $source = null): string
+    {
+        return self::readInput($source);
     }
 
     /**

--- a/tests/Connections/StdioTest.php
+++ b/tests/Connections/StdioTest.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Tests\Connections;
 
 use BlueFission\Connections\Connection;
+use BlueFission\Connections\IO;
 use BlueFission\Connections\Stdio;
 
 class StdioTest extends ConnectionTest
@@ -45,6 +46,54 @@ class StdioTest extends ConnectionTest
         $this->object->open();
 
         $this->assertEquals(Connection::STATUS_CONNECTED, $this->object->status(), "Status should be connected after opening output.");
+    }
+
+    public function testReadInputReadsExplicitStream()
+    {
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'request-body');
+        rewind($stream);
+
+        $this->assertSame('request-body', Stdio::readInput($stream));
+
+        fclose($stream);
+    }
+
+    public function testReadInputReturnsEmptyStringForEmptyStream()
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        $this->assertSame('', Stdio::readInput($stream));
+
+        fclose($stream);
+    }
+
+    public function testInputAliasAvoidsInteractiveStreamPolling()
+    {
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'alias-body');
+        rewind($stream);
+
+        $this->assertSame('alias-body', Stdio::input($stream));
+
+        fclose($stream);
+    }
+
+    public function testInputReturnsEmptyStringForUnreadableSource()
+    {
+        $this->assertSame('', Stdio::input(''));
+        $this->assertSame('', Stdio::input(__DIR__ . '/missing-input.txt'));
+    }
+
+    public function testIoInputDelegatesToSafeStdioRead()
+    {
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'io-body');
+        rewind($stream);
+
+        $this->assertSame('io-body', IO::input($stream));
+
+        fclose($stream);
     }
 
     // public function testStatusAfterClose()


### PR DESCRIPTION
## Intent summary

Add safe request/body input helpers for `Stdio` and `IO` so callers can read `php://input` or explicit streams without using interactive `stream_select()` polling.

Closes #118.

## User stories / acceptance criteria

- As a package consumer, I can read request/body input through `Stdio::readInput()` or `Stdio::input()`.
- As a package consumer, I can pass an explicit stream resource or readable stream/path string.
- Empty or unreadable input returns an empty string instead of throwing.
- The new helper path avoids `stream_select()` entirely.
- Existing `Stdio::open()` / `query()` behavior remains compatible.

## Key files changed

- `src/Connections/Stdio.php`
- `src/Connections/IO.php`
- `tests/Connections/StdioTest.php`
- `README.md`

## How to test

```bash
php -l src/Connections/Stdio.php
php -l src/Connections/IO.php
php -l tests/Connections/StdioTest.php
vendor/bin/phpunit --do-not-cache-result tests/Connections/StdioTest.php
vendor/bin/phpunit --do-not-cache-result
composer validate --strict
git diff --check
```

## QA checklist

- [x] Syntax checks pass.
- [x] Focused `Stdio` tests pass.
- [x] Full PHPUnit suite passes.
- [x] Composer metadata validates.
- [x] Whitespace check passes.
- [x] README documents the first-party helper.

## Approval conditions

- Confirm `Stdio::input()` and `Stdio::readInput()` are the intended public helper names.
- Confirm empty string is the correct unreadable/empty input fallback.
