### PR TITLE
Use primitive objects in request data

### DIFF
--- a/src/Services/Request.php
+++ b/src/Services/Request.php
@@ -2,7 +2,10 @@
 
 namespace BlueFission\Services;
 
+use BlueFission\Arr;
 use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
 
 /**
  * Class Request
@@ -22,7 +25,7 @@ class Request extends Obj
     {
         parent::__construct();
 
-        $this->_data = $this->all();
+        $this->_data = Arr::make($this->all());
     }
 
     /**
@@ -32,42 +35,51 @@ class Request extends Obj
      */
     public function all()
     {
-        switch ($this->type()) {
+        $method = Str::make($this->type())->upper();
+
+        switch ($method->val()) {
             case 'GET':
-                $request = filter_input_array(INPUT_GET);
-                if ($request === null || $request === false) {
-                    $request = $_GET ?? [];
-                }
+                $request = $this->input(INPUT_GET, $_GET ?? []);
                 break;
             case 'POST':
-                $request = filter_input_array(INPUT_POST);
-                if ($request === null || $request === false) {
-                    $request = $_POST ?? [];
-                }
+                $request = $this->input(INPUT_POST, $_POST ?? []);
                 break;
             default:
                 // $request = filter_input_array(INPUT_REQUEST); // Awaiting implmentation
-                $get = filter_input_array(INPUT_GET) ?? [];
-                $post = filter_input_array(INPUT_POST) ?? [];
+                $get = Arr::make($this->input(INPUT_GET, $_GET ?? []));
+                $post = Arr::make($this->input(INPUT_POST, $_POST ?? []));
 
-                if ($get === [] && !empty($_GET)) {
-                    $get = $_GET;
-                }
-                if ($post === [] && !empty($_POST)) {
-                    $post = $_POST;
-                }
-
-                $request = array_merge($get, $post);
+                $request = $get->merge($post->val())->val();
                 break;
         }
 
         return $request;
     }
 
+    /**
+     * Read request input with a superglobal fallback for CLI/test contexts.
+     *
+     * @param int $type
+     * @param array $fallback
+     * @return array
+     */
+    private function input(int $type, array $fallback = []): array
+    {
+        $request = filter_input_array($type);
+
+        if (Arr::is($request)) {
+            return $request;
+        }
+
+        return $fallback;
+    }
+
     public function file($field)
     {
-        $file = $_FILES[$field] ?? null;
-        if (!$file) {
+        $files = Arr::make($_FILES ?? []);
+        $file = $files->get($field);
+
+        if (!Val::is($file)) {
             return null;
         }
 
@@ -81,7 +93,7 @@ class Request extends Obj
      */
     public function type()
     {
-        return $_SERVER['REQUEST_METHOD'] ?? '_';
+        return Str::make($_SERVER['REQUEST_METHOD'] ?? '_')->upper()->val();
     }
 
     /**

--- a/tests/Services/RequestTest.php
+++ b/tests/Services/RequestTest.php
@@ -34,6 +34,41 @@ class RequestTest extends TestCase
         }
     }
 
+    public function testAllFallsBackToPost()
+    {
+        $originalPost = $_POST ?? [];
+        $originalMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST = ['posted' => 'value'];
+
+        $request = new Request();
+        $this->assertEquals('value', $request->all()['posted']);
+
+        $_POST = $originalPost;
+        if ($originalMethod === null) {
+            unset($_SERVER['REQUEST_METHOD']);
+        } else {
+            $_SERVER['REQUEST_METHOD'] = $originalMethod;
+        }
+    }
+
+    public function testTypeNormalizesRequestMethod()
+    {
+        $originalMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+
+        $_SERVER['REQUEST_METHOD'] = 'post';
+        $request = new Request();
+
+        $this->assertEquals('POST', $request->type());
+
+        if ($originalMethod === null) {
+            unset($_SERVER['REQUEST_METHOD']);
+        } else {
+            $_SERVER['REQUEST_METHOD'] = $originalMethod;
+        }
+    }
+
     public function testType()
     {
         $request = new Request();


### PR DESCRIPTION
## Intent summary
Continue #154 with a broader `Services\Request` pass. Request data is now carried internally as an `Arr`, request methods are normalized with `Str`, and input/file presence uses package primitives instead of open-coded checks.

## User stories / acceptance criteria
- As a maintainer, request data should stay on the DevElation value-object surface inside the service object.
- As a service consumer, GET/POST fallback behavior should remain compatible in CLI and test contexts.
- As a contributor, request method casing should normalize consistently.

## Key files changed
- `src/Services/Request.php`
- `tests/Services/RequestTest.php`

## How to test
- `php -l src/Services/Request.php`
- `php -l tests/Services/RequestTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Services/RequestTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Services`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit --do-not-cache-result --no-progress`

## QA checklist
- [x] Focused Request tests pass.
- [x] Services suite passes.
- [x] Full PHPUnit suite passes.
- [x] Composer metadata validates strictly.
- [x] Whitespace check passes.

## Approval conditions
Approve when the Request object-storage and input normalization changes are accepted as behavior-preserving and consistent with first-class primitive standards.

Refs #154.