### PR TITLE
Make Ratchet websocket transport optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ Install DevElation with Composer:
 composer require bluefission/develation
 ```
 
+The core package does not require the optional Ratchet websocket transport. If
+you use `BlueFission\Async\Sock`, install Ratchet in applications that can
+satisfy its dependency constraints:
+
+```bash
+composer require cboden/ratchet
+```
+
 The canonical source repository is `BlueFissionTech/develation` on GitHub.
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": ">=8.2",
-        "cboden/ratchet": "^0.4.4",
         "psr/http-message": "^2.0",
         "psr/http-client": "^1.0",
         "php-http/discovery": "^1.0"
@@ -34,9 +33,13 @@
         }
     },
     "require-dev": {
+        "cboden/ratchet": "^0.4.4",
         "phpunit/phpunit": "^11.5",
         "phpstan/phpstan": "^2.1",
         "friendsofphp/php-cs-fixer": "^3.0"
+    },
+    "suggest": {
+        "cboden/ratchet": "Install to use the optional BlueFission\\Async\\Sock Ratchet websocket transport."
     },
     "config": {
         "platform-check": true,

--- a/src/Async/Sock.php
+++ b/src/Async/Sock.php
@@ -2,9 +2,6 @@
 
 namespace BlueFission\Async;
 
-use Ratchet\Server\IoServer;
-use Ratchet\Http\HttpServer;
-use Ratchet\WebSocket\WsServer;
 use BlueFission\Behavioral\Configurable;
 use BlueFission\Behavioral\IConfigurable;
 use BlueFission\Behavioral\IDispatcher;
@@ -19,6 +16,13 @@ class Sock implements IDispatcher, IConfigurable
     use Configurable {
         Configurable::__construct as private __configConstruct;
     }
+
+    private const TRANSPORT_CLASSES = [
+        \Ratchet\Server\IoServer::class,
+        \Ratchet\Http\HttpServer::class,
+        \Ratchet\WebSocket\WsServer::class,
+        \Ratchet\MessageComponentInterface::class,
+    ];
 
     private $_server;
     private $_port;
@@ -45,19 +49,67 @@ class Sock implements IDispatcher, IConfigurable
     }
 
     /**
+     * Check whether the optional Ratchet websocket transport is installed.
+     */
+    public static function isAvailable(): bool
+    {
+        return self::missingDependencies() === [];
+    }
+
+    /**
+     * List missing classes required by the optional Ratchet transport.
+     *
+     * @param array<string>|null $classes
+     * @return array<string>
+     */
+    public static function missingDependencies(?array $classes = null): array
+    {
+        $missing = [];
+
+        foreach ($classes ?? self::TRANSPORT_CLASSES as $class) {
+            if (!class_exists($class) && !interface_exists($class)) {
+                $missing[] = $class;
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
      * Starts the WebSocket server.
      *
      * @return void
      */
     public function start(): void
     {
+        $missing = self::missingDependencies();
+
+        if ($missing !== []) {
+            throw new \RuntimeException(
+                'The Ratchet websocket transport is not installed. Install cboden/ratchet to use '
+                . self::class
+                . '. Missing: '
+                . implode(', ', $missing)
+            );
+        }
+
         $this->status("Starting WebSocket server on port {$this->config('port')}");
 
         $class = $this->config('class');
 
-        $webSocket = new WsServer(new $class());
-        $server = IoServer::factory(
-            new HttpServer($webSocket),
+        if (!is_string($class) || !class_exists($class)) {
+            throw new \InvalidArgumentException('WebSocket handler class is not available.');
+        }
+
+        $handler = new $class();
+
+        if (!$handler instanceof \Ratchet\ComponentInterface) {
+            throw new \InvalidArgumentException('WebSocket handler must implement Ratchet\\ComponentInterface.');
+        }
+
+        $webSocket = new \Ratchet\WebSocket\WsServer($handler);
+        $server = \Ratchet\Server\IoServer::factory(
+            new \Ratchet\Http\HttpServer($webSocket),
             $this->config('port'),
             $this->config('host')
         );

--- a/src/Async/WebSocketServer.php
+++ b/src/Async/WebSocketServer.php
@@ -2,14 +2,12 @@
 
 namespace BlueFission\Async;
 
-use Ratchet\MessageComponentInterface;
-use Ratchet\ConnectionInterface;
-
 /**
- * Basic WebSocketServer implementation using Ratchet.
- * Handles open, message, close, and error events for all clients.
+ * Shared behavior for the optional Ratchet websocket handler.
+ *
+ * @internal
  */
-class WebSocketServer implements MessageComponentInterface
+trait WebSocketServerBehavior
 {
     protected \SplObjectStorage $clients;
 
@@ -22,10 +20,10 @@ class WebSocketServer implements MessageComponentInterface
     /**
      * Handles a new connection.
      *
-     * @param ConnectionInterface $conn
+     * @param object $conn
      * @return void
      */
-    public function onOpen(ConnectionInterface $conn): void
+    public function onOpen($conn): void
     {
         $this->clients->attach($conn);
         echo "New connection! ({$conn->resourceId})\n";
@@ -34,11 +32,11 @@ class WebSocketServer implements MessageComponentInterface
     /**
      * Handles an incoming message from a client.
      *
-     * @param ConnectionInterface $from
+     * @param object $from
      * @param string $msg
      * @return void
      */
-    public function onMessage(ConnectionInterface $from, $msg): void
+    public function onMessage($from, $msg): void
     {
         echo sprintf("Message from %d: %s\n", $from->resourceId, $msg);
 
@@ -52,25 +50,41 @@ class WebSocketServer implements MessageComponentInterface
     /**
      * Handles a closed connection.
      *
-     * @param ConnectionInterface $conn
+     * @param object $conn
      * @return void
      */
-    public function onClose(ConnectionInterface $conn): void
+    public function onClose($conn): void
     {
         $this->clients->detach($conn);
         echo "Connection {$conn->resourceId} has disconnected\n";
-    }               
+    }
 
     /**
      * Handles an error on a connection.
      *
-     * @param ConnectionInterface $conn
+     * @param object $conn
      * @param \Exception $e
      * @return void
      */
-    public function onError(ConnectionInterface $conn, \Exception $e): void
+    public function onError($conn, \Exception $e): void
     {
         echo "An error has occurred: {$e->getMessage()}\n";
         $conn->close();
+    }
+}
+
+/**
+ * Basic WebSocketServer implementation for the optional Ratchet transport.
+ * Handles open, message, close, and error events for all clients.
+ */
+if (interface_exists(\Ratchet\MessageComponentInterface::class)) {
+    class WebSocketServer implements \Ratchet\MessageComponentInterface
+    {
+        use WebSocketServerBehavior;
+    }
+} else {
+    class WebSocketServer
+    {
+        use WebSocketServerBehavior;
     }
 }

--- a/tests/Async/SockTest.php
+++ b/tests/Async/SockTest.php
@@ -4,7 +4,6 @@ namespace BlueFission\Async\Tests;
 
 use PHPUnit\Framework\TestCase;
 use BlueFission\Async\Sock;
-use Ratchet\Server\IoServer;
 
 class SockTest extends TestCase {
     private $sock;
@@ -13,9 +12,11 @@ class SockTest extends TestCase {
 
     protected function setUp(): void {
         parent::setUp();
-        if (!class_exists(IoServer::class)) {
-            $this->markTestSkipped('Ratchet is not available');
+
+        if (!Sock::isAvailable()) {
+            return;
         }
+
         // Mock the WebSocketServer class which is referenced in Sock
         $this->mockWebSocketServer = $this->getMockBuilder('BlueFission\Async\WebSocketServer')
             ->disableOriginalConstructor()
@@ -25,7 +26,30 @@ class SockTest extends TestCase {
         $this->sock = new Sock($this->port, ['class' => get_class($this->mockWebSocketServer)]);
     }
 
+    public function testSockCanBeConfiguredWithoutStartingTransport() {
+        $sock = new Sock(9000, ['host' => '127.0.0.1', 'port' => 9000]);
+
+        $this->assertInstanceOf(Sock::class, $sock);
+        $this->assertSame(9000, $sock->config('port'));
+        $this->assertSame('127.0.0.1', $sock->config('host'));
+    }
+
+    public function testSockReportsTransportAvailability() {
+        $this->assertSame(Sock::missingDependencies() === [], Sock::isAvailable());
+    }
+
+    public function testSockReportsMissingTransportClasses() {
+        $this->assertSame(
+            ['BlueFission\\Tests\\MissingOptionalTransport'],
+            Sock::missingDependencies(['BlueFission\\Tests\\MissingOptionalTransport'])
+        );
+    }
+
     public function testStartAndStopWebSocketServer() {
+        if (!$this->sock) {
+            $this->markTestSkipped('Ratchet is not available');
+        }
+
         $this->assertInstanceOf(Sock::class, $this->sock);
         $this->assertEquals(get_class($this->mockWebSocketServer), $this->sock->config('class'));
 
@@ -62,6 +86,8 @@ class SockTest extends TestCase {
     protected function tearDown(): void {
         parent::tearDown();
         // Clean up after test
-        $this->sock->stop();
+        if ($this->sock) {
+            $this->sock->stop();
+        }
     }
 }

--- a/tests/ComposerMetadataTest.php
+++ b/tests/ComposerMetadataTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class ComposerMetadataTest extends TestCase
+{
+    public function testRatchetTransportIsOptional(): void
+    {
+        $composer = json_decode((string) file_get_contents(__DIR__ . '/../composer.json'), true);
+
+        $this->assertArrayNotHasKey('cboden/ratchet', $composer['require'] ?? []);
+        $this->assertArrayHasKey('cboden/ratchet', $composer['require-dev'] ?? []);
+        $this->assertArrayHasKey('cboden/ratchet', $composer['suggest'] ?? []);
+    }
+}


### PR DESCRIPTION
Closes #145

## Intent summary

Make the core package installable without forcing the Ratchet websocket transport into every consumer. Ratchet remains supported for `BlueFission\Async\Sock`, but it is now optional and guarded at runtime.

## User stories / acceptance criteria

- As a PHP 8.2+ application maintainer, I can require DevElation core primitives without installing the Ratchet transport.
- As a Symfony 7 or Laravel 12 host, package resolution is no longer blocked by Ratchet's Symfony HTTP Foundation constraint when websocket support is not used.
- As a maintainer, `BlueFission\Async\Sock` still exposes Ratchet-backed behavior when the optional package is installed.
- As a reviewer, package metadata and async tests cover the optional transport boundary.

## Key files changed

- `composer.json`: moves `cboden/ratchet` from runtime `require` to `require-dev` and `suggest`.
- `src/Async/Sock.php`: adds availability helpers and runtime guard messaging before Ratchet classes are used.
- `src/Async/WebSocketServer.php`: avoids hard failure when Ratchet interfaces are absent while preserving interface implementation when present.
- `tests/Async/SockTest.php`: keeps non-transport behavior testable without Ratchet and limits skips to real transport behavior.
- `tests/ComposerMetadataTest.php`: verifies Ratchet is optional in package metadata.
- `README.md`: documents optional websocket transport installation.

## How to test

```bash
php -l src/Async/Sock.php
php -l src/Async/WebSocketServer.php
php -l tests/Async/SockTest.php
php -l tests/ComposerMetadataTest.php
vendor/bin/phpunit --do-not-cache-result tests/Async/SockTest.php tests/ComposerMetadataTest.php
composer validate --strict
php vendor/phpunit/phpunit/phpunit --do-not-cache-result
```

## QA checklist

- [x] Core Composer metadata no longer requires `cboden/ratchet`.
- [x] Ratchet is documented as optional transport support.
- [x] `Sock` can be configured without starting or loading Ratchet transport classes.
- [x] Ratchet-backed behavior remains available when Ratchet is installed.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm the optional transport policy is acceptable for the next tag.
- Publish a new DevElation tag after merge so Composer consumers receive the corrected metadata.