### PR TITLE
Use HTTP query helper in HTML links

### DIFF
--- a/src/HTML/HTML.php
+++ b/src/HTML/HTML.php
@@ -4,6 +4,7 @@ namespace BlueFission\HTML;
 
 use BlueFission\Val;
 use BlueFission\Str;
+use BlueFission\Net\HTTP;
 use BlueFission\Utils\Util;
 
 /**
@@ -244,7 +245,7 @@ class HTML
         $query_r = array_merge($_POST, $_GET);
         unset($query_r[$begin]);
         unset($query_r[$end]);
-        $get_query = http_build_query($query_r);
+        $get_query = HTTP::query($query_r);
 
         if ($start > 0) {
             $chapter_r[] = '&lt; <a href="' . $href . '?' . $begin . '=' . ((($start) >= $lim) ? ($start - $lim) : 0) . '&amp;' . $get_query . '">Previous</a> ';

--- a/src/HTML/Table.php
+++ b/src/HTML/Table.php
@@ -5,6 +5,7 @@ namespace BlueFission\HTML;
 use BlueFission\Val;
 use BlueFission\Arr;
 use BlueFission\Obj;
+use BlueFission\Net\HTTP;
 use BlueFission\Behavioral\Configurable;
 
 /**
@@ -140,7 +141,7 @@ class Table extends Obj
                         $output .= '<td>';
                     }
                     if (($i == 1 || ($icon != '' && $i = 2)) && $link_style == 1) {
-                        $output .= '<a class="contentBox" href="' . $href . '?' . $varname . '=' . $value . ((Arr::isAssoc($query_r)) ? ('&' . http_build_query($query_r)) : '') . '">';
+                        $output .= '<a class="contentBox" href="' . $href . '?' . $varname . '=' . $value . ((Arr::isAssoc($query_r)) ? ('&' . HTTP::query($query_r)) : '') . '">';
                     }
                     if (!$show_image || $trunc != '') {
                         $data = HTML::format($b, '', $trunc);

--- a/tests/HTML/HTMLTest.php
+++ b/tests/HTML/HTMLTest.php
@@ -40,4 +40,21 @@ class HTMLTest extends \PHPUnit\Framework\TestCase
         $result = HTML::format("_Test content_", true);
         $this->assertEquals($expected, $result);
     }
+
+    public function testPaginateUsesHttpQueryHelper()
+    {
+        $originalGet = $_GET ?? [];
+        $originalPost = $_POST ?? [];
+
+        $_GET = ['start' => 0, 'lim' => 10, 'filter' => 'active'];
+        $_POST = ['token' => 'abc 123'];
+
+        $result = HTML::paginate(30, 'start', 'lim', '/items', 10);
+
+        $this->assertStringContainsString('token=abc+123', $result);
+        $this->assertStringContainsString('filter=active', $result);
+
+        $_GET = $originalGet;
+        $_POST = $originalPost;
+    }
 }

--- a/tests/HTML/TableTest.php
+++ b/tests/HTML/TableTest.php
@@ -79,4 +79,26 @@ class TableTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals($table->render(), $expected_render);
     }
+
+    public function testRenderLinksUseHttpQueryHelper()
+    {
+        $table = new Table([
+            'columns' => '2',
+            'headers' => false,
+            'href' => '/items',
+            'link_style' => 1,
+            'varname' => 'id',
+            'value' => '42',
+            'query' => ['token' => 'abc 123'],
+        ]);
+
+        $table->content([
+            ['ignored', 'Details'],
+        ]);
+
+        $this->assertStringContainsString(
+            'token=abc+123',
+            $table->render()
+        );
+    }
 }


### PR DESCRIPTION
Intent summary: Replace raw query-string construction in HTML link helpers with the package HTTP query utility.

User stories / acceptance criteria: HTML::paginate uses Net\\HTTP::query to preserve POST/GET parameters after removing pagination keys. Table link rendering uses Net\\HTTP::query for configured query parameters. Existing pagination and table link behavior remains compatible, with tests covering encoded spaces and preserved query fragments.

Key files changed: src/HTML/HTML.php; src/HTML/Table.php; tests/HTML/HTMLTest.php; tests/HTML/TableTest.php.

How to test: php -l src/HTML/HTML.php; php -l src/HTML/Table.php; php -l tests/HTML/HTMLTest.php; php -l tests/HTML/TableTest.php; vendor/bin/phpunit --do-not-cache-result tests/HTML; composer validate --strict; git diff --check; vendor/bin/phpunit --do-not-cache-result --no-progress.

QA checklist: Syntax passes; focused HTML tests pass; full PHPUnit suite passes with existing optional skips; Composer metadata validates; whitespace check passes.

Approval conditions: Review that HTTP::query output is the desired canonical query encoding for HTML pagination/table links.