### PR TITLE
Fix service string callback preparation

### DIFF
--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -224,17 +224,21 @@ class Service extends Obj
     {
         if (is_object($callback)) {
             $callback = $callback->bindTo($this->scope, $this->instance);
-        } elseif (Str::is($callback) && (Str::pos($callback, '::') !== false)) {
-            $function = explode('::', $callback);
-            $callback = [$callback[0], $function[1]];
         } elseif (Str::is($callback)) {
-            $callback = [$this->instance, $callback];
+            $callbackName = Str::make($callback);
+            $callback = $callbackName->contains('::')
+                ? $callbackName->split('::')->val()
+                : [$this->instance, $callbackName->val()];
         }
 
         if (Arr::is($callback) && Arr::size($callback) == 2) {
-            if ($this->instance instanceof $callback[0]) {
-                $callback[0] = $this->instance;
+            $callbackParts = Arr::make($callback);
+
+            if (Str::is($callbackParts[0]) && $this->instance instanceof $callbackParts[0]) {
+                $callbackParts[0] = $this->instance;
             }
+
+            $callback = $callbackParts->val();
         }
 
         return $callback;

--- a/tests/Services/ServiceTest.php
+++ b/tests/Services/ServiceTest.php
@@ -190,4 +190,29 @@ class ServiceTest extends \PHPUnit\Framework\TestCase
         $this->object->call('field', ['test', 'foobar']);
         echo $this->object->call('field', ['test']);
     }
+
+    public function testStringClassCallbacksBindToServiceInstance()
+    {
+        $this->expectOutputString('prepared callback');
+
+        $this->object->type = ServiceCallbackTarget::class;
+
+        $handler = new Handler(
+            new Behavior('DoStringCallback'),
+            ServiceCallbackTarget::class . '::emit'
+        );
+
+        $this->object->register('testService', $handler, Service::LOCAL_LEVEL);
+        $this->object->message('DoStringCallback');
+    }
+}
+
+class ServiceCallbackTarget extends Obj
+{
+    use Configurable;
+
+    public function emit($behavior = null, $args = null): void
+    {
+        echo 'prepared callback';
+    }
 }


### PR DESCRIPTION
Intent summary: Make Service callback preparation use DevElation string and array helpers while fixing Class::method callback parsing.

User stories / acceptance criteria: String callbacks continue to bind to the service instance. Class::method callbacks split into callable parts through Str and Arr, then bind to the service instance when the service instance matches the class. Existing local and scoped behavior dispatch remains compatible. Regression coverage proves Class::method strings dispatch correctly.

Key files changed: src/Services/Service.php; tests/Services/ServiceTest.php.

How to test: php -l src/Services/Service.php; php -l tests/Services/ServiceTest.php; vendor/bin/phpunit --do-not-cache-result tests/Services/ServiceTest.php; vendor/bin/phpunit --do-not-cache-result tests/Services; composer validate --strict; git diff --check; vendor/bin/phpunit --do-not-cache-result --no-progress.

QA checklist: Syntax passes; focused service tests pass; services suite passes; full PHPUnit suite passes with existing optional skips; Composer metadata validates; whitespace check passes.

Approval conditions: Review that Class::method callback splitting is correct and that converting matching class-name callbacks to the service instance preserves current dispatch expectations.