### PR TITLE
Use filesystem helper in command locator

### DIFF
--- a/src/System/CommandLocator.php
+++ b/src/System/CommandLocator.php
@@ -3,6 +3,7 @@
 namespace BlueFission\System;
 
 use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
 use BlueFission\Str;
 use BlueFission\DevElation as Dev;
 
@@ -87,7 +88,7 @@ class CommandLocator
 
     protected static function resolvePath(string $path): ?string
     {
-        if (!file_exists($path)) {
+        if (!FileSystem::fileExists($path)) {
             return null;
         }
 

--- a/tests/System/CommandLocatorTest.php
+++ b/tests/System/CommandLocatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace BlueFission\Tests\System;
+
+use BlueFission\Data\FileSystem;
+use BlueFission\System\CommandLocator;
+use PHPUnit\Framework\TestCase;
+
+class CommandLocatorTest extends TestCase
+{
+    public function testFindReturnsAbsoluteFilePath()
+    {
+        $file = tempnam(sys_get_temp_dir(), 'command-locator-');
+
+        try {
+            $this->assertSame(realpath($file), CommandLocator::find($file, [
+                'cache' => false,
+                'use_shell' => false,
+            ]));
+        } finally {
+            if ($file && FileSystem::fileExists($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    public function testFindReturnsNullForMissingAbsolutePath()
+    {
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('missing-command-', true);
+
+        $this->assertNull(CommandLocator::find($path, [
+            'cache' => false,
+            'use_shell' => false,
+        ]));
+    }
+}


### PR DESCRIPTION
Refs #154.

## Intent
Route command path existence checks through the package filesystem helper instead of a direct primitive call.

## User stories / acceptance criteria
- Absolute file command paths still resolve to their real path.
- Missing absolute command paths still return null.
- CommandLocator keeps shell lookup and PATH search behavior unchanged.
- The source and tests demonstrate package-local helper usage at the file boundary.

## Key files changed
- src/System/CommandLocator.php
- tests/System/CommandLocatorTest.php

## How to test
- php -l src/System/CommandLocator.php
- php -l tests/System/CommandLocatorTest.php
- vendor/bin/phpunit --do-not-cache-result tests/System/CommandLocatorTest.php
- composer validate --strict
- git diff --check
- vendor/bin/phpunit.bat --do-not-cache-result --colors=never

## QA checklist
- [x] Focused system tests pass
- [x] Composer manifest validates
- [x] Whitespace check passes
- [x] Full PHPUnit suite passes with optional skips

## Approval conditions
- Confirm this is the desired package-local helper boundary for command path resolution.