### PR TITLE
Add IPC dispatch contract

### DIFF
--- a/src/Behavioral/Dispatches.php
+++ b/src/Behavioral/Dispatches.php
@@ -10,7 +10,6 @@ use BlueFission\Behavioral\Behaviors\Meta;
 use BlueFission\Behavioral\Behaviors\Handler;
 use BlueFission\Behavioral\Behaviors\HandlerCollection;
 use BlueFission\Behavioral\Behaviors\BehaviorCollection;
-use BlueFission\IPC\IIPC;
 use InvalidArgumentException;
 
 /**
@@ -32,13 +31,6 @@ trait Dispatches
      * @var HandlerCollection
      */
     protected $_handlers;
-
-    /**
-     * Optional IPC transport for mirrored dispatches.
-     *
-     * @var IIPC|null
-     */
-    protected ?IIPC $_ipc = null;
 
     /**
      * Constructor of the Dispatches class
@@ -166,73 +158,12 @@ trait Dispatches
         }
 
         $this->trigger($behavior, $args);
-        $this->dispatchBehaviorIPC($behavior, $args);
 
-        return $this;
-    }
-
-    /**
-     * Inject an IPC transport for mirrored dispatches.
-     *
-     * @param IIPC $ipc
-     * @return static
-     */
-    public function setIPC(IIPC $ipc): static
-    {
-        $this->_ipc = $ipc;
-
-        return $this;
-    }
-
-    /**
-     * Send a message to an IPC channel when a transport is available.
-     *
-     * @param string $channel
-     * @param mixed $message
-     * @return static
-     */
-    public function dispatchIPC(string $channel, mixed $message): static
-    {
-        if ($this->_ipc) {
-            $this->_ipc->write($channel, $message);
+        if (method_exists($this, '_dispatch')) {
+            $this->_dispatch($behavior, $args);
         }
 
         return $this;
-    }
-
-    /**
-     * Read an IPC channel and pass messages to a callback.
-     *
-     * @param string $channel
-     * @param callable $callback
-     * @return static
-     */
-    public function listenIPC(string $channel, callable $callback): static
-    {
-        if ($this->_ipc) {
-            $messages = $this->_ipc->read($channel);
-            foreach ($messages as $message) {
-                $callback($message);
-            }
-            $this->_ipc->clear($channel);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Mirror a standard behavior dispatch to IPC.
-     *
-     * @param Behavior $behavior
-     * @param mixed $args
-     * @return void
-     */
-    protected function dispatchBehaviorIPC(Behavior $behavior, mixed $args): void
-    {
-        $this->dispatchIPC($behavior->name(), [
-            'behavior' => $behavior->name(),
-            'args' => $args,
-        ]);
     }
 
     /**

--- a/src/Behavioral/Dispatches.php
+++ b/src/Behavioral/Dispatches.php
@@ -10,6 +10,7 @@ use BlueFission\Behavioral\Behaviors\Meta;
 use BlueFission\Behavioral\Behaviors\Handler;
 use BlueFission\Behavioral\Behaviors\HandlerCollection;
 use BlueFission\Behavioral\Behaviors\BehaviorCollection;
+use BlueFission\IPC\IIPC;
 use InvalidArgumentException;
 
 /**
@@ -31,6 +32,13 @@ trait Dispatches
      * @var HandlerCollection
      */
     protected $_handlers;
+
+    /**
+     * Optional IPC transport for mirrored dispatches.
+     *
+     * @var IIPC|null
+     */
+    protected ?IIPC $_ipc = null;
 
     /**
      * Constructor of the Dispatches class
@@ -157,7 +165,74 @@ trait Dispatches
             $args = [$args];
         }
 
-        return $this->trigger($behavior, $args);
+        $this->trigger($behavior, $args);
+        $this->dispatchBehaviorIPC($behavior, $args);
+
+        return $this;
+    }
+
+    /**
+     * Inject an IPC transport for mirrored dispatches.
+     *
+     * @param IIPC $ipc
+     * @return static
+     */
+    public function setIPC(IIPC $ipc): static
+    {
+        $this->_ipc = $ipc;
+
+        return $this;
+    }
+
+    /**
+     * Send a message to an IPC channel when a transport is available.
+     *
+     * @param string $channel
+     * @param mixed $message
+     * @return static
+     */
+    public function dispatchIPC(string $channel, mixed $message): static
+    {
+        if ($this->_ipc) {
+            $this->_ipc->write($channel, $message);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Read an IPC channel and pass messages to a callback.
+     *
+     * @param string $channel
+     * @param callable $callback
+     * @return static
+     */
+    public function listenIPC(string $channel, callable $callback): static
+    {
+        if ($this->_ipc) {
+            $messages = $this->_ipc->read($channel);
+            foreach ($messages as $message) {
+                $callback($message);
+            }
+            $this->_ipc->clear($channel);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Mirror a standard behavior dispatch to IPC.
+     *
+     * @param Behavior $behavior
+     * @param mixed $args
+     * @return void
+     */
+    protected function dispatchBehaviorIPC(Behavior $behavior, mixed $args): void
+    {
+        $this->dispatchIPC($behavior->name(), [
+            'behavior' => $behavior->name(),
+            'args' => $args,
+        ]);
     }
 
     /**

--- a/src/Behavioral/IPCDispatches.php
+++ b/src/Behavioral/IPCDispatches.php
@@ -2,7 +2,7 @@
 
 namespace BlueFission\Behavioral;
 
-use BlueFission\IPC\IPC;
+use BlueFission\IPC\IIPC;
 
 /**
  * Trait IPCDispatches
@@ -13,17 +13,19 @@ use BlueFission\IPC\IPC;
  */
 trait IPCDispatches
 {
-    protected $_ipc;
+    protected ?IIPC $_ipc = null;
 
     /**
      * Injects an IPC instance into the class.
      *
-     * @param IPC $ipc The IPC object to use for communication
-     * @return void
+     * @param IIPC $ipc The IPC object to use for communication
+     * @return static
      */
-    public function setIPC(IPC $ipc): void
+    public function setIPC(IIPC $ipc): static
     {
         $this->_ipc = $ipc;
+
+        return $this;
     }
 
     /**
@@ -31,13 +33,15 @@ trait IPCDispatches
      *
      * @param string $channel The channel to write to
      * @param mixed $message The message payload to send
-     * @return void
+     * @return static
      */
-    public function dispatchIPC(string $channel, $message): void
+    public function dispatchIPC(string $channel, mixed $message): static
     {
         if ($this->_ipc) {
             $this->_ipc->write($channel, $message);
         }
+
+        return $this;
     }
 
     /**
@@ -45,9 +49,9 @@ trait IPCDispatches
      *
      * @param string $channel The channel to listen to
      * @param callable $callback The function to run on each received message
-     * @return void
+     * @return static
      */
-    public function listenIPC(string $channel, callable $callback): void
+    public function listenIPC(string $channel, callable $callback): static
     {
         if ($this->_ipc) {
             $messages = $this->_ipc->read($channel);
@@ -56,5 +60,7 @@ trait IPCDispatches
             }
             $this->_ipc->clear($channel);
         }
+
+        return $this;
     }
 }

--- a/src/Behavioral/IPCDispatches.php
+++ b/src/Behavioral/IPCDispatches.php
@@ -2,14 +2,15 @@
 
 namespace BlueFission\Behavioral;
 
+use BlueFission\Behavioral\Behaviors\Behavior;
 use BlueFission\IPC\IIPC;
 
 /**
  * Trait IPCDispatches
  *
- * Provides inter-process communication (IPC) dispatching and listening capabilities
- * via a shared IPC object. Classes using this trait can send messages to and listen
- * for messages from specific channels.
+ * Provides inter-process communication (IPC) dispatching and listening
+ * capabilities via a shared IPC object. When paired with Dispatches, the
+ * protected _dispatch hook mirrors standard behavior dispatches to IPC.
  */
 trait IPCDispatches
 {
@@ -62,5 +63,20 @@ trait IPCDispatches
         }
 
         return $this;
+    }
+
+    /**
+     * Mirror a standard behavior dispatch to IPC.
+     *
+     * @param Behavior $behavior
+     * @param mixed $args
+     * @return void
+     */
+    protected function _dispatch(Behavior $behavior, mixed $args = null): void
+    {
+        $this->dispatchIPC($behavior->name(), [
+            'behavior' => $behavior->name(),
+            'args' => $args,
+        ]);
     }
 }

--- a/src/IPC/IIPC.php
+++ b/src/IPC/IIPC.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BlueFission\IPC;
+
+interface IIPC
+{
+    /**
+     * Write a message to a channel.
+     *
+     * @param string $channel
+     * @param mixed $message
+     * @return void
+     */
+    public function write(string $channel, mixed $message): void;
+
+    /**
+     * Read messages from a channel.
+     *
+     * @param string $channel
+     * @return array
+     */
+    public function read(string $channel): array;
+
+    /**
+     * Clear messages from a channel.
+     *
+     * @param string $channel
+     * @return void
+     */
+    public function clear(string $channel): void;
+}

--- a/src/IPC/IPC.php
+++ b/src/IPC/IPC.php
@@ -4,9 +4,8 @@ namespace BlueFission\IPC;
 
 use BlueFission\Data\Storage\Storage;
 use BlueFission\Behavioral\Behaviors\State;
-use BlueFission\Behavioral\Behaviors\Event;
 
-class IPC
+class IPC implements IIPC
 {
     protected $_storage;
     protected $_maxRetries;
@@ -17,7 +16,7 @@ class IPC
         $this->_maxRetries = $maxRetries;
     }
 
-    public function write($channel, $message)
+    public function write(string $channel, mixed $message): void
     {
         if ($this->retryConnection()) {
             $data = $this->_storage->read() ?? [];
@@ -30,7 +29,7 @@ class IPC
         }
     }
 
-    public function read($channel)
+    public function read(string $channel): array
     {
         if ($this->retryConnection()) {
             $data = $this->_storage->read() ?? [];
@@ -42,7 +41,7 @@ class IPC
         }
     }
 
-    public function clear($channel)
+    public function clear(string $channel): void
     {
         if ($this->retryConnection()) {
             $data = $this->_storage->read() ?? [];

--- a/tests/Behavioral/DispatcherTest.php
+++ b/tests/Behavioral/DispatcherTest.php
@@ -3,7 +3,9 @@
 namespace BlueFission\Tests\Behavioral;
 
 use BlueFission\Behavioral\Dispatches;
+use BlueFission\Behavioral\IPCDispatches;
 use BlueFission\Behavioral\IDispatcher;
+use BlueFission\IPC\IIPC;
 
 class DispatcherTest extends \PHPUnit\Framework\TestCase
 {
@@ -57,4 +59,80 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         $this->object->dispatch('testBehavior', "This Manual Event Was Dispatched");
     }
 
+    public function testDispatchMirrorsToInjectedIPC()
+    {
+        $ipc = new class implements IIPC {
+            public array $messages = [];
+
+            public function write(string $channel, mixed $message): void
+            {
+                $this->messages[$channel][] = $message;
+            }
+
+            public function read(string $channel): array
+            {
+                return $this->messages[$channel] ?? [];
+            }
+
+            public function clear(string $channel): void
+            {
+                unset($this->messages[$channel]);
+            }
+        };
+
+        $this->expectOutputString('local');
+
+        $this->object->setIPC($ipc);
+        $this->object->behavior('testBehavior', function () {
+            echo 'local';
+        });
+        $this->object->dispatch('testBehavior', 'payload');
+
+        $this->assertSame(
+            [
+                [
+                    'behavior' => 'testBehavior',
+                    'args' => ['payload'],
+                ],
+            ],
+            $ipc->messages['testBehavior']
+        );
+    }
+
+    public function testIPCDispatchesTraitHelpersUseTransport()
+    {
+        $ipc = new class implements IIPC {
+            public array $messages = [];
+
+            public function write(string $channel, mixed $message): void
+            {
+                $this->messages[$channel][] = $message;
+            }
+
+            public function read(string $channel): array
+            {
+                return $this->messages[$channel] ?? [];
+            }
+
+            public function clear(string $channel): void
+            {
+                unset($this->messages[$channel]);
+            }
+        };
+
+        $object = new class {
+            use IPCDispatches;
+        };
+        $received = [];
+
+        $object
+            ->setIPC($ipc)
+            ->dispatchIPC('manual', ['value' => 1])
+            ->listenIPC('manual', function ($message) use (&$received) {
+                $received[] = $message;
+            });
+
+        $this->assertSame([['value' => 1]], $received);
+        $this->assertSame([], $ipc->read('manual'));
+    }
 }

--- a/tests/Behavioral/DispatcherTest.php
+++ b/tests/Behavioral/DispatcherTest.php
@@ -59,7 +59,14 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
         $this->object->dispatch('testBehavior', "This Manual Event Was Dispatched");
     }
 
-    public function testDispatchMirrorsToInjectedIPC()
+    public function testDispatchesDoesNotExposeIPCByDefault()
+    {
+        $this->assertFalse(method_exists($this->object, 'setIPC'));
+        $this->assertFalse(method_exists($this->object, 'dispatchIPC'));
+        $this->assertFalse(method_exists($this->object, 'listenIPC'));
+    }
+
+    public function testIPCDispatchTraitMirrorsStandardDispatchToInjectedIPC()
     {
         $ipc = new class implements IIPC {
             public array $messages = [];
@@ -82,11 +89,16 @@ class DispatcherTest extends \PHPUnit\Framework\TestCase
 
         $this->expectOutputString('local');
 
-        $this->object->setIPC($ipc);
-        $this->object->behavior('testBehavior', function () {
+        $object = new class implements IDispatcher {
+            use Dispatches;
+            use IPCDispatches;
+        };
+
+        $object->setIPC($ipc);
+        $object->behavior('testBehavior', function () {
             echo 'local';
         });
-        $this->object->dispatch('testBehavior', 'payload');
+        $object->dispatch('testBehavior', 'payload');
 
         $this->assertSame(
             [


### PR DESCRIPTION
Closes #151

## Intent summary
Add a first-party IPC transport contract and keep IPC dispatch behavior explicitly opt-in through IPCDispatches.

## User stories / acceptance criteria
- As a dispatcher user, plain Dispatches remains local-only and does not expose IPC helpers by default.
- As a dispatcher user, I can add IPCDispatches to a Dispatches class to mirror normalized behavior payloads to an injected IPC transport.
- As a dispatcher user, local behavior handlers continue to run as before when dispatch() is called.
- As a standalone IPC helper user, IPCDispatches exposes fluent setIPC(), dispatchIPC(), and listenIPC() helpers.

## Key files changed
- src/IPC/IIPC.php
- src/IPC/IPC.php
- src/Behavioral/Dispatches.php
- src/Behavioral/IPCDispatches.php
- tests/Behavioral/DispatcherTest.php

## How to test
- php -l src\\IPC\\IIPC.php
- php -l src\\IPC\\IPC.php
- php -l src\\Behavioral\\Dispatches.php
- php -l src\\Behavioral\\IPCDispatches.php
- php -l tests\\Behavioral\\DispatcherTest.php
- vendor\\bin\\phpunit --do-not-cache-result tests\\Behavioral\\DispatcherTest.php
- vendor\\bin\\phpunit --do-not-cache-result tests\\Behavioral
- vendor\\bin\\phpunit --do-not-cache-result
- composer validate --strict
- git diff --check

## QA checklist
- [x] Plain Dispatches remains local-only by default.
- [x] IPCDispatches provides the protected _dispatch hook for opt-in mirroring.
- [x] Dispatcher unit tests pass.
- [x] Behavioral test suite passes.
- [x] Full PHPUnit suite passes.
- [x] Composer metadata validates.
- [x] Diff whitespace check passes.

## Approval conditions
- Confirm the IPC mirror payload shape should be { behavior, args } on the behavior-name channel.
- Confirm the opt-in IPCDispatches hook is the right inheritance/trait boundary for IPC-aware dispatchers.
