### PR TITLE
Harden example smoke coverage

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -86,6 +86,6 @@ These examples intentionally stay small, but there are several DevElation featur
 - **Service mappings** (`Services\Mapping`, `Services\Request`/`Response`): wrap the todo or comments example as small services with typed requests/responses, showing how DevElation maps between external APIs and internal objects.
 - **Async/queues** (`Async`, `Data\Queues\Queue`): move expensive or periodic work (e.g., nightly purge of stale todos, background scoring) onto a DevElation queue.
 - **DevElation hooks** (`DevElation::apply`, `DevElation::do`): add filters/actions around critical points (before saving a todo, after posting a comment, when the NPC changes state) to demonstrate pluggable behavior without touching the core example logic.
-- **Example smoke tests** (`tests/Examples/ExamplesSmokeTest.php`): keep non-interactive examples executable as the helper surface evolves.
+- **Example smoke tests** (`tests/Examples/ExamplesSmokeTest.php`): keep non-interactive examples executable as the helper surface evolves. Run them with `vendor/bin/phpunit --do-not-cache-result tests/Examples/ExamplesSmokeTest.php`.
 
 Each of these modules already exists in `src/` and can be layered into the examples as you grow them into more full‑featured reference apps.

--- a/tests/Examples/ExamplesSmokeTest.php
+++ b/tests/Examples/ExamplesSmokeTest.php
@@ -7,9 +7,33 @@ use PHPUnit\Framework\TestCase;
 
 class ExamplesSmokeTest extends TestCase
 {
-    public function testCliReportExampleRuns(): void
+    public function testRunnableExamplesProduceExpectedOutput(): void
     {
-        [$exitCode, $output, $error] = $this->runExample([
+        $workflow = HTTP::jsonDecode($this->runExample(['examples/helpers/workflow.php']));
+
+        $this->assertSame('=== DevElation helper workflow ===', $workflow['title']);
+        $this->assertSame(3, $workflow['name_count']);
+        $this->assertTrue($workflow['source_file_exists']);
+        $this->assertTrue($workflow['source_file_reachable']);
+        $this->assertContains('names.txt', $workflow['fixture_entries']);
+        $this->assertSame('Ada Lovelace', $workflow['collection_name_summaries'][0]['name']);
+        $this->assertSame(0, $workflow['collection_name_summaries'][0]['index']);
+        $this->assertSame('ada-lovelace', $workflow['collection_name_summaries'][0]['slug']);
+        $this->assertTrue($workflow['admin_match']);
+        $this->assertTrue($workflow['enabled_flag']);
+        $this->assertSame('HTTP/1.1 200 OK', $workflow['status_line']);
+        $this->assertSame('Example%20Report.md', $workflow['encoded_path_segment']);
+
+        $packet = HTTP::jsonDecode($this->runExample(['examples/http/api_packet.php']));
+
+        $this->assertSame('GET', $packet['request']['method']);
+        $this->assertSame('https', $packet['request']['scheme']);
+        $this->assertSame('api.example.test', $packet['request']['host']);
+        $this->assertSame('Example%20Report.md', $packet['request']['path_segment']);
+        $this->assertSame('HTTP/1.1 202 Accepted', $packet['expected_response']['status']);
+        $this->assertStringStartsWith('api-example:', $packet['content_id']);
+
+        $cli = $this->runExample([
             'examples/cli/report.php',
             '--limit',
             '2',
@@ -19,76 +43,34 @@ class ExamplesSmokeTest extends TestCase
             'Smoke Report',
         ]);
 
-        $this->assertSame(0, $exitCode, $error);
-        $this->assertStringContainsString('Smoke Report', $output);
-        $this->assertStringContainsString('Item 1', $output);
+        $this->assertStringContainsString('Smoke Report', $cli);
+        $this->assertStringContainsString('Item 1', $cli);
+        $this->assertStringContainsString('total: 2', $cli);
+
+        $game = $this->runExample(['examples/game/gangs.php', 'script']);
+
+        $this->assertStringContainsString('Scripted DevElation Gangs run.', $game);
+        $this->assertStringContainsString('Territory:', $game);
+        $this->assertStringContainsString('Recap of NPC actions:', $game);
+
+        $todo = $this->runExample(['examples/todo/index.php']);
+
+        $this->assertStringContainsString('<title>DevElation Todo List</title>', $todo);
+        $this->assertStringContainsString('Session-backed list using DevElation Session storage', $todo);
+        $this->assertStringContainsString('table class="dev_table"', $todo);
+        $this->assertStringNotContainsString('{$', $todo);
+        $this->assertStringNotContainsString('{@', $todo);
+
+        $comments = $this->runExample(['examples/comments/index.php']);
+
+        $this->assertStringContainsString('<title>DevElation Comment Thread</title>', $comments);
+        $this->assertStringContainsString('Thread backed by DevElation Session storage', $comments);
+        $this->assertStringContainsString('table class="dev_table"', $comments);
+        $this->assertStringNotContainsString('{$', $comments);
+        $this->assertStringNotContainsString('{@', $comments);
     }
 
-    public function testHelperWorkflowExampleRuns(): void
-    {
-        [$exitCode, $output, $error] = $this->runExample(['examples/helpers/workflow.php']);
-
-        $this->assertSame(0, $exitCode, $error);
-
-        $data = HTTP::jsonDecode($output);
-
-        $this->assertSame(3, $data['name_count']);
-        $this->assertTrue($data['source_file_exists']);
-        $this->assertTrue($data['source_file_reachable']);
-        $this->assertSame('Ada Lovelace', $data['collection_name_summaries'][0]['name']);
-        $this->assertSame(0, $data['collection_name_summaries'][0]['index']);
-        $this->assertSame('ada-lovelace', $data['collection_name_summaries'][0]['slug']);
-        $this->assertTrue($data['admin_match']);
-        $this->assertTrue($data['enabled_flag']);
-        $this->assertSame('HTTP/1.1 200 OK', $data['status_line']);
-        $this->assertSame('Example%20Report.md', $data['encoded_path_segment']);
-    }
-
-    public function testHttpApiPacketExampleRuns(): void
-    {
-        [$exitCode, $output, $error] = $this->runExample(['examples/http/api_packet.php']);
-
-        $this->assertSame(0, $exitCode, $error);
-
-        $data = HTTP::jsonDecode($output);
-
-        $this->assertSame('GET', $data['request']['method']);
-        $this->assertSame('https', $data['request']['scheme']);
-        $this->assertSame('api.example.test', $data['request']['host']);
-        $this->assertSame('Example%20Report.md', $data['request']['path_segment']);
-        $this->assertSame('HTTP/1.1 202 Accepted', $data['expected_response']['status']);
-        $this->assertStringStartsWith('api-example:', $data['content_id']);
-    }
-
-    public function testGameScriptExampleRunsWithoutInput(): void
-    {
-        [$exitCode, $output, $error] = $this->runExample(['examples/game/gangs.php', 'script']);
-
-        $this->assertSame(0, $exitCode, $error);
-        $this->assertStringContainsString('Scripted DevElation Gangs run.', $output);
-        $this->assertStringContainsString('Recap of NPC actions:', $output);
-    }
-
-    public function testWebExamplesRenderWithoutPostData(): void
-    {
-        foreach ([
-            'examples/todo/index.php' => 'DevElation Todo List',
-            'examples/comments/index.php' => 'DevElation Comment Thread',
-        ] as $script => $heading) {
-            [$exitCode, $output, $error] = $this->runExample([$script]);
-
-            $this->assertSame(0, $exitCode, $error);
-            $this->assertStringContainsString($heading, $output);
-            $this->assertStringNotContainsString('{\\$', $output);
-            $this->assertStringNotContainsString('{@', $output);
-        }
-    }
-
-    /**
-     * @param array<int, string> $arguments
-     * @return array{0:int,1:string,2:string}
-     */
-    private function runExample(array $arguments): array
+    private function runExample(array $arguments): string
     {
         $pipes = [];
         $process = proc_open(
@@ -105,11 +87,14 @@ class ExamplesSmokeTest extends TestCase
 
         $output = stream_get_contents($pipes[1]);
         $error = stream_get_contents($pipes[2]);
-
         fclose($pipes[1]);
         fclose($pipes[2]);
 
-        return [proc_close($process), (string)$output, (string)$error];
+        $status = proc_close($process);
+
+        $this->assertSame(0, $status, $error);
+
+        return $output;
     }
 
     private function projectRoot(): string


### PR DESCRIPTION
Closes #153

## Intent summary
Keep the package examples executable as the helper surface evolves by consolidating and strengthening example smoke coverage.

## User stories / acceptance criteria
- As a package user, I can run a single smoke test that executes the runnable examples.
- As a maintainer, helper, HTTP, CLI, game, todo, and comment examples fail fast if they stop producing stable output.
- As a contributor, the examples README points to the validation command.

## Key files changed
- examples/README.md
- tests/Examples/ExamplesSmokeTest.php

## How to test
- php -l examples\\support.php
- php -l examples\\helpers\\workflow.php
- php -l examples\\http\\api_packet.php
- php -l examples\\cli\\report.php
- php -l examples\\game\\gangs.php
- php -l examples\\todo\\index.php
- php -l examples\\comments\\index.php
- php -l tests\\Examples\\ExamplesSmokeTest.php
- php examples\\helpers\\workflow.php
- php examples\\http\\api_packet.php
- php examples\\cli\\report.php --limit 2 --delay 0
- php examples\\game\\gangs.php script
- php examples\\todo\\index.php
- php examples\\comments\\index.php
- vendor\\bin\\phpunit --do-not-cache-result tests\\Examples\\ExamplesSmokeTest.php
- vendor\\bin\\phpunit --do-not-cache-result
- composer validate --strict
- git diff --check

## QA checklist
- [x] Every file under examples/ was inspected.
- [x] Runnable PHP examples were manually smoke-run.
- [x] Example smoke test passes.
- [x] Full PHPUnit suite passes locally. Local run used TMP/TEMP redirected to artifacts/tmp because the default temp location was out of space.
- [x] Composer metadata validates.
- [x] Diff whitespace check passes.

## Approval conditions
- Confirm the consolidated one-method smoke test is preferred for this repo while PHPUnit process isolation is enabled.
