### PR TITLE
Use HTTP status line in Application

### DIFF
--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -1089,7 +1089,7 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 		} elseif ( is_callable([$recipient, $behavior->name()] ) ) {
 			call_user_func_array([$recipient, $behavior->name()], [$data]);
 		} else {
-			header("HTTP/1.0 404 Not Found");
+			header(HTTP::statusLine(404, 'HTTP/1.0') ?? 'HTTP/1.0 404 Not Found');
 			return '404';
 		}
 	}

--- a/tests/Net/HTTPTest.php
+++ b/tests/Net/HTTPTest.php
@@ -61,6 +61,7 @@ class HTTPTest extends TestCase {
     public function testStatusHelpersResolveKnownCodes() {
         $this->assertSame('Not Found', HTTP::statusText(404));
         $this->assertSame('HTTP/1.1 404 Not Found', HTTP::statusLine(404));
+        $this->assertSame('HTTP/1.0 404 Not Found', HTTP::statusLine(404, 'HTTP/1.0'));
         $this->assertSame('HTTP/2 200 OK', HTTP::statusLine(200, ' HTTP/2 '));
         $this->assertNull(HTTP::statusText(799));
         $this->assertNull(HTTP::statusLine(799));


### PR DESCRIPTION
Intent summary: Replace the raw Application 404 status header string with the package HTTP status-line helper.

User stories / acceptance criteria: Application fallback dispatch uses Net\\HTTP::statusLine for the 404 response header while preserving the existing HTTP/1.0 404 output and '404' return value. HTTP status-line coverage includes the HTTP/1.0 404 form used by Application.

Key files changed: src/Services/Application.php; tests/Net/HTTPTest.php.

How to test: php -l src/Services/Application.php; php -l tests/Net/HTTPTest.php; vendor/bin/phpunit --do-not-cache-result tests/Net/HTTPTest.php; vendor/bin/phpunit --do-not-cache-result tests/Services/ApplicationTest.php; composer validate --strict; git diff --check; vendor/bin/phpunit --do-not-cache-result --no-progress.

QA checklist: Syntax passes; focused HTTP and Application tests pass; full PHPUnit suite passes with existing optional skips; Composer metadata validates; whitespace check passes.

Approval conditions: Review that HTTP/1.0 remains the intended protocol string for this fallback status header.