### PR TITLE
Add strict scalar helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Helper API notes:
 - Use `Arr::mergeRecursive($base, $next)` when associative keys should be replaced recursively and numeric lists should append in order while preserving duplicates.
 - Use `Str::repeat($value, $times)` or the explicit `Str::strRepeat($value, $times)` alias as the canonical static helper for `str_repeat`-style behavior. Repeat counts must be non-negative; existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
 - Use `Str::match($left, $right, Str::IGNORE_CASE)` for case-insensitive equality checks. Values are string-cast before comparison and whitespace remains significant.
+- Use `Num::isIntStrict()`, `Num::isFloatStrict()` / `Num::isDoubleStrict()`, and `Flag::isBoolStrict()` / `Flag::isBooleanStrict()` when native scalar type checks must not coerce strings or numeric values.
 - `BlueFission\Data\FileSystem::fileExists($path)` checks concrete file paths without initializing storage state. `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without creating missing paths.
 
 ### DateTime Handling

--- a/src/Flag.php
+++ b/src/Flag.php
@@ -80,6 +80,26 @@ class Flag extends Val implements IVal
     }
 
     /**
+     * Check whether the value is a native boolean without coercion.
+     *
+     * @return bool
+     */
+    public function _isBoolStrict(): bool
+    {
+        return is_bool($this->_data);
+    }
+
+    /**
+     * Alias for native boolean checks.
+     *
+     * @return bool
+     */
+    public function _isBooleanStrict(): bool
+    {
+        return $this->_isBoolStrict();
+    }
+
+    /**
      * Returns the boolean representation of a given value
      *
      * @param mixed $value The value to cast to a boolean

--- a/src/Num.php
+++ b/src/Num.php
@@ -88,7 +88,37 @@ class Num extends Val implements IVal {
     {
         $number = $this->_data;
         return (is_numeric($number) && ((Val::isNotEmpty($number) && $number != 0) || $allowZero));
-    }    
+    }
+
+    /**
+     * Check whether the value is a native integer without coercion.
+     *
+     * @return bool
+     */
+    public function _isIntStrict(): bool
+    {
+        return is_int($this->_data);
+    }
+
+    /**
+     * Check whether the value is a native float without coercion.
+     *
+     * @return bool
+     */
+    public function _isFloatStrict(): bool
+    {
+        return is_float($this->_data);
+    }
+
+    /**
+     * Alias for native float checks.
+     *
+     * @return bool
+     */
+    public function _isDoubleStrict(): bool
+    {
+        return $this->_isFloatStrict();
+    }
 
 	/**
 	 * Sets string formatting for the output of the number

--- a/tests/FlagTest.php
+++ b/tests/FlagTest.php
@@ -92,6 +92,18 @@ class FlagTest extends ValTest
 
     }
 
+    public function testStrictBooleanHelpersDoNotCoerceTokens()
+    {
+        $this->assertTrue(Flag::isBoolStrict(true));
+        $this->assertTrue(Flag::isBoolStrict(false));
+        $this->assertTrue(Flag::isBooleanStrict(false));
+        $this->assertFalse(Flag::isBoolStrict('true'));
+        $this->assertFalse(Flag::isBoolStrict('false'));
+        $this->assertFalse(Flag::isBoolStrict(1));
+        $this->assertFalse(Flag::isBooleanStrict(0));
+        $this->assertFalse(Flag::isBoolStrict(''));
+    }
+
     public function testSetsValue()
     {
         $object = new static::$classname();

--- a/tests/NumTest.php
+++ b/tests/NumTest.php
@@ -45,6 +45,25 @@ class NumTest extends ValTest
         $this->assertFalse($this->blankObject->isValid());
     }
 
+    public function testStrictIntegerHelperDoesNotCoerceStrings()
+    {
+        $this->assertTrue(Num::isIntStrict(0));
+        $this->assertTrue(Num::isIntStrict(42));
+        $this->assertFalse(Num::isIntStrict('42'));
+        $this->assertFalse(Num::isIntStrict(42.0));
+        $this->assertFalse(Num::isIntStrict(''));
+    }
+
+    public function testStrictFloatHelpersDoNotCoerceIntegersOrStrings()
+    {
+        $this->assertTrue(Num::isFloatStrict(0.0));
+        $this->assertTrue(Num::isFloatStrict(2.5));
+        $this->assertTrue(Num::isDoubleStrict(2.5));
+        $this->assertFalse(Num::isFloatStrict(2));
+        $this->assertFalse(Num::isFloatStrict('2.5'));
+        $this->assertFalse(Num::isDoubleStrict('2.5'));
+    }
+
     public function testPercentageReturnsCorrectValue()
     {
         $this->assertEquals(0.058, $this->largeObject->percentage(5));


### PR DESCRIPTION
## Intent summary

Add strict scalar helper methods for native integer, float/double, and boolean checks without coercing numeric or boolean-like strings. The JSON decode portion of this issue is already present on `master` through `HTTP::jsonDecode()` and its tests, so this PR completes the missing scalar side of the contract.

Closes #107.

## User stories / acceptance criteria

- As a package consumer, I can call `Num::isIntStrict()` for native integer checks.
- As a package consumer, I can call `Num::isFloatStrict()` or `Num::isDoubleStrict()` for native float checks.
- As a package consumer, I can call `Flag::isBoolStrict()` or `Flag::isBooleanStrict()` for native boolean checks.
- Numeric strings, boolean-like strings, empty strings, and numeric values of the wrong native type do not pass strict checks.
- README documents when to use these strict helpers.

## Key files changed

- `src/Num.php`
- `src/Flag.php`
- `tests/NumTest.php`
- `tests/FlagTest.php`
- `README.md`

## How to test

```bash
php -l src/Num.php
php -l src/Flag.php
php -l tests/NumTest.php
php -l tests/FlagTest.php
vendor/bin/phpunit --do-not-cache-result tests/NumTest.php
vendor/bin/phpunit --do-not-cache-result tests/FlagTest.php
vendor/bin/phpunit --do-not-cache-result tests/Net/HTTPTest.php
vendor/bin/phpunit --do-not-cache-result
composer validate --strict
git diff --check
```

## QA checklist

- [x] Syntax checks pass.
- [x] Focused primitive tests pass.
- [x] Existing HTTP JSON decode tests pass.
- [x] Full PHPUnit suite passes.
- [x] Composer metadata validates.
- [x] Whitespace check passes.

## Approval conditions

- Confirm the helper names match the desired public surface.
- Confirm strict helpers should remain non-coercive even for numeric or boolean-like strings.
