### PR TITLE
Fix Arr unshift chain return

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -225,7 +225,10 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Unshifts the first element onto the data array
+     * Unshifts a value onto the beginning of the data array.
+     *
+     * @param mixed $value
+     * @return IVal
      */
     public function _unshift(mixed $value): IVal
     {
@@ -233,7 +236,12 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
             return $this;
         }
 
-        return array_unshift($this->_data, $value);
+        $array = $this->_data;
+        array_unshift($array, $value);
+
+        $this->alter($array);
+
+        return $this;
     }
 
     /**

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -121,6 +121,22 @@ class ArrTest extends ValTest {
 		$this->assertEquals(['foo', 'bar'], static::$classname::merge(['foo'], ['bar']));
 	}
 
+	public function testUnshiftMutatesAndReturnsSelfForChaining()
+	{
+		$object = new static::$classname(['middle']);
+
+		$result = $object->unshift('first');
+
+		$this->assertSame($object, $result);
+		$this->assertEquals(['first', 'middle'], $object->val());
+		$this->assertEquals(['first', 'middle', 'last'], $object->append(['last'])->val());
+	}
+
+	public function testUnshiftReturnsUpdatedArrayStatically()
+	{
+		$this->assertEquals(['first', 'middle'], static::$classname::unshift(['middle'], 'first'));
+	}
+
 	public function testMergeRecursesAssociativeArraysAndAppendsNestedLists()
 	{
 		$merged = static::$classname::merge(

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -208,6 +208,24 @@ class StrTest extends ValTest {
 		$this->assertSame('foobar', Str::concat('foo', 'bar'));
 	}
 
+	public function testSnakeIsChainableAndAvailableStatically()
+	{
+		$object = new Str('My Name Is John');
+
+		$this->assertSame($object, $object->snake());
+		$this->assertSame('my_name_is_john', $object->val());
+		$this->assertSame('my_name_is_john', Str::snake('My Name Is John'));
+	}
+
+	public function testPluralizeReturnsStringAndIsAvailableStatically()
+	{
+		$object = new Str('comment');
+
+		$this->assertSame('comments', $object->pluralize());
+		$this->assertSame('comments', Str::pluralize('comment'));
+		$this->assertSame('people', Str::pluralize('person'));
+	}
+
 	public function testMatchesAndMatchPatternSupportRegexChecks()
 	{
 		$this->assertTrue($this->object->matches('/^My Name/'));


### PR DESCRIPTION
Closes #147

## Intent summary

Restore `Arr::unshift()` to the same mutating helper contract as the rest of the DevElation magic chaining surface.

## User stories / acceptance criteria

- Instance calls return the `Arr` object so `Arr::make([...])->unshift(...)->append(...)` remains chainable.
- Static calls return the updated array through `Val::__callStatic` unwrapping.
- `Str::snake()` remains a chainable mutating helper and is available statically.
- `Str::pluralize()` remains a scalar string helper and is available statically.

## Key files changed

- `src/Arr.php`: `_unshift()` now mutates via `alter()` and returns `$this` instead of PHP's integer count.
- `tests/ArrTest.php`: adds instance chaining and static return regression coverage.
- `tests/StrTest.php`: confirms `snake` and `pluralize` static/helper contracts.

## How to test

```bash
php -l src/Arr.php
php -l tests/ArrTest.php
php -l tests/StrTest.php
vendor/bin/phpunit --do-not-cache-result tests/ArrTest.php tests/StrTest.php
php vendor/phpunit/phpunit/phpunit --do-not-cache-result
git diff --check
```

## QA checklist

- [x] `Arr::unshift(['middle'], 'first')` returns `['first', 'middle']`.
- [x] `$arr->unshift('first')` returns the same `Arr` instance for chaining.
- [x] `Str::snake('My Name Is John')` returns `my_name_is_john`.
- [x] `Str::pluralize('comment')` returns `comments`; irregular `person` returns `people`.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm `Arr::unshift()` should expose the mutated array for static calls rather than PHP's native count return.