### PR TITLE
Use file utilities in application assets

### DIFF
--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -10,6 +10,7 @@ use BlueFission\Collections\Collection;
 use BlueFission\Services\Mapping;
 use BlueFission\Cli\Args;
 use BlueFission\Cli\Args\OptionDefinition;
+use BlueFission\Data\FileSystem;
 use BlueFission\Val;
 use BlueFission\Str;
 use BlueFission\Arr;
@@ -356,44 +357,60 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 
 	public function assetDir($directory = null) {
 		if ( $directory ) {
-			$directory = trim($directory, '/');
-			$this->_assetDir = $directory;
+			$this->_assetDir = Str::make($directory)->trim('/')->val();
 		}
 		return $this->_assetDir;
 	}
 
 	public function webRoot($path = null) {
 		if ( $path ) {
-			$path = trim($path, '/');
-			$this->_webRoot = $path;
+			$this->_webRoot = Str::make($path)->trim('/')->val();
 		}
 		return $this->_webRoot;
 	}
 
 	public function fileExists($path) {
-		$templateDir = $this->assetDir();
-		$webRoot = $this->webRoot();
-		if ( file_exists($webRoot.DIRECTORY_SEPARATOR.$path) ) {
-			return true;
-		} elseif ( file_exists( $templateDir.DIRECTORY_SEPARATOR.$path ) ) {
-			return true;
-		} else {
-			return false;
+		foreach ($this->assetCandidates($path) as $candidate) {
+			if (FileSystem::fileExists($candidate)) {
+				return true;
+			}
 		}
+
+		return false;
 	}
 
 	public function fileContents($path) {
-		$templateDir = $this->assetDir();
-		$webRoot = $this->webRoot();
-		if ( $path != "" && file_exists($webRoot.DIRECTORY_SEPARATOR.$path) ) {
-			header('Content-type: '. $this->getMimeType($webRoot.DIRECTORY_SEPARATOR.$path));
-			return file_get_contents($webRoot.DIRECTORY_SEPARATOR.$path);
-		} elseif ( $path != "" && file_exists( $templateDir.DIRECTORY_SEPARATOR.$path ) ) {
-			header('Content-type: '. $this->getMimeType($templateDir.DIRECTORY_SEPARATOR.$path));
-			return file_get_contents($templateDir.DIRECTORY_SEPARATOR.$path);
-		} else {
+		if (Str::isEmpty($path)) {
 			return null;
 		}
+
+		foreach ($this->assetCandidates($path) as $candidate) {
+			if (!FileSystem::fileExists($candidate)) {
+				continue;
+			}
+
+			header(HTTP::headerLine('Content-type', $this->getMimeType($candidate)));
+
+			return (new FileSystem($candidate))->read()->contents();
+		}
+
+		return null;
+	}
+
+	private function assetCandidates($path): Arr
+	{
+		return Arr::make([$this->webRoot(), $this->assetDir()])
+			->map(fn ($root) => $this->assetPath($root, $path))
+			->filter(fn ($candidate) => Str::make($candidate)->isNotEmpty());
+	}
+
+	private function assetPath($root, $path): string
+	{
+		return Arr::make([$root, $path])
+			->map(fn ($part) => Str::make((string)$part)->trim('/')->val())
+			->filter(fn ($part) => Str::make($part)->isNotEmpty())
+			->join(DIRECTORY_SEPARATOR)
+			->val();
 	}
 
 	public function getMimeType($filename) {

--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -357,14 +357,14 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 
 	public function assetDir($directory = null) {
 		if ( $directory ) {
-			$this->_assetDir = Str::make($directory)->trim('/')->val();
+			$this->_assetDir = $this->assetRootPath($directory);
 		}
 		return $this->_assetDir;
 	}
 
 	public function webRoot($path = null) {
 		if ( $path ) {
-			$this->_webRoot = Str::make($path)->trim('/')->val();
+			$this->_webRoot = $this->assetRootPath($path);
 		}
 		return $this->_webRoot;
 	}
@@ -406,11 +406,24 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 
 	private function assetPath($root, $path): string
 	{
+		$root = $this->assetRootPath($root);
+		$path = Str::make((string)$path)->trim('/\\')->val();
+
 		return Arr::make([$root, $path])
-			->map(fn ($part) => Str::make((string)$part)->trim('/')->val())
 			->filter(fn ($part) => Str::make($part)->isNotEmpty())
 			->join(DIRECTORY_SEPARATOR)
 			->val();
+	}
+
+	private function assetRootPath($path): string
+	{
+		$path = Str::make((string)$path)->trim()->val();
+
+		if ($path === DIRECTORY_SEPARATOR) {
+			return $path;
+		}
+
+		return rtrim($path, '/\\');
 	}
 
 	public function getMimeType($filename) {

--- a/tests/Services/ApplicationTest.php
+++ b/tests/Services/ApplicationTest.php
@@ -72,6 +72,8 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
             $app->webRoot($root);
             $app->assetDir($assets);
 
+            $this->assertSame(rtrim($root, '/\\'), $app->webRoot());
+            $this->assertSame(rtrim($assets, '/\\'), $app->assetDir());
             $this->assertTrue($app->fileExists('app.css'));
             $this->assertSame('web-root', $app->fileContents('app.css'));
         } finally {

--- a/tests/Services/ApplicationTest.php
+++ b/tests/Services/ApplicationTest.php
@@ -59,6 +59,48 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($first, Application::instance());
     }
 
+    public function testApplicationReadsFilesFromWebRootFirst()
+    {
+        $root = $this->makeTempDirectory('web-root');
+        $assets = $this->makeTempDirectory('asset-root');
+
+        try {
+            file_put_contents($root . DIRECTORY_SEPARATOR . 'app.css', 'web-root');
+            file_put_contents($assets . DIRECTORY_SEPARATOR . 'app.css', 'asset-root');
+
+            $app = Application::getInstance('AssetWebRootTest');
+            $app->webRoot($root);
+            $app->assetDir($assets);
+
+            $this->assertTrue($app->fileExists('app.css'));
+            $this->assertSame('web-root', $app->fileContents('app.css'));
+        } finally {
+            $this->removeTempDirectory($root);
+            $this->removeTempDirectory($assets);
+        }
+    }
+
+    public function testApplicationFallsBackToAssetDirectoryForFiles()
+    {
+        $root = $this->makeTempDirectory('empty-root');
+        $assets = $this->makeTempDirectory('asset-root');
+
+        try {
+            file_put_contents($assets . DIRECTORY_SEPARATOR . 'app.js', 'asset-root');
+
+            $app = Application::getInstance('AssetFallbackTest');
+            $app->webRoot($root);
+            $app->assetDir($assets);
+
+            $this->assertTrue($app->fileExists('app.js'));
+            $this->assertSame('asset-root', $app->fileContents('app.js'));
+            $this->assertNull($app->fileContents('missing.js'));
+        } finally {
+            $this->removeTempDirectory($root);
+            $this->removeTempDirectory($assets);
+        }
+    }
+
     public function testApplicationCanRouteMessage()
     {
         $this->expectOutputString('Test Output');
@@ -218,5 +260,28 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $property->setAccessible(true);
 
         return $property->getValue($app);
+    }
+
+    private function makeTempDirectory(string $prefix): string
+    {
+        $directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid($prefix . '-', true);
+        mkdir($directory);
+
+        return $directory;
+    }
+
+    private function removeTempDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach (glob($directory . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        rmdir($directory);
     }
 }


### PR DESCRIPTION
Intent summary: Refactor Application asset file handling to use package-owned Data and Net utilities while preserving web-root priority and asset-dir fallback behavior.

User stories / acceptance criteria: assetDir and webRoot normalize through Str. fileExists probes candidate paths through Data\\FileSystem::fileExists. fileContents resolves candidates through Arr, emits the content-type line through Net\\HTTP::headerLine, and reads file data through Data\\FileSystem. Existing web-root-first lookup and asset-directory fallback behavior are covered by tests using temporary files.

Key files changed: src/Services/Application.php; tests/Services/ApplicationTest.php.

How to test: php -l src/Services/Application.php; php -l tests/Services/ApplicationTest.php; vendor/bin/phpunit --do-not-cache-result tests/Services/ApplicationTest.php; vendor/bin/phpunit --do-not-cache-result tests/Services; composer validate --strict; git diff --check; vendor/bin/phpunit --do-not-cache-result --no-progress.

QA checklist: Syntax passes; focused Application tests pass; Services suite passes; full PHPUnit suite passes with existing optional skips; Composer metadata validates; whitespace check passes.

Approval conditions: Review that FileSystem-based reads are appropriate for Application asset delivery and that web-root precedence over assetDir remains intended.