### PR TITLE
Add numeric angle and trigonometry helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Helper API notes:
 - Use `Str::startsWith($value, $needle)`, `Str::endsWith($value, $needle)`, and `Str::match($left, $right, Str::IGNORE_CASE)` for string boundary and equality checks. Values are string-cast before comparison and whitespace remains significant.
 - Use `Date::formatTimestamp($timestamp, 'Y-m-d')` as a concise replacement for `date($format, $timestamp)`.
 - Use `Num::isIntStrict()`, `Num::isFloatStrict()` / `Num::isDoubleStrict()`, and `Flag::isBoolStrict()` / `Flag::isBooleanStrict()` when native scalar type checks must not coerce strings or numeric values.
+- Use `Num::deg2rad($degrees)`, `Num::rad2deg($radians)`, `Num::sin($radians)`, `Num::cos($radians)`, and `Num::atan2($y, $x)` for hookable angle and trigonometry helpers. Angles passed to trigonometry helpers are radians.
 - `BlueFission\Data\FileSystem::fileExists($path)` checks concrete file paths without initializing storage state. `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without creating missing paths.
 - Use `BlueFission\Data\FileSystem::lines($eol)` for read-only file line values and `FileSystem::entries()` for sorted directory entry values. Missing targets return empty arrays and are not created.
 - Use `BlueFission\Connections\Stdio::input()` or `Stdio::readInput()` to read request/body streams without interactive `stream_select()` polling. Empty or unreadable input returns an empty string.

--- a/capability_surface.md
+++ b/capability_surface.md
@@ -29,7 +29,7 @@ values while preserving a simple path back to native data through `val()`.
 | --- | --- | --- |
 | Generic values | `BlueFission\Val` | Base wrapper behavior, dynamic helper dispatch, value access, diagnostics, hooks. |
 | Strings | `BlueFission\Str` | String transforms, normalization, formatting, matching, and repeat helpers. |
-| Numbers | `BlueFission\Num` | Numeric operations, formatting, conversion, and comparison helpers. |
+| Numbers | `BlueFission\Num` | Numeric operations, formatting, conversion, comparison, angle, and trigonometry helpers. |
 | Flags | `BlueFission\Flag` | Boolean parsing, conversion, and boolean-state helpers. |
 | Arrays | `BlueFission\Arr` | Array traversal, key/value checks, merging, mapping, filtering, counting, and ordering helpers. |
 | Objects | `BlueFission\Obj` | Dynamic fields, nested value access, object projection, and structured value helpers. |

--- a/src/Num.php
+++ b/src/Num.php
@@ -418,8 +418,100 @@ class Num extends Val implements IVal {
     }
 
     /**
+     * Convert degrees to radians.
+     *
+     * @return IVal
+     */
+    public function _deg2rad(): IVal
+    {
+        $value = deg2rad((float)$this->_data);
+
+        $this->alter($value);
+
+        return $this;
+    }
+
+    /**
+     * Alias for degrees-to-radians conversion.
+     *
+     * @return IVal
+     */
+    public function _degreesToRadians(): IVal
+    {
+        return $this->_deg2rad();
+    }
+
+    /**
+     * Convert radians to degrees.
+     *
+     * @return IVal
+     */
+    public function _rad2deg(): IVal
+    {
+        $value = rad2deg((float)$this->_data);
+
+        $this->alter($value);
+
+        return $this;
+    }
+
+    /**
+     * Alias for radians-to-degrees conversion.
+     *
+     * @return IVal
+     */
+    public function _radiansToDegrees(): IVal
+    {
+        return $this->_rad2deg();
+    }
+
+    /**
+     * Get the sine of the number, interpreted as radians.
+     *
+     * @return IVal
+     */
+    public function _sin(): IVal
+    {
+        $value = sin((float)$this->_data);
+
+        $this->alter($value);
+
+        return $this;
+    }
+
+    /**
+     * Get the cosine of the number, interpreted as radians.
+     *
+     * @return IVal
+     */
+    public function _cos(): IVal
+    {
+        $value = cos((float)$this->_data);
+
+        $this->alter($value);
+
+        return $this;
+    }
+
+    /**
+     * Get the two-argument arctangent of y and x.
+     *
+     * @param float $x The x coordinate
+     *
+     * @return IVal
+     */
+    public function _atan2(float $x): IVal
+    {
+        $value = atan2((float)$this->_data, $x);
+
+        $this->alter($value);
+
+        return $this;
+    }
+
+    /**
      * Set or return the decimal representation of a number
-     * 
+     *
      * @return mixed | Num
      */
     public function _dec(): mixed

--- a/tests/NumTest.php
+++ b/tests/NumTest.php
@@ -176,6 +176,39 @@ class NumTest extends ValTest
         $this->assertEquals(exp(log(729)), $number->exp()->val());
     }
 
+    public function testAngleConversionHelpersMutateValueAndDispatchStatically()
+    {
+        $degrees = new Num(180);
+
+        $this->assertEqualsWithDelta(M_PI, $degrees->deg2rad()->val(), 0.000000000001);
+        $this->assertEqualsWithDelta(M_PI, Num::deg2rad(180), 0.000000000001);
+        $this->assertEqualsWithDelta(M_PI / 2, Num::degreesToRadians(90), 0.000000000001);
+        $this->assertEqualsWithDelta(-M_PI / 2, Num::deg2rad(-90), 0.000000000001);
+        $this->assertEqualsWithDelta(0.0, Num::deg2rad(0), 0.000000000001);
+
+        $this->assertEqualsWithDelta(180.0, Num::rad2deg(M_PI), 0.000000000001);
+        $this->assertEqualsWithDelta(90.0, Num::radiansToDegrees(M_PI / 2), 0.000000000001);
+        $this->assertEqualsWithDelta(-90.0, Num::rad2deg(-M_PI / 2), 0.000000000001);
+        $this->assertEqualsWithDelta(0.0, Num::rad2deg(0), 0.000000000001);
+    }
+
+    public function testTrigonometryHelpersMatchPhpMath()
+    {
+        $angle = new Num(M_PI / 2);
+
+        $this->assertEqualsWithDelta(1.0, $angle->sin()->val(), 0.000000000001);
+        $this->assertEqualsWithDelta(sin(0), Num::sin(0), 0.000000000001);
+        $this->assertEqualsWithDelta(sin(-M_PI / 2), Num::sin(-M_PI / 2), 0.000000000001);
+
+        $this->assertEqualsWithDelta(cos(0), Num::cos(0), 0.000000000001);
+        $this->assertEqualsWithDelta(cos(M_PI), Num::cos(M_PI), 0.000000000001);
+        $this->assertEqualsWithDelta(cos(-M_PI), Num::cos(-M_PI), 0.000000000001);
+
+        $this->assertEqualsWithDelta(atan2(1, 1), Num::atan2(1, 1), 0.000000000001);
+        $this->assertEqualsWithDelta(atan2(0, 1), Num::atan2(0, 1), 0.000000000001);
+        $this->assertEqualsWithDelta(atan2(-1, 0), Num::atan2(-1, 0), 0.000000000001);
+    }
+
     public function testAbsoluteRoundAndIntegerHelpers()
     {
         $number = new Num(-12.75);

--- a/usage_readiness_checklist.md
+++ b/usage_readiness_checklist.md
@@ -27,6 +27,7 @@ Strings:
 Numbers, flags, and dates:
 
 - Use `Num` for numeric conversion, arithmetic, formatting, and comparison helpers that should be hookable.
+- Use `Num::deg2rad()`, `Num::rad2deg()`, `Num::sin()`, `Num::cos()`, and `Num::atan2()` for angle and trigonometry operations that should remain on the helper surface.
 - Use `Flag` for boolean-style values instead of scattering one-off string comparisons.
 - Use `Date` for date/time value handling and `Date::formatTimestamp($timestamp, $format)` for timestamp formatting.
 


### PR DESCRIPTION
## Intent summary

Add hookable `Num` helpers for common angle conversion and trigonometry operations while preserving the existing value-object and static helper dispatch conventions.

Closes #138.

## User stories / acceptance criteria

- As a caller, I can use `Num::deg2rad($degrees)` and `Num::rad2deg($radians)` instead of raw PHP conversion helpers when I want DevElation helper semantics.
- As a caller, I can use `Num::sin($radians)`, `Num::cos($radians)`, and `Num::atan2($y, $x)` with PHP-compatible results.
- Instance calls mutate and return the `Num` value object, while static calls return the computed native value through the existing dispatch pattern.
- Tests cover positive, negative, and zero values with explicit floating-point tolerances and radians units.

## Key files changed

- `src/Num.php`
- `tests/NumTest.php`
- `README.md`
- `usage_readiness_checklist.md`
- `capability_surface.md`

## How to test

```bash
php -l src/Num.php
php -l tests/NumTest.php
composer validate --strict
git diff --check
vendor/bin/phpunit --do-not-cache-result tests/NumTest.php
```

Local note: this isolated worktree does not include `vendor/`, so I also ran a direct PSR-4 runtime probe against the source tree to verify static dispatch behavior without installing dependencies.

## QA checklist

- [x] Syntax checks pass for touched PHP files.
- [x] Composer metadata validates strictly.
- [x] Git whitespace checks pass.
- [x] Runtime probe confirms static helper dispatch for the new helpers.
- [x] PHPUnit coverage was added for the intended behavior.

## Approval conditions

- CI passes on the PR branch.
- Maintainers approve the helper names and documented radians semantics.
