### PR TITLE
Use helper objects for application instances

### DIFF
--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -222,7 +222,7 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
         	$this->config['name'] ??
         	get_called_class();
 
-        if (isset(self::$_instances[$name])) {
+        if (Arr::hasKey(self::$_instances, $name)) {
             return self::$_instances[$name];
         }
 
@@ -243,11 +243,11 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
     static function getInstance($name = null)
     {
         $appName = $name ?? get_called_class();
-        if (!isset(self::$_instances[$appName])) {
-        	$config = [];
-        	if ($name) {
-        		$config['name'] = $name;
-        	}
+        if (!Arr::hasKey(self::$_instances, $appName)) {
+            $config = [];
+            if ($name) {
+                $config['name'] = $name;
+            }
             self::$_instances[$appName] = new static($config);
         }
 
@@ -261,12 +261,14 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
      */
     static function instance()
     {
-		if (count(self::$_instances) <= 0) {
+		$instances = Arr::make(self::$_instances);
+		if ($instances->isEmpty()) {
 	        $calledClass = get_called_class();
 			self::$_instances[$calledClass] = new static();
+			$instances = Arr::make(self::$_instances);
 		}
 
-		return array_values(self::$_instances)[0];
+		return $instances->values()[0];
 	}
 
     /**

--- a/tests/Services/ApplicationTest.php
+++ b/tests/Services/ApplicationTest.php
@@ -43,6 +43,22 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(\stdClass::class, $service);
     }
 
+    public function testNamedApplicationInstancesAreReused()
+    {
+        $first = Application::getInstance('InstanceHelperTest');
+        $second = Application::getInstance('InstanceHelperTest');
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testApplicationInstanceReturnsFirstRegisteredInstance()
+    {
+        $first = Application::instance();
+        Application::getInstance('LaterInstanceHelperTest');
+
+        $this->assertSame($first, Application::instance());
+    }
+
     public function testApplicationCanRouteMessage()
     {
         $this->expectOutputString('Test Output');


### PR DESCRIPTION
Intent summary: Refactor Application singleton instance bookkeeping to use DevElation array helpers while preserving named and first-instance behavior.

User stories / acceptance criteria: Application named instance checks use Arr::hasKey. First-instance lookup uses Arr object emptiness and values handling instead of raw count/array_values calls. Existing named getInstance reuse and Application::instance first-registered behavior remain compatible and covered by tests.

Key files changed: src/Services/Application.php; tests/Services/ApplicationTest.php.

How to test: php -l src/Services/Application.php; php -l tests/Services/ApplicationTest.php; vendor/bin/phpunit --do-not-cache-result tests/Services/ApplicationTest.php; vendor/bin/phpunit --do-not-cache-result tests/Services; composer validate --strict; git diff --check; vendor/bin/phpunit --do-not-cache-result --no-progress.

QA checklist: Syntax passes; focused Application tests pass; Services suite passes; full PHPUnit suite passes with existing optional skips; Composer metadata validates; whitespace check passes.

Approval conditions: Review that Application::instance continues to return the first registered instance and that named getInstance reuse remains unchanged.