### PR TITLE
Refactor application route lookup helpers

### DIFF
--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -1049,6 +1049,23 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 	}
 
 	/**
+	 * Return the matching URI from a route collection.
+	 *
+	 * @param iterable $uris
+	 * @return mixed string|bool
+	 */
+	private function matchingUri( $uris )
+	{
+		$uri = new Uri();
+		foreach ( Arr::make($uris) as $testUri ) {
+			if ( $uri->match($testUri) ) {
+				return $testUri;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Check if the given uris exists
 	 *
 	 * @param array $uris
@@ -1056,13 +1073,7 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 	 */
 	private function uriExists( $uris )
 	{
-		$uri = new Uri();
-		foreach ( $uris as $testUri ) {
-			if ( $uri->match($testUri) ) {
-				return true;
-			}
-		}
-		return false;
+		return $this->matchingUri($uris) !== false;
 	}
 
 	/**
@@ -1073,13 +1084,7 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 	 */
 	private function returnMatchingUri( $uris )
 	{
-		$uri = new Uri();
-		foreach ( $uris as $testUri ) {
-			if ( $uri->match($testUri) ) {
-				return $testUri;
-			}
-		}
-		return false;
+		return $this->matchingUri($uris);
 	}
 
 	/**

--- a/tests/Services/ApplicationTest.php
+++ b/tests/Services/ApplicationTest.php
@@ -255,6 +255,44 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $_SERVER = $originalServer;
     }
 
+    public function testRouteHelpersReturnMatchingUri()
+    {
+        $originalServer = $_SERVER;
+
+        $_SERVER['HTTP_HOST'] = 'example.test';
+        $_SERVER['REQUEST_URI'] = '/catalog/active';
+        unset($_SERVER['HTTPS']);
+
+        try {
+            $app = Application::getInstance('RouteHelperMatchTest');
+            $uris = ['/status', '/catalog/$filter'];
+
+            $this->assertTrue($this->invokeApplicationMethod($app, 'uriExists', [$uris]));
+            $this->assertSame('/catalog/$filter', $this->invokeApplicationMethod($app, 'returnMatchingUri', [$uris]));
+        } finally {
+            $_SERVER = $originalServer;
+        }
+    }
+
+    public function testRouteHelpersReturnFalseWithoutMatch()
+    {
+        $originalServer = $_SERVER;
+
+        $_SERVER['HTTP_HOST'] = 'example.test';
+        $_SERVER['REQUEST_URI'] = '/catalog/active';
+        unset($_SERVER['HTTPS']);
+
+        try {
+            $app = Application::getInstance('RouteHelperMissTest');
+            $uris = ['/status', '/catalog/active/items'];
+
+            $this->assertFalse($this->invokeApplicationMethod($app, 'uriExists', [$uris]));
+            $this->assertFalse($this->invokeApplicationMethod($app, 'returnMatchingUri', [$uris]));
+        } finally {
+            $_SERVER = $originalServer;
+        }
+    }
+
     private function applicationArguments(Application $app): array
     {
         $reflection = new \ReflectionClass($app);
@@ -262,6 +300,15 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $property->setAccessible(true);
 
         return $property->getValue($app);
+    }
+
+    private function invokeApplicationMethod(Application $app, string $method, array $arguments = [])
+    {
+        $reflection = new \ReflectionClass($app);
+        $method = $reflection->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($app, $arguments);
     }
 
     private function makeTempDirectory(string $prefix): string


### PR DESCRIPTION
Refs #154.

## Intent
Unify Application route matching behind one internal helper while preserving the existing private helper return contracts.

## User stories / acceptance criteria
- Route existence checks continue to return booleans.
- Matching route lookup continues to return the matched URI or false.
- Route collections use package array helpers for iterable handling.
- Existing Application behavior remains unchanged.

## Key files changed
- src/Services/Application.php
- tests/Services/ApplicationTest.php

## How to test
- php -l src/Services/Application.php
- php -l tests/Services/ApplicationTest.php
- vendor/bin/phpunit --do-not-cache-result tests/Services/ApplicationTest.php
- composer validate --strict
- git diff --check
- vendor/bin/phpunit.bat --do-not-cache-result --colors=never

## QA checklist
- [x] Focused service tests pass
- [x] Composer manifest validates
- [x] Whitespace check passes
- [x] Full PHPUnit suite passes with optional skips

## Approval conditions
- Confirm the private helper consolidation is acceptable for the ongoing helper usage audit.