### PR TITLE
Use primitive objects in service mappings

### DIFF
--- a/src/Services/Mapping.php
+++ b/src/Services/Mapping.php
@@ -3,7 +3,9 @@
 namespace BlueFission\Services;
 
 use BlueFission\Services\Application as App;
-use BlueFission\Obj;
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
 
 /**
  * Class Mapping
@@ -61,11 +63,15 @@ class Mapping {
 	static public function add(String $path, $callable, String $name = '', String $method = 'get')
 	{
 		$app = App::instance();
+		$httpMethod = Str::make($method)->trim()->lower();
+		$routePath = Str::make($path)->trim()->trim('/');
+		$routeName = Str::make($name)->trim();
+
 		$mapping = $app->map(
-			strtolower($method), 
-			filter_var(trim($path, '/'), FILTER_SANITIZE_URL), 
+			$httpMethod->val(),
+			filter_var($routePath->val(), FILTER_SANITIZE_URL),
 			$callable, 
-			trim($name)
+			$routeName->val()
 		);
 
 		return $mapping;
@@ -82,13 +88,32 @@ class Mapping {
 	 */
 	static public function crud($root, $package, $controller, $idField, $gateway = '')
 	{
-		$name = str_replace(['/','-','_'], ['.','.','.'], $root.$package);
+		$name = Str::make($root.$package)
+			->replace('/', '.')
+			->replace('-', '.')
+			->replace('_', '.');
+		$resourcePath = self::pathFromParts($root, $package);
+		$itemPath = Str::make($resourcePath->val())->append('/$')->append($idField);
 
-		self::add($root.'/'.$package, [$controller, 'index'], $name, 'get')->gateway($gateway);
-		self::add($root.'/'.$package."/$".$idField, [$controller, 'find'], $name.'.get', 'get')->gateway($gateway);
-		self::add($root.'/'.$package, [$controller, 'save'], $name.'.save', 'post')->gateway($gateway);
-		self::add($root.'/'.$package."/$".$idField, [$controller, 'update'], $name.'.update', 'post')->gateway($gateway);
-		self::add($root.'/'.$package."/$".$idField, [$controller, 'delete'], $name.'.delete', 'delete')->gateway($gateway);
+		self::add($resourcePath->val(), [$controller, 'index'], $name->val(), 'get')->gateway($gateway);
+		self::add($itemPath->val(), [$controller, 'find'], Str::make($name->val())->append('.get')->val(), 'get')->gateway($gateway);
+		self::add($resourcePath->val(), [$controller, 'save'], Str::make($name->val())->append('.save')->val(), 'post')->gateway($gateway);
+		self::add($itemPath->val(), [$controller, 'update'], Str::make($name->val())->append('.update')->val(), 'post')->gateway($gateway);
+		self::add($itemPath->val(), [$controller, 'delete'], Str::make($name->val())->append('.delete')->val(), 'delete')->gateway($gateway);
+	}
+
+	/**
+	 * Build a URL path from arbitrary path segments.
+	 *
+	 * @param mixed ...$parts
+	 * @return Str
+	 */
+	private static function pathFromParts(...$parts): Str
+	{
+		return Arr::make($parts)
+			->map(fn ($part) => Str::make($part)->trim()->trim('/')->val())
+			->filter(fn ($part) => Str::make($part)->isNotEmpty())
+			->join('/');
 	}
 
 	/**
@@ -100,16 +125,15 @@ class Mapping {
 	 */
 	public function gateway( $gateway )
 	{
-		if (is_array($gateway)) {
-			foreach ($gateway as $g) {
-				if (trim((string)$g) !== '') {
-					$this->_gateways[] = $g;
-				}
-			}
-		} else {
-			if (trim((string)$gateway) !== '') {
-				$this->_gateways[] = $gateway;
-			}
+		if (!Val::is($gateway)) {
+			return $this;
+		}
+
+		$gateways = Arr::make(Arr::is($gateway) ? $gateway : [$gateway])
+			->filter(fn ($g) => Str::make((string)$g)->trim()->isNotEmpty());
+
+		foreach ($gateways as $g) {
+			$this->_gateways[] = $g;
 		}
 
 		return $this;

--- a/tests/Services/MappingTest.php
+++ b/tests/Services/MappingTest.php
@@ -32,6 +32,15 @@ class MappingTest extends TestCase
         $this->assertEquals($callable, $mapping->callable);
     }
 
+    public function testAddNormalizesMethodPathAndNameWithPrimitiveObjects()
+    {
+        $mapping = Mapping::add(' /admin/users/ ', function () {}, ' users.index ', ' POST ');
+
+        $this->assertEquals('post', $mapping->method);
+        $this->assertEquals('admin/users', $mapping->path);
+        $this->assertEquals('users.index', $mapping->name);
+    }
+
     public function testCrudMethod()
     {
         $root = '/test';


### PR DESCRIPTION
## Intent summary
Follow-up implementation slice for #154. This updates `Services\Mapping` as a fuller single-file pass, using DevElation primitive objects for route method/path/name normalization, CRUD path/name assembly, and gateway filtering.

## User stories / acceptance criteria
- As a maintainer, mapping internals should use `Str`, `Arr`, and `Val` objects for repeated string/list/value work rather than open-coded primitive calls.
- As a router consumer, existing CRUD route paths, mapping names, and gateway assignment should remain compatible.
- As a contributor, route inputs with extra whitespace should normalize predictably before registration.

## Key files changed
- `src/Services/Mapping.php`
- `tests/Services/MappingTest.php`

## How to test
- `php -l src/Services/Mapping.php`
- `php -l tests/Services/MappingTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Services/MappingTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Services`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit --do-not-cache-result --no-progress`

## QA checklist
- [x] Focused Mapping tests pass.
- [x] Services suite passes.
- [x] Full PHPUnit suite passes.
- [x] Composer metadata validates strictly.
- [x] Whitespace check passes.
- [x] No downstream package or local workflow references added.

## Approval conditions
Approve when the Mapping helper-object pass is accepted as behavior-preserving and appropriately scoped. This PR references #154 but should not close it; remaining source/test audit slices continue separately.

Refs #154.