### PR TITLE
Align data queues with Arr helper patterns

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -378,18 +378,15 @@ class Arr extends Val implements IVal, ArrayAccess, IteratorAggregate
      *
      * @param int $offset
      * @param int|null $length
-     * @return IVal
+     * @return Arr
      */
-    public function _slice(int $offset, int $length = null): array
+    public function _slice(int $offset, int $length = null): Arr
     {
         if (!$this->is($this->_data)) {
-            return $this;
+            return Arr::make();
         }
 
-        $array = $this->_data;
-        $array = array_slice($array, $offset, $length);
-
-        return $array;
+        return Arr::make(array_slice($this->_data, $offset, $length));
     }
 
     /**

--- a/src/Data/Log.php
+++ b/src/Data/Log.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Data;
 
+use BlueFission\Arr;
 use BlueFission\Val;
 use BlueFission\IObj;
 use BlueFission\Data\FileSystem;
@@ -214,9 +215,11 @@ class Log extends Data implements iData
     {
         $records = (Val::isNull($records)) ? $this->config('max_logs') : $records;
         $raw = $this->data();
-        $message = array_slice($raw, -($records));
-        $message = array_filter($message);
-        // $output = implode("\n", $message)."\n";
+        $message = Arr::make($raw)
+            ->slice(-($records))
+            ->filter(fn ($line) => Val::isNotEmpty($line))
+            ->val();
+
         $output = '';
         foreach ($message as $time => $line) {
             $output .= "{$time} - {$line}\n";

--- a/src/Data/Queues/DiskQueue.php
+++ b/src/Data/Queues/DiskQueue.php
@@ -97,7 +97,7 @@ class DiskQueue extends Queue implements IQueue
             return true;
         }
 
-        return count($array) ? false : true;
+        return Arr::count($array) ? false : true;
     }
 
     /**
@@ -120,7 +120,7 @@ class DiskQueue extends Queue implements IQueue
         }
 
         if (self::$_mode == static::FILO) {
-            $array = array_reverse($array);
+            $array = Arr::reverse($array);
         }
 
         $message = null;
@@ -229,7 +229,7 @@ class DiskQueue extends Queue implements IQueue
         $fs->dirname = $queue;
         $array = $fs->listDir();
 
-        if (!is_array($array) || count($array) < 1) {
+        if (!Arr::is($array) || Arr::count($array) < 1) {
             return 1;
         }
         // rsort($array);

--- a/src/Data/Queues/FileQueue.php
+++ b/src/Data/Queues/FileQueue.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Data\Queues;
 
 use RuntimeException;
+use BlueFission\Arr;
 use BlueFission\Collections\Collection;
 
 /**
@@ -70,20 +71,20 @@ class FileQueue extends Queue implements IQueue
 
         // Reverse the array if FILO
         if (self::$_mode == static::FILO) {
-            self::$cache[$queue] = array_reverse(self::$cache[$queue]);
+            self::$cache[$queue] = Arr::make(self::$cache[$queue])->reverse()->val();
         }
 
         if ($after_id === false && $till_id === false) {
             $item = array_shift(self::$cache[$queue]);
         } else {
             $after_id = $after_id ?? 0;
-            $length = $till_id === false ? count(self::$cache[$queue]) : $till_id;
+            $length = $till_id === false ? Arr::count(self::$cache[$queue]) : $till_id;
             $item = new Collection(array_splice(self::$cache[$queue], $after_id, $length));
         }
 
         // Fix it
         if (self::$_mode == static::FILO) {
-            self::$cache[$queue] = array_reverse(self::$cache[$queue]);
+            self::$cache[$queue] = Arr::make(self::$cache[$queue])->reverse()->val();
         }
         self::save();
         return $item;

--- a/src/Data/Queues/FileQueue.php
+++ b/src/Data/Queues/FileQueue.php
@@ -4,6 +4,7 @@ namespace BlueFission\Data\Queues;
 
 use RuntimeException;
 use BlueFission\Arr;
+use BlueFission\Val;
 use BlueFission\Collections\Collection;
 
 /**
@@ -62,7 +63,13 @@ class FileQueue extends Queue implements IQueue
     public static function isEmpty($queue)
     {
         self::ensureFileHandle();
-        return empty(self::$cache[$queue]);
+        $items = self::$cache[$queue] ?? null;
+
+        if (!Val::is($items)) {
+            return true;
+        }
+
+        return Arr::count($items) === 0;
     }
 
     public static function dequeue($queue, $after_id = false, $till_id = false)
@@ -78,8 +85,10 @@ class FileQueue extends Queue implements IQueue
             $item = array_shift(self::$cache[$queue]);
         } else {
             $after_id = $after_id ?? 0;
-            $length = $till_id === false ? Arr::count(self::$cache[$queue]) : $till_id;
-            $item = new Collection(array_splice(self::$cache[$queue], $after_id, $length));
+            $queueItems = Arr::make(self::$cache[$queue]);
+            $length = $till_id === false ? $queueItems->count() : $till_id;
+            $item = new Collection($queueItems->slice($after_id, $length)->val());
+            self::$cache[$queue] = $queueItems->splice([], $after_id, $length)->val();
         }
 
         // Fix it

--- a/src/Data/Queues/Queue.php
+++ b/src/Data/Queues/Queue.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Data\Queues;
 
+use BlueFission\Arr;
 use BlueFission\Collections\Collection;
 
 /**
@@ -75,7 +76,7 @@ class Queue implements IQueue
     public static function isEmpty($queue)
     {
         $stack = self::instance();
-        $count = isset($stack[$queue]) && count($stack[$queue]);
+        $count = isset($stack[$queue]) && Arr::count($stack[$queue]);
         return $count ? false : true;
     }
 
@@ -99,9 +100,9 @@ class Queue implements IQueue
             }
             return $item;
         } elseif ($after_id !== false && $till_id === false) {
-            $till_id = count($stack[$queue]) - 1;
+            $till_id = Arr::count($stack[$queue]) - 1;
         }
-        $items = new Collection(array_slice($stack[$queue], $after_id, $till_id, true));
+        $items = new Collection(Arr::slice($stack[$queue], $after_id, $till_id));
         return $items;
     }
 

--- a/src/Data/Queues/Queue.php
+++ b/src/Data/Queues/Queue.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Data\Queues;
 
 use BlueFission\Arr;
+use BlueFission\Val;
 use BlueFission\Collections\Collection;
 
 /**
@@ -76,8 +77,13 @@ class Queue implements IQueue
     public static function isEmpty($queue)
     {
         $stack = self::instance();
-        $count = isset($stack[$queue]) && Arr::count($stack[$queue]);
-        return $count ? false : true;
+        $items = $stack[$queue] ?? null;
+
+        if (!Val::is($items)) {
+            return true;
+        }
+
+        return Arr::count($items) === 0;
     }
 
     /**

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -269,6 +269,13 @@ class ArrTest extends ValTest {
 		$this->assertSame(['foo', 'bar'], static::$classname::merge(['foo'], ['bar']));
 	}
 
+	public function testSliceReturnsArrForFluentChaining()
+	{
+		$object = new static::$classname(['foo', 'bar', 'baz']);
+
+		$this->assertEquals(['BAR'], $object->slice(1, 1)->map('strtoupper')->val());
+	}
+
 	public function testReversesValues()
 	{
 		$object = new static::$classname(['foo', 'bar', 'baz']);

--- a/tests/Data/LogTest.php
+++ b/tests/Data/LogTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BlueFission\Tests\Data;
+
+use BlueFission\Arr;
+use BlueFission\Data\Log;
+use BlueFission\Obj;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class LogTest extends TestCase
+{
+    public function testMessageUsesArrSliceAndFilterPipeline(): void
+    {
+        $log = new Log(['instant' => true]);
+
+        $data = new ReflectionProperty(Obj::class, '_data');
+        $data->setAccessible(true);
+        $data->setValue($log, Arr::make([
+            '2026-07-01 10:00:00' => 'first',
+            '2026-07-01 10:01:00' => '',
+            '2026-07-01 10:02:00' => 'third',
+        ]));
+
+        $message = new ReflectionMethod(Log::class, 'message');
+        $message->setAccessible(true);
+
+        $this->assertSame(
+            "2026-07-01 10:02:00 - third\n",
+            $message->invoke($log, 2)
+        );
+    }
+}


### PR DESCRIPTION
## Intent summary
First implementation slice for the source/test helper-pattern audit in #154. This keeps native PHP where it is still the implementation boundary, but routes safe consumer-level array operations through DevElation primitives.

## User stories / acceptance criteria
- As a library consumer, instance `Arr::slice()` can continue fluent primitive chains instead of dropping to a raw array.
- As a maintainer, queue count/reverse/slice operations use `Arr` where helper semantics match native behavior.
- As a maintainer, log message formatting uses the fluent `Arr` pipeline for slice/filter behavior.
- Static `Arr::slice($array, ...)` still returns a plain array for helper-style callers.

## Key files changed
- `src/Arr.php`
- `src/Data/Log.php`
- `src/Data/Queues/Queue.php`
- `src/Data/Queues/DiskQueue.php`
- `src/Data/Queues/FileQueue.php`
- `tests/ArrTest.php`
- `tests/Data/LogTest.php`

## How to test
- `php -l src/Arr.php`
- `php -l src/Data/Log.php`
- `php -l src/Data/Queues/Queue.php`
- `php -l src/Data/Queues/DiskQueue.php`
- `php -l src/Data/Queues/FileQueue.php`
- `php -l tests/ArrTest.php`
- `php -l tests/Data/LogTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/ArrTest.php tests/Data/LogTest.php tests/Data/Queues`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit --do-not-cache-result --no-progress`

## QA checklist
- [x] Focused primitive/data tests pass.
- [x] Full PHPUnit suite passes.
- [x] Composer metadata validates strictly.
- [x] Whitespace check passes.
- [x] No downstream package or local workflow references added.

## Approval conditions
Approve when the `Arr::slice()` instance fluency is accepted and queue/log behavior remains compatible. This PR references #154 but should not close it; the remaining source/test audit should continue in follow-up slices.

Refs #154.