### PR TITLE
Centralize Data filesystem probes

### DIFF
--- a/src/Data/Directory.php
+++ b/src/Data/Directory.php
@@ -49,7 +49,7 @@ abstract class Directory extends Hierarchical implements ICollection
     public function exists(?string $path = null): bool
     {
         $target = $this->targetPath($path);
-        $exists = Val::isNotNull($target) && is_dir($target);
+        $exists = FileSystem::directoryExists($target);
 
         return (bool)Dev::apply('_out', $exists);
     }
@@ -63,7 +63,7 @@ abstract class Directory extends Hierarchical implements ICollection
     public function isReachable(?string $path = null): bool
     {
         $target = $this->targetPath($path);
-        $isReachable = Val::isNotNull($target) && is_dir($target) && is_readable($target);
+        $isReachable = FileSystem::directoryExists($target) && FileSystem::isReadable($target);
 
         return (bool)Dev::apply('_out', $isReachable);
     }

--- a/src/Data/File.php
+++ b/src/Data/File.php
@@ -74,7 +74,7 @@ class File extends Hierarchical implements IDispatcher
     public function exists(?string $path = null): bool
     {
         $target = $this->targetPath($path);
-        $exists = Val::isNotNull($target) && is_file($target);
+        $exists = FileSystem::fileExists($target);
 
         return (bool)Dev::apply('_out', $exists);
     }
@@ -88,7 +88,7 @@ class File extends Hierarchical implements IDispatcher
     public function isReachable(?string $path = null): bool
     {
         $target = $this->targetPath($path);
-        $isReachable = Val::isNotNull($target) && is_file($target) && is_readable($target);
+        $isReachable = FileSystem::fileExists($target) && FileSystem::isReadable($target);
 
         return (bool)Dev::apply('_out', $isReachable);
     }

--- a/src/Data/FileSystem.php
+++ b/src/Data/FileSystem.php
@@ -604,8 +604,44 @@ class FileSystem extends Data implements IData {
 	}
 
 	/**
+	 * Check whether a concrete directory path exists without initializing storage state.
+	 *
+	 * @param string|null $path
+	 * @return bool
+	 */
+	public static function directoryExists(?string $path): bool
+	{
+		if (Val::isNull($path) || $path === '') {
+			return (bool)Dev::apply('_out', false);
+		}
+
+		$path = Dev::apply('_in', $path);
+		$exists = is_string($path) && is_dir($path);
+
+		return (bool)Dev::apply('_out', $exists);
+	}
+
+	/**
+	 * Check whether a concrete path is readable without initializing storage state.
+	 *
+	 * @param string|null $path
+	 * @return bool
+	 */
+	public static function isReadable(?string $path): bool
+	{
+		if (Val::isNull($path) || $path === '') {
+			return (bool)Dev::apply('_out', false);
+		}
+
+		$path = Dev::apply('_in', $path);
+		$isReadable = is_string($path) && is_readable($path);
+
+		return (bool)Dev::apply('_out', $isReadable);
+	}
+
+	/**
 	 * Upload a file
-	 * 
+	 *
 	 * @param array $document The file to be uploaded
 	 * @param bool $overwrite Whether to overwrite the file if it already exists
 	 * @return IObj

--- a/tests/Data/FileSystemTest.php
+++ b/tests/Data/FileSystemTest.php
@@ -59,7 +59,7 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase {
 		$this->object->filename = 'testfile.txt';
 		$this->object->write();
 
-		$this->assertTrue(file_exists($this->testdirectory.DIRECTORY_SEPARATOR.'testfile.txt'));
+		$this->assertTrue(FileSystem::fileExists($this->testdirectory.DIRECTORY_SEPARATOR.'testfile.txt'));
 	}
 
 	public function testStaticFileExistsChecksConcretePathWithoutConstructingStorage()
@@ -71,6 +71,32 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue(FileSystem::fileExists($path));
 		$this->assertFalse(FileSystem::fileExists($missing));
 		$this->assertFalse(FileSystem::fileExists($this->testdirectory));
+		$this->assertFileDoesNotExist($missing);
+	}
+
+	public function testStaticDirectoryExistsChecksConcretePathWithoutConstructingStorage()
+	{
+		$directory = $this->testdirectory.DIRECTORY_SEPARATOR.'nested';
+		$file = $this->testdirectory.DIRECTORY_SEPARATOR.'sample.txt';
+		$missing = $this->testdirectory.DIRECTORY_SEPARATOR.'missing';
+		mkdir($directory);
+		touch($file);
+
+		$this->assertTrue(FileSystem::directoryExists($directory));
+		$this->assertFalse(FileSystem::directoryExists($file));
+		$this->assertFalse(FileSystem::directoryExists($missing));
+		$this->assertDirectoryDoesNotExist($missing);
+	}
+
+	public function testStaticIsReadableChecksConcretePathWithoutConstructingStorage()
+	{
+		$path = $this->testdirectory.DIRECTORY_SEPARATOR.'readable.txt';
+		$missing = $this->testdirectory.DIRECTORY_SEPARATOR.'missing-readable.txt';
+		touch($path);
+
+		$this->assertTrue(FileSystem::isReadable($path));
+		$this->assertTrue(FileSystem::isReadable($this->testdirectory));
+		$this->assertFalse(FileSystem::isReadable($missing));
 		$this->assertFileDoesNotExist($missing);
 	}
 


### PR DESCRIPTION
Refs #154.

## Intent
Centralize concrete file, directory, and readability probes behind FileSystem helpers, then have File and Directory consume those shared Data helpers.

## User stories / acceptance criteria
- File existence checks still return true only for concrete files.
- Directory existence checks still return true only for concrete directories.
- Reachability checks preserve readable-path semantics.
- Static probes use the DevElation input/output filter boundary.
- Existing storage-backed FileSystem::exists behavior remains unchanged.

## Key files changed
- src/Data/FileSystem.php
- src/Data/File.php
- src/Data/Directory.php
- tests/Data/FileSystemTest.php

## How to test
- php -l src/Data/FileSystem.php
- php -l src/Data/File.php
- php -l src/Data/Directory.php
- php -l tests/Data/FileSystemTest.php
- vendor/bin/phpunit --do-not-cache-result tests/Data/FileSystemTest.php tests/Data/FileDirectoryExistenceTest.php
- composer validate --strict
- git diff --check
- vendor/bin/phpunit.bat --do-not-cache-result --colors=never

## QA checklist
- [x] Focused Data tests pass after cleanup
- [x] Composer manifest validates
- [x] Whitespace check passes after cleanup
- [x] Full PHPUnit suite passes with optional skips

## Approval conditions
- Confirm the shared static probe names and File/Directory delegation pattern are acceptable for the helper usage audit.