### PR TITLE
Add FileSystem iterable helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Helper API notes:
 - Use `Str::repeat($value, $times)` or the explicit `Str::strRepeat($value, $times)` alias as the canonical static helper for `str_repeat`-style behavior. Repeat counts must be non-negative; existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
 - Use `Str::match($left, $right, Str::IGNORE_CASE)` for case-insensitive equality checks. Values are string-cast before comparison and whitespace remains significant.
 - `BlueFission\Data\FileSystem::fileExists($path)` checks concrete file paths without initializing storage state. `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without creating missing paths.
+- Use `BlueFission\Data\FileSystem::lines($eol)` for read-only file line values and `FileSystem::entries()` for sorted directory entry values. Missing targets return empty arrays and are not created.
 
 ### DateTime Handling
 Sophisticated date and time manipulation with object-oriented principles, extending PHP's native `DateTime` class.

--- a/src/Data/FileSystem.php
+++ b/src/Data/FileSystem.php
@@ -753,9 +753,70 @@ class FileSystem extends Data implements IData {
 
 		$this->status('Success');
 
-		return $output;	
+		return $output;
 	}
-	
+
+	/**
+	 * Return directory entries as a predictable iterable list.
+	 *
+	 * This helper only inspects the target directory. Missing or disallowed
+	 * directories return an empty list and are not created.
+	 *
+	 * @return array
+	 */
+	public function entries(): array
+	{
+		$entries = $this->listDir(false);
+
+		if (!Arr::is($entries)) {
+			return Dev::apply('_out', []);
+		}
+
+		$entries = Arr::make($entries)->sort()->val();
+
+		return Dev::apply('_out', $entries);
+	}
+
+	/**
+	 * Return file contents split into iterable line values.
+	 *
+	 * This helper reads the current file target when one is configured,
+	 * otherwise it splits the in-memory contents value. Missing files return
+	 * an empty list and are not created.
+	 *
+	 * @param string $eol
+	 * @return array
+	 */
+	public function lines(string $eol = PHP_EOL): array
+	{
+		$eol = Dev::apply('_in', $eol);
+		$contents = null;
+		$file = $this->file();
+
+		if ($file) {
+			$path = $this->path();
+			$filepath = $path.DIRECTORY_SEPARATOR.$file;
+
+			if (!$this->allowedDir($filepath) || !$this->exists($filepath) || !is_readable($filepath)) {
+				return Dev::apply('_out', []);
+			}
+
+			$contents = file_get_contents($filepath);
+		} elseif (Val::isNotNull($this->contents())) {
+			$contents = $this->contents();
+		}
+
+		if (!Str::is($contents) || $contents === '') {
+			return Dev::apply('_out', []);
+		}
+
+		if ($eol === '') {
+			return Dev::apply('_out', [$contents]);
+		}
+
+		return Dev::apply('_out', explode($eol, $contents));
+	}
+
 	/**
 	 * Get or set the contents of the file
 	 *

--- a/tests/Data/FileSystemTest.php
+++ b/tests/Data/FileSystemTest.php
@@ -90,4 +90,62 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse($filesystem->exists($missing));
 		$this->assertFileDoesNotExist($missing);
 	}
+
+	public function testLinesReadsFileContentsAsIterableValues()
+	{
+		$path = $this->testdirectory.DIRECTORY_SEPARATOR.'names.txt';
+		file_put_contents($path, 'Ada'.PHP_EOL.'Grace');
+
+		$filesystem = new FileSystem($path);
+
+		$this->assertSame(['Ada', 'Grace'], $filesystem->lines());
+	}
+
+	public function testLinesCanSplitInMemoryContents()
+	{
+		$filesystem = new FileSystem([
+			'root' => $this->testdirectory,
+			'filter' => [],
+			'doNotConfirm' => true,
+		]);
+		$filesystem->contents('alpha|beta|gamma');
+
+		$this->assertSame(['alpha', 'beta', 'gamma'], $filesystem->lines('|'));
+	}
+
+	public function testLinesReturnsEmptyListForMissingFileWithoutCreatingIt()
+	{
+		$missing = $this->testdirectory.DIRECTORY_SEPARATOR.'missing-lines.txt';
+		$filesystem = new FileSystem($missing);
+
+		$this->assertSame([], $filesystem->lines());
+		$this->assertFileDoesNotExist($missing);
+	}
+
+	public function testEntriesReturnsSortedDirectoryValues()
+	{
+		touch($this->testdirectory.DIRECTORY_SEPARATOR.'zeta.txt');
+		touch($this->testdirectory.DIRECTORY_SEPARATOR.'alpha.txt');
+
+		$filesystem = new FileSystem([
+			'root' => $this->testdirectory,
+			'filter' => [],
+			'doNotConfirm' => true,
+		]);
+
+		$this->assertSame(['alpha.txt', 'zeta.txt'], $filesystem->entries());
+	}
+
+	public function testEntriesReturnsEmptyListForMissingDirectoryWithoutCreatingIt()
+	{
+		$missing = $this->testdirectory.DIRECTORY_SEPARATOR.'missing-directory';
+		$filesystem = new FileSystem([
+			'root' => $missing,
+			'filter' => [],
+			'doNotConfirm' => true,
+		]);
+
+		$this->assertSame([], $filesystem->entries());
+		$this->assertDirectoryDoesNotExist($missing);
+	}
 }


### PR DESCRIPTION
## Intent summary

Add read-only iterable helpers for file line traversal and directory entry traversal on `FileSystem`.

Closes #109.

## User stories / acceptance criteria

- As a package consumer, I can call `FileSystem::lines($eol)` to receive file contents as iterable line values.
- As a package consumer, I can call `FileSystem::entries()` to receive sorted directory entry values.
- Missing file and directory targets return empty arrays and are not created.
- Helpers are read-only and do not alter existing `read()`, `write()`, `mkdir()`, or `listDir()` behavior.
- README documents the intended helper usage.

## Key files changed

- `src/Data/FileSystem.php`
- `tests/Data/FileSystemTest.php`
- `README.md`

## How to test

```bash
php -l src/Data/FileSystem.php
php -l tests/Data/FileSystemTest.php
vendor/bin/phpunit --do-not-cache-result tests/Data/FileSystemTest.php
vendor/bin/phpunit --do-not-cache-result
composer validate --strict
git diff --check
```

## QA checklist

- [x] Syntax checks pass.
- [x] Focused `FileSystem` tests pass.
- [x] Full PHPUnit suite passes.
- [x] Composer metadata validates.
- [x] Whitespace check passes.
- [x] Missing targets are verified not to be created.

## Approval conditions

- Confirm `entries()` is the preferred sorted directory-list helper name.
- Confirm `lines()` should preserve `explode()` semantics for the configured EOL delimiter.
