### PR TITLE
Fix client connection helper usage

### DIFF
--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -2,6 +2,11 @@
 
 namespace BlueFission\Services;
 
+use BlueFission\Arr;
+use BlueFission\Connections\Curl;
+use BlueFission\Net\HTTP;
+use BlueFission\Str;
+
 // @TODO: make other classes extend this base class
 abstract class Client extends Service
 {
@@ -12,6 +17,8 @@ abstract class Client extends Service
 
     public function __construct()
     {
+        parent::__construct();
+
         $this->_curl = new Curl([
             'method' => 'post',
         ]);
@@ -19,12 +26,12 @@ abstract class Client extends Service
 
     public function get(string $endpoint = '')
     {
-        $target = implode('/', [$this->_baseUrl, $endpoint]);
+        $target = $this->target($endpoint);
 
         $this->_curl->config('target', $target);
         $this->_curl->open();
         $this->_curl->query();
-        $response = $this->_curl->getResult();
+        $response = $this->_curl->result();
         $this->_curl->close();
 
         return $response;
@@ -32,14 +39,23 @@ abstract class Client extends Service
 
     public function post($data, string $endpoint = '')
     {
-        $target = implode('/', [$this->_baseUrl, $endpoint]);
+        $target = $this->target($endpoint);
 
         $this->_curl->config('target', $target);
         $this->_curl->open();
-        $this->_curl->query(http_build_query($data));
-        $response = $this->_curl->getResult();
+        $this->_curl->query(HTTP::query(Arr::toArray($data)));
+        $response = $this->_curl->result();
         $this->_curl->close();
 
         return $response;
+    }
+
+    protected function target(string $endpoint = ''): string
+    {
+        return Arr::make([$this->_baseUrl ?? '', $endpoint])
+            ->map(fn ($part) => Str::make($part)->trim()->trim('/')->val())
+            ->filter(fn ($part) => Str::make($part)->isNotEmpty())
+            ->join('/')
+            ->val();
     }
 }

--- a/tests/Services/ClientTest.php
+++ b/tests/Services/ClientTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace BlueFission\Tests\Services;
+
+use BlueFission\Connections\Curl;
+use BlueFission\IObj;
+use BlueFission\Services\Client;
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase
+{
+    public function testGetBuildsNormalizedTargetAndReturnsResult()
+    {
+        $curl = new ClientTestCurl('payload');
+        $client = new ClientTestDouble($curl, 'https://api.example.test/root/');
+
+        $response = $client->get('/users');
+
+        $this->assertSame('payload', $response);
+        $this->assertSame('https://api.example.test/root/users', $curl->config('target'));
+        $this->assertSame([null], $curl->queries);
+        $this->assertTrue($curl->opened);
+        $this->assertTrue($curl->closed);
+    }
+
+    public function testPostUsesHttpQueryHelper()
+    {
+        $curl = new ClientTestCurl('created');
+        $client = new ClientTestDouble($curl, 'https://api.example.test/root/');
+
+        $response = $client->post(['name' => 'Jane Doe'], '/users/');
+
+        $this->assertSame('created', $response);
+        $this->assertSame('https://api.example.test/root/users', $curl->config('target'));
+        $this->assertSame(['name=Jane+Doe'], $curl->queries);
+    }
+}
+
+class ClientTestDouble extends Client
+{
+    public function __construct(ClientTestCurl $curl, string $baseUrl)
+    {
+        parent::__construct();
+
+        $this->_curl = $curl;
+        $this->_baseUrl = $baseUrl;
+    }
+}
+
+class ClientTestCurl extends Curl
+{
+    public array $queries = [];
+    public bool $opened = false;
+    public bool $closed = false;
+
+    private array $config = [];
+    private mixed $fakeResult;
+
+    public function __construct(mixed $result)
+    {
+        $this->fakeResult = $result;
+    }
+
+    public function config($config = null, $value = null): mixed
+    {
+        if (is_array($config)) {
+            foreach ($config as $key => $item) {
+                $this->config[$key] = $item;
+            }
+
+            return $this;
+        }
+
+        if ($value !== null) {
+            $this->config[$config] = $value;
+
+            return $this;
+        }
+
+        if ($config !== null) {
+            return $this->config[$config] ?? null;
+        }
+
+        return $this->config;
+    }
+
+    public function open(): IObj
+    {
+        $this->opened = true;
+
+        return $this;
+    }
+
+    public function query($query = null): IObj
+    {
+        $this->queries[] = $query;
+
+        return $this;
+    }
+
+    public function close(): IObj
+    {
+        $this->closed = true;
+
+        return $this;
+    }
+
+    public function result()
+    {
+        return $this->fakeResult;
+    }
+}


### PR DESCRIPTION
Intent summary: Make the abstract service Client use package-owned connection and HTTP helpers consistently while fixing stale connection method references.

User stories / acceptance criteria: Client imports the Connections\\Curl class it uses. Client initializes its Service base state. GET and POST build normalized targets through Arr and Str helpers. POST builds payloads through Net\\HTTP::query. Client reads the connection response through the existing result() method. Tests cover target normalization, query construction, and result return without making network calls.

Key files changed: src/Services/Client.php; tests/Services/ClientTest.php.

How to test: php -l src/Services/Client.php; php -l tests/Services/ClientTest.php; vendor/bin/phpunit --do-not-cache-result tests/Services/ClientTest.php; vendor/bin/phpunit --do-not-cache-result tests/Services; composer validate --strict; git diff --check; vendor/bin/phpunit --do-not-cache-result --no-progress.

QA checklist: Syntax passes; focused client tests pass; services suite passes; full PHPUnit suite passes with existing optional skips; Composer metadata validates; whitespace check passes.

Approval conditions: Review that parent Service initialization is appropriate for Client subclasses and that normalized slash handling is the intended URL target behavior.