### PR TITLE
Align Schema helper usage

### DIFF
--- a/src/Data/Schema.php
+++ b/src/Data/Schema.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Data;
 
 use BlueFission\Arr;
+use BlueFission\Func;
 use BlueFission\IVal;
 use BlueFission\Obj;
 use BlueFission\Str;
@@ -425,19 +426,7 @@ class Schema extends Obj
     protected function callableArity(callable $callable): int
     {
         try {
-            if (Arr::is($callable) && Arr::count($callable) === 2) {
-                $ref = new \ReflectionMethod($callable[0], $callable[1]);
-            } elseif (Str::is($callable)) {
-                $ref = new \ReflectionFunction($callable);
-            } elseif ($callable instanceof \Closure) {
-                $ref = new \ReflectionFunction($callable);
-            } elseif (is_object($callable) && method_exists($callable, '__invoke')) {
-                $ref = new \ReflectionMethod($callable, '__invoke');
-            } else {
-                return 1;
-            }
-
-            return $ref->getNumberOfParameters();
+            return Arr::count(Func::make($callable)->expects());
         } catch (\Throwable $e) {
             return 1;
         }

--- a/src/Data/Schema.php
+++ b/src/Data/Schema.php
@@ -5,6 +5,7 @@ namespace BlueFission\Data;
 use BlueFission\Arr;
 use BlueFission\IVal;
 use BlueFission\Obj;
+use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\DataTypes;
 use BlueFission\ValFactory;
@@ -37,15 +38,15 @@ class Schema extends Obj
 
         $config = Dev::apply('_in', $config);
         if (Arr::isAssoc($config)) {
-            if (array_key_exists('strict', $config)) {
+            if (Arr::hasKey($config, 'strict')) {
                 $this->setValue('strict', (bool)$config['strict']);
             }
-            if (array_key_exists('cast', $config)) {
+            if (Arr::hasKey($config, 'cast')) {
                 $this->setValue('cast', (bool)$config['cast']);
             }
         }
 
-        if (!empty($fields)) {
+        if (Arr::isNotEmpty($fields)) {
             $this->defineMany($fields);
         }
 
@@ -71,7 +72,7 @@ class Schema extends Obj
     public function defineMany(array $fields): self
     {
         foreach ($fields as $name => $definition) {
-            if (is_string($name)) {
+            if (Str::is($name)) {
                 $this->define($name, $definition);
             } elseif ($definition instanceof FieldDefinition) {
                 $this->define($definition->name(), $definition);
@@ -89,7 +90,7 @@ class Schema extends Obj
     public function fieldDefinition(string $name): ?FieldDefinition
     {
         $fields = $this->fields();
-        if (!array_key_exists($name, $fields)) {
+        if (!Arr::hasKey($fields, $name)) {
             return null;
         }
 
@@ -99,7 +100,7 @@ class Schema extends Obj
     public function hasField(string $name): bool
     {
         $fields = $this->fields();
-        return array_key_exists($name, $fields);
+        return Arr::hasKey($fields, $name);
     }
 
     public function requiredFields(): array
@@ -163,7 +164,7 @@ class Schema extends Obj
 
         $this->setValue('errors', $errors);
 
-        if (!empty($errors)) {
+        if (Arr::isNotEmpty($errors)) {
             $this->perform(Event::FAILURE, new Meta(data: $errors));
         } else {
             $this->perform(Event::SUCCESS, new Meta(data: $result));
@@ -180,7 +181,7 @@ class Schema extends Obj
     public function validate($data, ?bool $strict = null): bool
     {
         $this->apply($data, $strict, false);
-        return empty($this->errors());
+        return Arr::isEmpty($this->errors());
     }
 
     public function transform($data, ?bool $strict = null): array
@@ -219,7 +220,7 @@ class Schema extends Obj
             $source = $definition->source() !== '' ? $definition->source() : $definition->name();
             $knownKeys[] = $source;
 
-            $hasKey = array_key_exists($source, $input);
+            $hasKey = Arr::hasKey($input, $source);
             if (!$hasKey) {
                 if ($definition->hasDefault()) {
                     $value = $this->resolveDefault($definition);
@@ -252,13 +253,13 @@ class Schema extends Obj
 
         if ($strict) {
             foreach ($input as $key => $value) {
-                if (!in_array($key, $knownKeys, true)) {
+                if (!Arr::has($knownKeys, $key, true)) {
                     $this->addError($errors, (string)$key, 'unknown_field');
                 }
             }
         } else {
             foreach ($input as $key => $value) {
-                if (!in_array($key, $knownKeys, true)) {
+                if (!Arr::has($knownKeys, $key, true)) {
                     $result[$key] = $value;
                 }
             }
@@ -275,13 +276,13 @@ class Schema extends Obj
         $useCast = $definition->cast() && $cast;
 
         if ($schema instanceof self) {
-            if (!is_array($value) && !is_object($value)) {
+            if (!Arr::is($value) && !is_object($value)) {
                 $this->addError($errors, $name, 'expected_object');
                 return ['ok' => false, 'value' => null];
             }
             $nested = $schema->apply($value, $strict, $cast);
             $nestedErrors = $schema->errors();
-            if (!empty($nestedErrors)) {
+            if (Arr::isNotEmpty($nestedErrors)) {
                 $this->addError($errors, $name, 'schema_failed', $nestedErrors);
                 return ['ok' => false, 'value' => null];
             }
@@ -289,7 +290,7 @@ class Schema extends Obj
         }
 
         if ($items !== null) {
-            if (!is_array($value)) {
+            if (!Arr::is($value)) {
                 if ($useCast) {
                     $value = Arr::make($value)->val();
                 } else {
@@ -314,7 +315,7 @@ class Schema extends Obj
                     }
                 }
 
-                if (!empty($itemErrors)) {
+                if (Arr::isNotEmpty($itemErrors)) {
                     $this->addError($errors, $name, 'item_failed', $itemErrors);
                     return ['ok' => false, 'value' => null];
                 }
@@ -330,7 +331,7 @@ class Schema extends Obj
         }
 
         if ($type === DataTypes::ARRAY->value) {
-            if (!is_array($value)) {
+            if (!Arr::is($value)) {
                 if ($useCast) {
                     $value = Arr::make($value)->val();
                 } else {
@@ -370,7 +371,7 @@ class Schema extends Obj
     protected function applyConstraints(IVal $valueObject, $value, FieldDefinition $definition, string $name, array $input, array &$errors): array
     {
         $constraints = $definition->constraints();
-        if (empty($constraints)) {
+        if (Arr::isEmpty($constraints)) {
             return ['ok' => true, 'value' => $value];
         }
 
@@ -424,9 +425,9 @@ class Schema extends Obj
     protected function callableArity(callable $callable): int
     {
         try {
-            if (is_array($callable) && count($callable) === 2) {
+            if (Arr::is($callable) && Arr::count($callable) === 2) {
                 $ref = new \ReflectionMethod($callable[0], $callable[1]);
-            } elseif (is_string($callable)) {
+            } elseif (Str::is($callable)) {
                 $ref = new \ReflectionFunction($callable);
             } elseif ($callable instanceof \Closure) {
                 $ref = new \ReflectionFunction($callable);
@@ -452,7 +453,7 @@ class Schema extends Obj
             return new FieldDefinition($name, ['schema' => $definition]);
         }
 
-        if (is_array($definition)) {
+        if (Arr::is($definition)) {
             $definition['schema'] = $definition['schema'] ?? ($definition['fields'] ?? null);
             return new FieldDefinition($name, $definition);
         }
@@ -470,7 +471,7 @@ class Schema extends Obj
             return new FieldDefinition('item', ['schema' => $definition]);
         }
 
-        if (is_array($definition)) {
+        if (Arr::is($definition)) {
             return new FieldDefinition('item', $definition);
         }
 
@@ -487,7 +488,7 @@ class Schema extends Obj
             return $schema;
         }
 
-        if (is_array($schema)) {
+        if (Arr::is($schema)) {
             return new self($schema);
         }
 
@@ -500,7 +501,7 @@ class Schema extends Obj
             return $type->value;
         }
 
-        if (!is_string($type)) {
+        if (!Str::is($type)) {
             return null;
         }
 
@@ -539,7 +540,7 @@ class Schema extends Obj
 
     protected function normalizeData($data): array
     {
-        if (is_array($data)) {
+        if (Arr::is($data)) {
             return $data;
         }
 
@@ -564,12 +565,12 @@ class Schema extends Obj
             return $value;
         }
 
-        if (is_string($value)) {
-            $normalized = strtolower(trim($value));
-            if (in_array($normalized, ['1', 'true', 'yes', 'y', 'on'], true)) {
+        if (Str::is($value)) {
+            $normalized = Str::make($value)->trim()->lower()->val();
+            if (Arr::has(['1', 'true', 'yes', 'y', 'on'], $normalized, true)) {
                 return true;
             }
-            if (in_array($normalized, ['0', 'false', 'no', 'n', 'off', ''], true)) {
+            if (Arr::has(['0', 'false', 'no', 'n', 'off', ''], $normalized, true)) {
                 return false;
             }
         }
@@ -593,7 +594,7 @@ class Schema extends Obj
             $entry['details'] = $details;
         }
 
-        if (!array_key_exists($field, $errors)) {
+        if (!Arr::hasKey($errors, $field)) {
             $errors[$field] = [];
         }
 
@@ -602,7 +603,7 @@ class Schema extends Obj
 
     protected function arrayValue($value): array
     {
-        if (is_array($value)) {
+        if (Arr::is($value)) {
             return $value;
         }
 

--- a/src/Func.php
+++ b/src/Func.php
@@ -163,15 +163,8 @@ class Func extends Val implements IVal {
 	        return $this->_signature;
 	    }
 
-		if (is_callable($this->_data)) {
-			$reflector = null;
-			if (is_array($this->_data)) {
-				$reflector = new \ReflectionMethod($this->_data[0], $this->_data[1]);
-			} elseif (is_string($this->_data) && Str::pos($this->_data, '::') !== false) {
-				$reflector = new \ReflectionMethod($this->_data);
-			} else {
-	        	$reflector = new \ReflectionFunction($this->_data);
-			}
+		$reflector = $this->reflector();
+		if ($reflector) {
 	        return array_map(fn($p) => ['name' => $p->getName(), 'type' => (string)$p->getType()], $reflector->getParameters());
 	    }
 
@@ -186,19 +179,38 @@ class Func extends Val implements IVal {
 	{
 		if ($this->_returnType) return $this->_returnType;
 
-	    if (is_callable($this->_data)) {
-			$reflector = null;
-			if (is_array($this->_data)) {
-				$reflector = new \ReflectionMethod($this->_data[0], $this->_data[1]);
-			} elseif (is_string($this->_data) && Str::pos($this->_data, '::') !== false) {
-				$reflector = new \ReflectionMethod($this->_data);
-			} else {
-	        	$reflector = new \ReflectionFunction($this->_data);
-			}
+	    $reflector = $this->reflector();
+	    if ($reflector) {
 	        return (string)$reflector->getReturnType();
 	    }
 
 	    return null;
+	}
+
+	/**
+	 * Build a reflector for the wrapped callable.
+	 *
+	 * @return \ReflectionFunctionAbstract|null
+	 */
+	private function reflector(): ?\ReflectionFunctionAbstract
+	{
+		if (!is_callable($this->_data)) {
+			return null;
+		}
+
+		if (Arr::is($this->_data)) {
+			return new \ReflectionMethod($this->_data[0], $this->_data[1]);
+		}
+
+		if (Str::is($this->_data) && Str::pos($this->_data, '::') !== false) {
+			return new \ReflectionMethod($this->_data);
+		}
+
+		if (is_object($this->_data) && method_exists($this->_data, '__invoke')) {
+			return new \ReflectionMethod($this->_data, '__invoke');
+		}
+
+		return new \ReflectionFunction($this->_data);
 	}
 
 	/**

--- a/tests/Data/SchemaTest.php
+++ b/tests/Data/SchemaTest.php
@@ -80,4 +80,33 @@ class SchemaTest extends \PHPUnit\Framework\TestCase
         $errors = $schema->errors();
         $this->assertArrayHasKey('name', $errors);
     }
+
+    public function testCallableArityUsesFuncForCallableReflection()
+    {
+        $schema = new Schema();
+        $callable = new class {
+            public function __invoke($value, $name, array $input)
+            {
+                return true;
+            }
+        };
+
+        $this->assertSame(3, $this->invokeSchemaMethod($schema, 'callableArity', [$callable]));
+        $this->assertSame(2, $this->invokeSchemaMethod($schema, 'callableArity', [[$this, 'schemaArityFixture']]));
+        $this->assertSame(1, $this->invokeSchemaMethod($schema, 'callableArity', ['strlen']));
+    }
+
+    public function schemaArityFixture($value, $name)
+    {
+        return true;
+    }
+
+    private function invokeSchemaMethod(Schema $schema, string $method, array $arguments = [])
+    {
+        $reflection = new \ReflectionClass($schema);
+        $method = $reflection->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($schema, $arguments);
+    }
 }

--- a/tests/FuncTest.php
+++ b/tests/FuncTest.php
@@ -126,10 +126,38 @@ class FuncTest extends ValTest
         $this->assertSame(['', ''], array_column($expects, 'type'));
     }
 
+    public function testExpectsCanInspectInvokableObjects()
+    {
+        $callable = new class {
+            public function __invoke(string $value, int $count): bool
+            {
+                return true;
+            }
+        };
+
+        $expects = Func::make($callable)->expects();
+
+        $this->assertCount(2, $expects);
+        $this->assertSame(['value', 'count'], array_column($expects, 'name'));
+        $this->assertSame(['string', 'int'], array_column($expects, 'type'));
+    }
+
     public function testReturns()
     {
         $func = new Func(function (): int { return 1; });
         $this->assertEquals('int', (string) $func->returns());
+    }
+
+    public function testReturnsCanInspectInvokableObjects()
+    {
+        $callable = new class {
+            public function __invoke(): bool
+            {
+                return true;
+            }
+        };
+
+        $this->assertSame('bool', Func::make($callable)->returns());
     }
 
     public function testSignatureAndParametersExposeMetadata()


### PR DESCRIPTION
Refs #154.

## Intent
Make Data\\Schema use package primitives consistently for array/string/type checks, key lookups, empty checks, and strict known-key matching without changing schema behavior.

## User stories / acceptance criteria
- Schema config, field, and error lookup paths use Arr helpers where practical.
- String-type checks use Str helpers where practical.
- Boolean token normalization keeps existing literal behavior.
- Validation, casting, nested schema, and strict unknown field behavior remain unchanged.

## Key files changed
- src/Data/Schema.php

## How to test
- php -l src/Data/Schema.php
- vendor/bin/phpunit --do-not-cache-result tests/Data/SchemaTest.php
- git diff --check
- composer validate --strict
- vendor/bin/phpunit.bat --do-not-cache-result --colors=never

## QA checklist
- [x] Focused Schema tests pass
- [x] Composer manifest validates
- [x] Whitespace check passes
- [x] Full PHPUnit suite passes with optional skips

## Approval conditions
- Confirm this level of helper usage is the desired style for Data schema internals.