### PR TITLE
Complete primitive fluent helpers

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -392,6 +392,46 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
         return $array;
     }
 
+    /**
+     * Splice the internal array with a replacement array.
+     *
+     * @param array|Arr $replacement
+     * @param int $offset
+     * @param int|null $length
+     * @return IVal
+     */
+    public function _splice(array|Arr $replacement, int $offset, int $length = null): IVal
+    {
+        if (!$this->is($this->_data)) {
+            return $this;
+        }
+
+        if ($replacement instanceof Arr) {
+            $replacement = $replacement->toArray();
+        }
+
+        $array = $this->_data;
+        array_splice($array, $offset, $length, $replacement);
+        $this->alter($array);
+
+        return $this;
+    }
+
+    /**
+     * Join the array into a Str primitive.
+     *
+     * @param string $separator
+     * @return Str
+     */
+    public function _join(string $separator = ' '): Str
+    {
+        if (!$this->is($this->_data)) {
+            return Str::make('');
+        }
+
+        return Str::make(implode($separator, $this->_data));
+    }
+
 
     /**
      * Sort the array

--- a/src/Date.php
+++ b/src/Date.php
@@ -161,8 +161,23 @@ class Date extends Val implements IVal
         return $this;
     }
 
-    public function snapshot(): IVal
+    /**
+     * Snapshot the current date value.
+     *
+     * @param int|null $limit Maximum number of snapshots to retain.
+     * @return IVal
+     */
+    public function snapshot(?int $limit = null): IVal
     {
+        if (!is_null($limit)) {
+            $this->_snapshotLimit = max(1, $limit);
+        }
+
+        $this->_snapshots[] = $this->_value;
+        while (count($this->_snapshots) > $this->_snapshotLimit) {
+            array_shift($this->_snapshots);
+        }
+
         $this->_snapshot = $this->_value;
 
         return $this;
@@ -170,7 +185,8 @@ class Date extends Val implements IVal
 
     public function reset(): IVal
     {
-        $this->_value = $this->_snapshot ?? 0;
+        $this->_value = count($this->_snapshots) > 0 ? array_pop($this->_snapshots) : 0;
+        $this->_snapshot = count($this->_snapshots) > 0 ? $this->_snapshots[count($this->_snapshots) - 1] : null;
 
         $this->setValue($this->_value);
 

--- a/src/IVal.php
+++ b/src/IVal.php
@@ -36,11 +36,12 @@ interface IVal
     public function ref(&$value): IVal;
 
     /**
-     * Snapshot the value of the var
+     * Snapshot the value of the var.
      *
+     * @param int|null $limit Maximum number of snapshots to retain.
      * @return IVal
      */
-    public function snapshot(): IVal;
+    public function snapshot(?int $limit = null): IVal;
 
     /**
      * Clear the value of the snapshot
@@ -55,6 +56,28 @@ interface IVal
      * @return IVal
      */
     public function reset(): IVal;
+
+    /**
+     * Return the most recent snapshot value.
+     *
+     * @return mixed
+     */
+    public function recall(): mixed;
+
+    /**
+     * Clone the current value object.
+     *
+     * @return IVal
+     */
+    public function copy(): IVal;
+
+    /**
+     * Assign a clone of this value object to the provided variable.
+     *
+     * @param mixed $newVar
+     * @return IVal
+     */
+    public function as(&$newVar): IVal;
 
     /**
      * Get the change between the current value and the snapshot

--- a/src/Num.php
+++ b/src/Num.php
@@ -187,18 +187,26 @@ class Num extends Val implements IVal {
      */
     public function _add(): IVal
     {
-    	$values = func_get_args();
-		$number = $this->_data;
-		if (!Num::isValid($number)) $number = 0;
+        $values = func_get_args();
+		$number = $this->numericValue($this->_data);
 
 		foreach ($values as $value) {
-			if (!Num::isValid($value)) $value = 0;
-			$number += $value;
+			$number += $this->numericValue($value);
 		}
 
 		$this->alter($number);
 
 		return $this;
+	}
+
+	/**
+	 * Alias for add().
+	 *
+	 * @return IVal
+	 */
+	public function _plus(): IVal
+	{
+		return $this->_add(...func_get_args());
 	}
 
 	/**
@@ -211,17 +219,35 @@ class Num extends Val implements IVal {
 	public function _sub(): IVal
 	{
 		$values = func_get_args();
-		$number = $this->_data;
-		if (!Num::isValid($number)) $number = 0;
+		$number = $this->numericValue($this->_data);
 
 		foreach ($values as $value) {
-			if (!Num::isValid($value)) $value = 0;
-			$number -= $value;
+			$number -= $this->numericValue($value);
 		}
 
 		$this->alter($number);
 
 		return $this;
+	}
+
+	/**
+	 * Alias for sub().
+	 *
+	 * @return IVal
+	 */
+	public function _minus(): IVal
+	{
+		return $this->_sub(...func_get_args());
+	}
+
+	/**
+	 * Verb alias for sub().
+	 *
+	 * @return IVal
+	 */
+	public function _subtract(): IVal
+	{
+		return $this->_sub(...func_get_args());
 	}
 
 	/**
@@ -234,17 +260,25 @@ class Num extends Val implements IVal {
 	public function _multiply(): IVal
 	{
 		$values = func_get_args();
-		$number = $this->_data;
-		if (!Num::isValid($number)) $number = 0;
+		$number = $this->numericValue($this->_data);
 
 		foreach ($values as $value) {
-			if (!Num::isValid($value)) $value = 0;
-			$number *= $value;
+			$number *= $this->numericValue($value);
 		}
 
 		$this->alter($number);
 
 		return $this;
+	}
+
+	/**
+	 * Alias for multiply().
+	 *
+	 * @return IVal
+	 */
+	public function _times(): IVal
+	{
+		return $this->_multiply(...func_get_args());
 	}
 
 	/**
@@ -257,11 +291,10 @@ class Num extends Val implements IVal {
 	public function _divide(): IVal
 	{
 		$values = func_get_args();
-		$number = $this->_data;
-		if (!Num::isValid($number)) $number = 0;
+		$number = $this->numericValue($this->_data);
 
 		foreach ($values as $value) {
-			if (!Num::isValid($value)) $value = 0;
+			$value = $this->numericValue($value);
 			if ($value != 0) {
 				$number /= $value;
 			}
@@ -270,6 +303,16 @@ class Num extends Val implements IVal {
 		$this->alter($number);
 
 		return $this;
+	}
+
+	/**
+	 * Alias for divide().
+	 *
+	 * @return IVal
+	 */
+	public function _by(): IVal
+	{
+		return $this->_divide(...func_get_args());
 	}
 
 	/**
@@ -301,11 +344,11 @@ class Num extends Val implements IVal {
      *
      * @return float The ratio between two values
      */
-    public function _percentage(float $part = 0, bool $percent = false): float
+    public function _percentage(mixed $part = 0, bool $percent = false): float
     {
-        $whole = $this->_data;
+        $whole = $this->numericValue($this->_data);
+        $part = $this->numericValue($part);
 
-        if (!Num::isValid($part)) $part = 0;
         if (!Num::isValid($whole)) $whole = 1;
 
         $ratio = $whole/($part * 100);
@@ -364,9 +407,9 @@ class Num extends Val implements IVal {
  	 *
  	 * @return IVal
  	 */
- 	public function _pow($power): IVal
- 	{
-        $value = pow($this->_data, $power);
+    public function _pow($power): IVal
+    {
+        $value = pow($this->numericValue($this->_data), $this->numericValue($power));
 
         $this->alter($value);
 
@@ -616,8 +659,8 @@ class Num extends Val implements IVal {
      *
      * @return float The minimum of the two numbers
      */
-    public function _min(float $number): float {
-        return min($this->_data, $number);
+    public function _min(mixed $number): float|int {
+        return min($this->numericValue($this->_data), $this->numericValue($number));
     }
 
     /**
@@ -627,9 +670,28 @@ class Num extends Val implements IVal {
      *
      * @return float The maximum of the two numbers
      */
-    public function _max(float $number): float {
-        return max($this->_data, $number);
+    public function _max(mixed $number): float|int {
+        return max($this->numericValue($this->_data), $this->numericValue($number));
     }
+
+	/**
+	 * Unwrap value objects and normalize numeric operands.
+	 *
+	 * @param mixed $value
+	 * @return float|int
+	 */
+	protected function numericValue(mixed $value): float|int
+	{
+		if ($value instanceof IVal) {
+			$value = $value->val();
+		}
+
+		if (!Num::isValid($value)) {
+			return 0;
+		}
+
+		return $value + 0;
+	}
 
     /**
      * Return int value of the $_value

--- a/src/Num.php
+++ b/src/Num.php
@@ -206,7 +206,7 @@ class Num extends Val implements IVal {
 	 */
 	public function _plus(): IVal
 	{
-		return $this->_add(...func_get_args());
+		return $this->add(...func_get_args());
 	}
 
 	/**
@@ -237,7 +237,7 @@ class Num extends Val implements IVal {
 	 */
 	public function _minus(): IVal
 	{
-		return $this->_sub(...func_get_args());
+		return $this->sub(...func_get_args());
 	}
 
 	/**
@@ -247,7 +247,7 @@ class Num extends Val implements IVal {
 	 */
 	public function _subtract(): IVal
 	{
-		return $this->_sub(...func_get_args());
+		return $this->sub(...func_get_args());
 	}
 
 	/**
@@ -278,7 +278,7 @@ class Num extends Val implements IVal {
 	 */
 	public function _times(): IVal
 	{
-		return $this->_multiply(...func_get_args());
+		return $this->multiply(...func_get_args());
 	}
 
 	/**
@@ -312,7 +312,7 @@ class Num extends Val implements IVal {
 	 */
 	public function _by(): IVal
 	{
-		return $this->_divide(...func_get_args());
+		return $this->divide(...func_get_args());
 	}
 
 	/**

--- a/src/Str.php
+++ b/src/Str.php
@@ -222,7 +222,11 @@ class Str extends Val implements IVal {
 	 *
 	 * @return int The position of the first occurrence of $needle in the string, or -1 if not found
 	 */
-	public function _pos(string $needle): int|bool {
+	public function _pos(string $needle, int $mode = self::MATCH_EXACT): int|bool {
+		if (($mode & self::IGNORE_CASE) === self::IGNORE_CASE) {
+			return stripos($this->_data, $needle);
+		}
+
 		return strpos($this->_data, $needle);
 	}
 
@@ -233,8 +237,8 @@ class Str extends Val implements IVal {
 	 *
 	 * @return int The position of the first occurrence of $needle in the string, or -1 if not found
 	 */
-	public function _ipos(string $needle): int {
-		return stripos($this->_data, $needle);
+	public function _ipos(string $needle): int|bool {
+		return $this->_pos($needle, self::IGNORE_CASE);
 	}
 
 	// Reverse strpos
@@ -266,6 +270,15 @@ class Str extends Val implements IVal {
 			return 0;
 		}
 		return strlen($this->_data);
+	}
+
+	/**
+	 * Alias for the string length helper.
+	 *
+	 * @return int
+	 */
+	public function _size(): int {
+		return $this->_len();
 	}
 
 	/**

--- a/src/Val.php
+++ b/src/Val.php
@@ -35,6 +35,41 @@ class Val implements IVal, IDispatcher {
 	protected $_snapshot = null;
 
 	/**
+	 * Queue of captured snapshots.
+	 *
+	 * @var array<int, mixed>
+	 */
+	protected array $_snapshots = [];
+
+	/**
+	 * Maximum number of snapshots retained.
+	 *
+	 * @var int
+	 */
+	protected int $_snapshotLimit = 1;
+
+	/**
+	 * Temporary condition used by then()/otherwise().
+	 *
+	 * @var bool
+	 */
+	protected bool $_temporaryCondition = false;
+
+	/**
+	 * Whether a temporary condition is currently set.
+	 *
+	 * @var bool
+	 */
+	protected bool $_hasTemporaryCondition = false;
+
+	/**
+	 * Most recently consumed condition, retained for otherwise().
+	 *
+	 * @var bool|null
+	 */
+	protected ?bool $_lastCondition = null;
+
+	/**
 	 * @var string $_forceType
 	 */
 	protected $_forceType = false;
@@ -48,7 +83,7 @@ class Val implements IVal, IDispatcher {
 
 	private static $_last = null;
 
-	private static $_slots = [];
+	private static array $_slots = [];
 
 	/**
 	 * @var string PRIVATE_PREFIX
@@ -197,7 +232,10 @@ class Val implements IVal, IDispatcher {
 	 */
 	public static function slot(string $name, callable $callable): IVal
 	{
-		$this->_slots[$name] = $callable->bindTo($this, $this);
+		$class = get_called_class();
+		self::$_slots[$class][$name] = \Closure::fromCallable($callable);
+
+		return new $class();
 	}
 
 	/**
@@ -419,7 +457,9 @@ class Val implements IVal, IDispatcher {
 	 * @return IVal The instance of the Flag class
 	 */
 	public function then( $callback ) {
-		if ( $this->_data ) {
+		$condition = $this->conditionForThen();
+
+		if ( $condition ) {
 			$callback( $this );
 		}
 
@@ -434,9 +474,28 @@ class Val implements IVal, IDispatcher {
 	 * @return IVal The instance of the Flag class
 	 */
 	public function otherwise( $callback ) {
-		if ( !$this->_data ) {
+		$condition = $this->conditionForOtherwise();
+
+		if ( !$condition ) {
 			$callback( $this );
 		}
+
+		return $this;
+	}
+
+	/**
+	 * Set a temporary condition for then()/otherwise() chains.
+	 *
+	 * @param mixed $valueOrMethodName
+	 * @param mixed|null $compValueOrOperator
+	 * @param mixed|null $compValue
+	 * @return IVal
+	 */
+	public function _if(mixed $valueOrMethodName, mixed $compValueOrOperator = null, mixed $compValue = null): IVal
+	{
+		$this->_temporaryCondition = $this->evaluateCondition($valueOrMethodName, $compValueOrOperator, $compValue, func_num_args());
+		$this->_hasTemporaryCondition = true;
+		$this->_lastCondition = null;
 
 		return $this;
 	}
@@ -593,15 +652,35 @@ class Val implements IVal, IDispatcher {
 	}
 
 	/**
-	 * Snapshot the value of the var
+	 * Snapshot the value of the var.
 	 *
+	 * @param int|null $limit Maximum number of snapshots to retain.
 	 * @return IVal
 	 */
-	public function snapshot(): IVal
+	public function snapshot(?int $limit = null): IVal
 	{
+		if ( !is_null($limit) ) {
+			$this->_snapshotLimit = max(1, $limit);
+		}
+
+		$this->_snapshots[] = $this->_data;
+		while (count($this->_snapshots) > $this->_snapshotLimit) {
+			array_shift($this->_snapshots);
+		}
+
 		$this->_snapshot = $this->_data;
 
 		return $this;
+	}
+
+	/**
+	 * Return the most recent snapshot value.
+	 *
+	 * @return mixed
+	 */
+	public function recall(): mixed
+	{
+		return $this->_snapshot;
 	}
 
 	/**
@@ -611,6 +690,7 @@ class Val implements IVal, IDispatcher {
 	public function clearSnapshot(): IVal
 	{
 		$this->_snapshot = null;
+		$this->_snapshots = [];
 
 		return $this;
 	}
@@ -622,8 +702,14 @@ class Val implements IVal, IDispatcher {
 	 */
 	public function reset(): IVal
 	{
-		$this->_data = $this->_snapshot;
-		$this->trigger(Event::CHANGE);
+		$value = null;
+
+		if (count($this->_snapshots) > 0) {
+			$value = array_pop($this->_snapshots);
+		}
+
+		$this->_snapshot = count($this->_snapshots) > 0 ? $this->_snapshots[count($this->_snapshots) - 1] : null;
+		$this->alter($value);
 
 		return $this;
 	}
@@ -636,6 +722,29 @@ class Val implements IVal, IDispatcher {
 	public function delta()
 	{
 		return $this->_data - $this->_snapshot;
+	}
+
+	/**
+	 * Clone the current value object.
+	 *
+	 * @return IVal
+	 */
+	public function copy(): IVal
+	{
+		return clone $this;
+	}
+
+	/**
+	 * Assign a clone of this value object to the provided variable.
+	 *
+	 * @param mixed $newVar
+	 * @return IVal
+	 */
+	public function as(&$newVar): IVal
+	{
+		$newVar = $this->copy();
+
+		return $newVar;
 	}
 
 	/**
@@ -712,9 +821,13 @@ class Val implements IVal, IDispatcher {
 			
 			return $output;
 		} else {
-			if ( in_array($method, self::$_slots, true) ) {
+			$slot = self::slotFor(get_class($this), $method);
+			if ( $slot ) {
 				$this->trigger(Event::ACTION_PERFORMED);
-				return call_user_func_array(self::$_slots[$method], $args);
+				$bound = $slot->bindTo($this, get_class($this));
+				$output = call_user_func_array($bound, $args);
+
+				return $output ?? $this;
 			}
 
 			// throw new Exception("Method {$method} not defined", 1);
@@ -766,11 +879,162 @@ class Val implements IVal, IDispatcher {
 				$output = $output->val();
 			}
 			return $output;
-		} 
+		}
+
+		$slot = self::slotFor($class, $method);
+		if ( $slot ) {
+			$value = array_shift($args);
+
+			self::$_last = $value;
+
+			$object = new $class($value, false, false);
+			$bound = $slot->bindTo($object, $class);
+			$output = call_user_func_array($bound, $args);
+			if ( $output instanceof IVal ) {
+				return $output->val();
+			}
+
+			return $output ?? $object->val();
+		}
 
 		// throw new Exception("Method {$method} not defined", 1);
 		error_log("Method {$method} not defined in class " . get_called_class());
 		return false;
+	}
+
+	/**
+	 * Resolve a registered slot for a class, including inherited slots.
+	 *
+	 * @param string $class
+	 * @param string $method
+	 * @return \Closure|null
+	 */
+	protected static function slotFor(string $class, string $method): ?\Closure
+	{
+		$classes = array_merge([$class], class_parents($class) ?: []);
+
+		foreach ($classes as $candidate) {
+			if ( isset(self::$_slots[$candidate][$method]) ) {
+				return self::$_slots[$candidate][$method];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve the condition consumed by then().
+	 *
+	 * @return bool
+	 */
+	protected function conditionForThen(): bool
+	{
+		if ( $this->_hasTemporaryCondition ) {
+			$condition = $this->_temporaryCondition;
+			$this->_lastCondition = $condition;
+			$this->_hasTemporaryCondition = false;
+
+			return $condition;
+		}
+
+		return (bool)$this->_data;
+	}
+
+	/**
+	 * Resolve the condition consumed by otherwise().
+	 *
+	 * @return bool
+	 */
+	protected function conditionForOtherwise(): bool
+	{
+		if ( !is_null($this->_lastCondition) ) {
+			$condition = $this->_lastCondition;
+			$this->_lastCondition = null;
+
+			return $condition;
+		}
+
+		if ( $this->_hasTemporaryCondition ) {
+			$condition = $this->_temporaryCondition;
+			$this->_hasTemporaryCondition = false;
+
+			return $condition;
+		}
+
+		return (bool)$this->_data;
+	}
+
+	/**
+	 * Evaluate an if() condition.
+	 *
+	 * @param mixed $valueOrMethodName
+	 * @param mixed|null $compValueOrOperator
+	 * @param mixed|null $compValue
+	 * @param int $argCount
+	 * @return bool
+	 */
+	protected function evaluateCondition(mixed $valueOrMethodName, mixed $compValueOrOperator, mixed $compValue, int $argCount): bool
+	{
+		if ( $argCount === 1 ) {
+			return $this->compareValues($this->_data, '=', $valueOrMethodName);
+		}
+
+		$left = $this->conditionSubject($valueOrMethodName);
+
+		if ( $argCount === 2 ) {
+			return $this->compareValues($left, '=', $compValueOrOperator);
+		}
+
+		return $this->compareValues($left, (string)$compValueOrOperator, $compValue);
+	}
+
+	/**
+	 * Resolve a conditional subject from a method/helper name or literal value.
+	 *
+	 * @param mixed $value
+	 * @return mixed
+	 */
+	protected function conditionSubject(mixed $value): mixed
+	{
+		if ( is_string($value) ) {
+			if ( method_exists($this, $value) ) {
+				$value = $this->{$value}();
+			} elseif ( method_exists($this, self::PRIVATE_PREFIX.$value) ) {
+				$value = $this->{self::PRIVATE_PREFIX.$value}();
+			}
+		}
+
+		return $value instanceof IVal ? $value->val() : $value;
+	}
+
+	/**
+	 * Compare two values with a supported operator.
+	 *
+	 * @param mixed $left
+	 * @param string $operator
+	 * @param mixed $right
+	 * @return bool
+	 */
+	protected function compareValues(mixed $left, string $operator, mixed $right): bool
+	{
+		if ( $left instanceof IVal ) {
+			$left = $left->val();
+		}
+		if ( $right instanceof IVal ) {
+			$right = $right->val();
+		}
+
+		return match ($operator) {
+			'=', '==' => $left == $right,
+			'===' => $left === $right,
+			'!=', '<>' => $left != $right,
+			'!==' => $left !== $right,
+			'>' => $left > $right,
+			'>=' => $left >= $right,
+			'<' => $left < $right,
+			'<=' => $left <= $right,
+			default => false,
+		};
 	}
 
 	public function __destroy()

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -287,6 +287,30 @@ class ArrTest extends ValTest {
 		$this->assertEquals([5 => 'five', 2 => 'two'], static::$classname::reverse([2 => 'two', 5 => 'five'], true));
 	}
 
+	public function testSpliceMutatesAndReturnsSelfForChaining()
+	{
+		$object = new static::$classname(['hello', 'world']);
+
+		$result = $object->splice(['my', 'friends'], 1, 1);
+
+		$this->assertSame($object, $result);
+		$this->assertSame(['hello', 'my', 'friends'], $object->val());
+	}
+
+	public function testSpliceReturnsUpdatedArrayStatically()
+	{
+		$this->assertSame(['hello', 'my', 'friends'], static::$classname::splice(['hello', 'world'], ['my', 'friends'], 1, 1));
+	}
+
+	public function testJoinReturnsStringPrimitiveAndStaticString()
+	{
+		$object = new static::$classname(['hello', 'my', 'friends']);
+
+		$this->assertSame('hello my friends', $object->join()->val());
+		$this->assertSame('hello,my,friends', static::$classname::join(['hello', 'my', 'friends'], ','));
+		$this->assertSame('hello my friends', \BlueFission\Str::make('hello world')->split()->splice(['my', 'friends'], 1, 1)->join()->val());
+	}
+
 	public function testsRemovesDuplicates()
 	{
 		$object = new static::$classname(['foo', 'bar', 'foo']);

--- a/tests/NumTest.php
+++ b/tests/NumTest.php
@@ -165,6 +165,23 @@ class NumTest extends ValTest
         $this->assertEquals(6, $number->divide(4)->val());
     }
 
+    public function testMathAliasesAcceptValueObjects()
+    {
+        $number = Num::make(10);
+
+        $number
+            ->plus(Num::make(5))
+            ->times(Num::make(2))
+            ->by(Num::make(5))
+            ->minus(Num::make(1));
+
+        $this->assertEquals(5, $number->val());
+        $this->assertEquals(15, Num::plus(10, Num::make(5)));
+        $this->assertEquals(8, Num::subtract(10, Num::make(2)));
+        $this->assertEquals(20, Num::times(10, Num::make(2)));
+        $this->assertEquals(5, Num::by(10, Num::make(2)));
+    }
+
     public function testPowerAndRootHelpersMutateValue()
     {
         $number = new Num(9);

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -198,6 +198,22 @@ class StrTest extends ValTest {
 		$this->assertFalse(Str::match('', 0));
 	}
 
+	public function testSizeAliasesLen()
+	{
+		$this->assertSame(15, $this->object->size());
+		$this->assertSame(15, Str::size('My Name Is John'));
+	}
+
+	public function testPosSupportsIgnoreCaseModeAndIposAlias()
+	{
+		$object = new Str('Content-Type');
+
+		$this->assertSame(8, $object->pos('type', Str::IGNORE_CASE));
+		$this->assertSame(8, $object->ipos('type'));
+		$this->assertFalse($object->pos('type'));
+		$this->assertSame(8, Str::pos('Content-Type', 'type', Str::IGNORE_CASE));
+	}
+
 	public function testAppendPrependAndConcatMutateString()
 	{
 		$object = new Str('john');

--- a/tests/ValTest.php
+++ b/tests/ValTest.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Tests;
 
 use BlueFission\Val;
+use BlueFission\Num;
 use BlueFission\DataTypes;
 
 class ValTest extends \PHPUnit\Framework\TestCase
@@ -333,5 +334,82 @@ class ValTest extends \PHPUnit\Framework\TestCase
         }
 
         $this->assertEquals($var1, $var2->val());
+    }
+
+    public function testStaticSlotRegistrationWorksForInstancesAndStaticDispatch()
+    {
+        Val::slot('appendUnitTestSuffix', function ($suffix = 'Suffix') {
+            $this->val($this->val() . $suffix);
+
+            return $this;
+        });
+
+        $this->assertSame('valueSuffix', Val::make('value')->appendUnitTestSuffix()->val());
+        $this->assertSame('value!', Val::appendUnitTestSuffix('value', '!'));
+    }
+
+    public function testSnapshotQueueRecallAndResetWalksBack()
+    {
+        $value = new Val('one', false);
+
+        $value
+            ->snapshot(3)
+            ->val('two')
+            ->snapshot()
+            ->val('three')
+            ->snapshot()
+            ->val('four');
+
+        $this->assertSame('three', $value->recall());
+        $this->assertSame('three', $value->reset()->val());
+        $this->assertSame('two', $value->reset()->val());
+        $this->assertSame('one', $value->reset()->val());
+    }
+
+    public function testCopyAndAsCloneValueObjects()
+    {
+        $value = Val::make('base');
+        $copy = $value->copy();
+
+        $copy->val('copy');
+
+        $this->assertSame('base', $value->val());
+        $this->assertSame('copy', $copy->val());
+
+        $value->as($assigned);
+
+        $this->assertNotSame($value, $assigned);
+        $this->assertSame('base', $assigned->val());
+    }
+
+    public function testConditionalIfSupportsValueMethodAndOperatorComparisons()
+    {
+        $value = new Val('ready', false);
+        $hit = false;
+        $miss = false;
+
+        $value
+            ->if('ready')
+            ->then(function () use (&$hit) {
+                $hit = true;
+            })
+            ->otherwise(function () use (&$miss) {
+                $miss = true;
+            });
+
+        $number = new Num(1, false);
+        $changed = false;
+
+        $number
+            ->snapshot()
+            ->val(3)
+            ->if('delta', '>', 0)
+            ->then(function () use (&$changed) {
+                $changed = true;
+            });
+
+        $this->assertTrue($hit);
+        $this->assertFalse($miss);
+        $this->assertTrue($changed);
     }
 }


### PR DESCRIPTION
Closes #149

## Intent summary
Complete the first primitive-helper slice for fluent value objects and static helper parity.

## User stories / acceptance criteria
- As a consumer, I can register Val slots statically and call them on instances or through static helper dispatch.
- As a consumer, I can retain a bounded snapshot queue, recall the current snapshot, reset backward through snapshots, and clone values fluently.
- As a consumer, I can use Val conditional chaining with value, method, and operator comparisons.
- As a consumer, I can splice and join Arr values in a Str split/splice/join chain.
- As a consumer, I can use Str size() and a shared IGNORE_CASE mode for position checks.
- As a consumer, I can use Num aliases plus/minus/times/by/subtract with Val operands.

## Key files changed
- src/Val.php, src/IVal.php, src/Date.php
- src/Arr.php, src/Str.php, src/Num.php
- tests/ValTest.php, tests/ArrTest.php, tests/StrTest.php, tests/NumTest.php

## How to test
- php -l src\\IVal.php
- php -l src\\Val.php
- php -l src\\Date.php
- php -l src\\Arr.php
- php -l src\\Str.php
- php -l src\\Num.php
- php -l tests\\ValTest.php
- php -l tests\\ArrTest.php
- php -l tests\\StrTest.php
- php -l tests\\NumTest.php
- vendor\\bin\\phpunit --do-not-cache-result tests\\ValTest.php
- vendor\\bin\\phpunit --do-not-cache-result tests\\ArrTest.php
- vendor\\bin\\phpunit --do-not-cache-result tests\\StrTest.php
- vendor\\bin\\phpunit --do-not-cache-result tests\\NumTest.php
- vendor\\bin\\phpunit --do-not-cache-result
- composer validate --strict
- git diff --check

## QA checklist
- [x] Focused primitive tests pass.
- [x] Full PHPUnit suite passes.
- [x] Composer metadata validates.
- [x] Diff whitespace check passes.

## Approval conditions
- Confirm the snapshot queue API and conditional comparison semantics match the intended fluent primitive direction.
- Confirm Arr::splice argument order is acceptable for split()->splice(replacement, offset, length)->join() chaining.
