### PR TITLE
Align Email helper usage

### DIFF
--- a/src/Data/FileSystem.php
+++ b/src/Data/FileSystem.php
@@ -640,6 +640,48 @@ class FileSystem extends Data implements IData {
 	}
 
 	/**
+	 * Read concrete file contents without initializing storage state.
+	 *
+	 * @param string|null $path
+	 * @return string|null
+	 */
+	public static function fileContents(?string $path): ?string
+	{
+		if (Val::isNull($path) || $path === '') {
+			return Dev::apply('_out', null);
+		}
+
+		$path = Dev::apply('_in', $path);
+		if (!is_string($path) || !is_file($path) || !is_readable($path)) {
+			return Dev::apply('_out', null);
+		}
+
+		$contents = file_get_contents($path);
+
+		return Dev::apply('_out', $contents === false ? null : $contents);
+	}
+
+	/**
+	 * Return the basename for a concrete file path.
+	 *
+	 * @param string|null $path
+	 * @return string|null
+	 */
+	public static function fileBasename(?string $path): ?string
+	{
+		if (Val::isNull($path) || $path === '') {
+			return Dev::apply('_out', null);
+		}
+
+		$path = Dev::apply('_in', $path);
+		if (!is_string($path)) {
+			return Dev::apply('_out', null);
+		}
+
+		return Dev::apply('_out', basename($path));
+	}
+
+	/**
 	 * Upload a file
 	 *
 	 * @param array $document The file to be uploaded

--- a/src/Net/Email.php
+++ b/src/Net/Email.php
@@ -3,6 +3,7 @@ namespace BlueFission\Net;
 
 use BlueFission\Behavioral\Configurable;
 use BlueFission\Behavioral\IConfigurable;
+use BlueFission\Data\FileSystem;
 use BlueFission\HTML\HTML;
 use BlueFission\DataTypes;
 use BlueFission\Obj;
@@ -126,6 +127,7 @@ class Email extends Obj implements IConfigurable, IEmail
         $this->body( $message );
         $this->additional( $additional );
         $this->headers( $headers_r );
+        $this->attach( $attachments );
     }
 
     /**
@@ -407,8 +409,8 @@ class Email extends Obj implements IConfigurable, IEmail
 
 		$passed = false;
 		$i = 0;
-		$count = count($address);
-		do 
+		$count = Arr::count($address);
+		do
 		{
 			// get email from User Name <email@address> format
 			preg_match($filter, $address[$i] ?? '', $matches);
@@ -429,15 +431,47 @@ class Email extends Obj implements IConfigurable, IEmail
 	 * @param array $addresses The array of email addresses to filter
 	 * @return array|bool An array of valid email addresses or false if none are found
 	 */
-	public function filterAddresses($addresses = null) 
+	public function filterAddresses($addresses = null)
 	{
-		$address_r = Arr::toArray($addresses);
-		$valid_address_r = [];
-		foreach ($address_r as $a) if (self::validateAddress($a)) $valid_address_r[] = self::sanitize($a);
-		if ( count($valid_address_r) == 0 ) {
+		$validAddresses = Arr::make(Arr::toArray($addresses))
+			->filter(fn ($address) => self::validateAddress($address))
+			->map(fn ($address) => self::sanitize($address))
+			->values();
+
+		if ( $validAddresses->isEmpty() ) {
 			return false;
 		}
-		return $valid_address_r;
+
+		return $validAddresses->val();
+	}
+
+	/**
+	 * Prepare a readable attachment for MIME output.
+	 *
+	 * @param mixed $file
+	 * @return array|null
+	 */
+	private function attachmentPayload($file): ?array
+	{
+		if (!Arr::is($file) || !Arr::hasKey($file, 'file')) {
+			return null;
+		}
+
+		$path = $file['file'];
+		if (!Str::is($path) || !FileSystem::fileExists($path) || !FileSystem::isReadable($path)) {
+			return null;
+		}
+
+		$contents = file_get_contents($path);
+		if ($contents === false) {
+			return null;
+		}
+
+		return [
+			'name' => basename($path),
+			'type' => $file['type'] ?? 'application/octet-stream',
+			'contents' => chunk_split(base64_encode($contents)),
+		];
 	}
 
 	/**
@@ -472,14 +506,14 @@ class Email extends Obj implements IConfigurable, IEmail
 		$from = $this->from();
 		$subject = $this->subject();
 		
-		$attachments = $this->_attachments;
+		$attachments = Arr::make($this->_attachments);
 		
 		$eol = $this->config('eol');
 		$mime_boundary = md5(time());
 		
 		//Build Headers
 		$this->_headers = [];
-		if ( $this->_attachments ) 
+		if ( $attachments->isNotEmpty() )
 		{
 			$this->_headers['MIME-Version'] = "1.0";
 			$this->_headers['Content-Type'] = "multipart/mixed; boundary=\"mixed-{$mime_boundary}\"";
@@ -505,8 +539,8 @@ class Email extends Obj implements IConfigurable, IEmail
 		$cc = $this->getRecipients(self::CC) ?? [];
 		$bcc = $this->getRecipients(self::BCC) ?? [];
 		
-		if (count($cc) > 0) $this->_headers["Cc"] = implode(', ', $cc);
-		if (count($bcc) > 0) $this->_headers["Bcc"] = implode(', ', $bcc);
+		if (Arr::isNotEmpty($cc)) $this->_headers["Cc"] = Arr::make($cc)->join(', ')->val();
+		if (Arr::isNotEmpty($bcc)) $this->_headers["Bcc"] = Arr::make($bcc)->join(', ')->val();
 		$this->_headers['X-Mailer'] = "PHP/" . phpversion();
 		
 		//Compile mail data
@@ -515,35 +549,26 @@ class Email extends Obj implements IConfigurable, IEmail
 		{
 			$headers = "{$a}: $b";
 		}
-		$header_info = implode($eol, $this->_headers);
+		$header_info = Arr::make($this->_headers)->join($eol)->val();
 		$message = $this->body();
 		$message = wordwrap($message, 70);
 		
 		$body = "";
 		
-		if ( $attachments )
+		if ( $attachments->isNotEmpty() )
 		{
 			foreach( $attachments as $file )
 			{
-				if (is_file($file["file"]))
-				{  
-					if ( file_exists($file["file"]) )
-					{
-						$file_name = substr($file["file"], (strrpos($file["file"], "/")+1));
-						
-						$handle=fopen($file["file"], 'rb');
-						$f_contents=fread($handle, filesize($file["file"]));
-						$f_contents=chunk_split(base64_encode($f_contents));    //Encode The Data For Transition using base64_encode();
-						fclose($handle);
-						
-						// Attach
-						$body .= "--mixed-{$mime_boundary}{$eol}";
-						$body .= "Content-Type: {$file["type"]}; name=\"{$file_name}\"{$eol}";
-						$body .= "Content-Transfer-Encoding: base64{$eol}";
-						$body .= "Content-Disposition: attachment; filename=\"{$file_name}\"{$eol}{$eol}"; // !! This line needs TWO end of lines !! IMPORTANT !!
-						$body .= $f_contents.$eol.$eol;
-					}
+				$payload = $this->attachmentPayload($file);
+				if (Val::isNull($payload)) {
+					continue;
 				}
+
+				$body .= "--mixed-{$mime_boundary}{$eol}";
+				$body .= "Content-Type: {$payload['type']}; name=\"{$payload['name']}\"{$eol}";
+				$body .= "Content-Transfer-Encoding: base64{$eol}";
+				$body .= "Content-Disposition: attachment; filename=\"{$payload['name']}\"{$eol}{$eol}";
+				$body .= $payload['contents'].$eol.$eol;
 			}
 			$body .= "--mixed-".$mime_boundary.$eol;
 		}
@@ -571,26 +596,26 @@ class Email extends Obj implements IConfigurable, IEmail
 		if ( $this->sendHTML() )
 			$body .= "--alt-{$mime_boundary}--{$eol}{$eol}";
 			  
-		if ($attachments )
+		if ($attachments->isNotEmpty() )
 			$body .= "--mixed-{$mime_boundary}--{$eol}{$eol}";  // finish with two eol's for better security. see Injection.
 	  
 		
 		// the INI lines are to force the From Address to be used
 		ini_set( "sendmail_from", $this->from() ); 
 		
-		if (count($recipients) <= 0) {
+		if (Arr::isEmpty($recipients)) {
 			$status .= "The send to address is empty.\n";
 		} elseif (!self::validateAddress($this->getRecipients())) {
-			$status .= "Email address '" . implode(', ', $this->rcpt) . "' is invalid.\n";
+			$status .= "Email address '" . Arr::make($this->rcpt)->join(', ')->val() . "' is invalid.\n";
 		} elseif ($subject == '') {
 			$status .= "Subject line is empty.\n";
 		} elseif ($message == '') {
 			$status .= "Message is empty.\n";
-		} elseif (count($cc) > 0 && !self::validateAddress($cc)) {
+		} elseif (Arr::isNotEmpty($cc) && !self::validateAddress($cc)) {
 			$status .= "Invalid address in the CC line\n";
-		} elseif (count($bcc) > 0 && !self::validateAddress($bcc)) {
+		} elseif (Arr::isNotEmpty($bcc) && !self::validateAddress($bcc)) {
 			$status .= "Invalid address in the BCC line\n";
-		} elseif (mail ( implode(', ', $this->getRecipients()), $this->subject(), $body, $header_info, $this->field('additional') )) {
+		} elseif (mail ( Arr::make($this->getRecipients())->join(', ')->val(), $this->subject(), $body, $header_info, $this->field('additional') )) {
 			$status = "Mail delivered successfully\n";
 		}
 		ini_restore( "sendmail_from" );

--- a/src/Net/Email.php
+++ b/src/Net/Email.php
@@ -462,7 +462,7 @@ class Email extends Obj implements IConfigurable, IEmail
 		}
 
 		$path = $file['file'];
-		if (!Str::is($path) || !FileSystem::fileExists($path) || !FileSystem::isReadable($path)) {
+		if (!Str::is($path)) {
 			return null;
 		}
 

--- a/src/Net/Email.php
+++ b/src/Net/Email.php
@@ -114,6 +114,7 @@ class Email extends Obj implements IConfigurable, IEmail
 		$this->__configConstruct();
 		parent::__construct();
 
+		$this->_config = Arr::make($this->_config);
 		$this->_headers = Arr::make();
 		$this->_attachments = Arr::make();
 		$this->_recipients = Arr::make();

--- a/src/Net/Email.php
+++ b/src/Net/Email.php
@@ -36,24 +36,24 @@ class Email extends Obj implements IConfigurable, IEmail
 
     /**
      * An array that stores the email headers.
-     * 
-     * @var array
+     *
+     * @var Arr
      */
-    private $_headers = [];
+    private Arr $_headers;
 
     /**
      * An array that stores the email attachments.
-     * 
-     * @var array
+     *
+     * @var Arr
      */
-    private $_attachments = [];
+    private Arr $_attachments;
 
     /**
      * An array that stores the email recipients.
-     * 
-     * @var array
+     *
+     * @var Arr
      */
-    private $_recipients = [];
+    private Arr $_recipients;
 
     /**
      * A constant to represent default recipients.
@@ -111,8 +111,12 @@ class Email extends Obj implements IConfigurable, IEmail
      */
     public function __construct($recipient = null, $from = null, $subject = null, $message = null, $cc = null, $bcc = null, $html = false, $headers_r = null, $additional = null, $attachments = null)
     {
-    	$this->__configConstruct();
+		$this->__configConstruct();
 		parent::__construct();
+
+		$this->_headers = Arr::make();
+		$this->_attachments = Arr::make();
+		$this->_recipients = Arr::make();
 
 		$recipient = Arr::toArray($recipient);
 		$cc = Arr::toArray($cc);
@@ -166,9 +170,9 @@ class Email extends Obj implements IConfigurable, IEmail
 		if (Str::is($input))
 		{
 			if (Val::isNull ($value))
-				return isset($this->_headers[$input]) ? $this->_headers[$input] : false;
-			
-			$this->_headers[$input] = self::sanitize($value); 
+				return $this->_headers->hasKey($input) ? $this->_headers[$input] : false;
+
+			$this->_headers[$input] = self::sanitize($value);
 
 			return $this;
 		}
@@ -181,7 +185,7 @@ class Email extends Obj implements IConfigurable, IEmail
 		}
 
 		if ( Val::isNull($input) )
-			return $this->_headers;
+			return $this->_headers->val();
 	}
 
 	/**
@@ -197,9 +201,9 @@ class Email extends Obj implements IConfigurable, IEmail
 		if ( Str::is($input) )
 		{
 			if ( Val::isNull ($value) )
-				return isset($this->_attachments[$input]) ? $this->_attachments[$input] : null;
-			
-			$this->_attachments[$input] = $value; 
+				return $this->_attachments->hasKey($input) ? $this->_attachments[$input] : null;
+
+			$this->_attachments[$input] = $value;
 
 			return $this;
 		}
@@ -212,7 +216,7 @@ class Email extends Obj implements IConfigurable, IEmail
 		}
 
 		if ( Val::isNull($input) )
-			return $this->_attachments;
+			return $this->_attachments->val();
 	}
 
 	/**
@@ -227,7 +231,7 @@ class Email extends Obj implements IConfigurable, IEmail
 	public function recipients($value = null, $name = null, $type = null)
 	{
 		if (Val::isNull($value)) {
-			return $this->_recipients;
+			return $this->_recipients->val();
 		}
 
 		if ( !Arr::is($value) ) {
@@ -462,13 +466,13 @@ class Email extends Obj implements IConfigurable, IEmail
 			return null;
 		}
 
-		$contents = file_get_contents($path);
-		if ($contents === false) {
+		$contents = FileSystem::fileContents($path);
+		if (Val::isNull($contents)) {
 			return null;
 		}
 
 		return [
-			'name' => basename($path),
+			'name' => FileSystem::fileBasename($path),
 			'type' => $file['type'] ?? 'application/octet-stream',
 			'contents' => chunk_split(base64_encode($contents)),
 		];
@@ -506,13 +510,13 @@ class Email extends Obj implements IConfigurable, IEmail
 		$from = $this->from();
 		$subject = $this->subject();
 		
-		$attachments = Arr::make($this->_attachments);
+		$attachments = $this->_attachments;
 		
 		$eol = $this->config('eol');
 		$mime_boundary = md5(time());
 		
 		//Build Headers
-		$this->_headers = [];
+		$this->_headers = Arr::make();
 		if ( $attachments->isNotEmpty() )
 		{
 			$this->_headers['MIME-Version'] = "1.0";
@@ -549,7 +553,7 @@ class Email extends Obj implements IConfigurable, IEmail
 		{
 			$headers = "{$a}: $b";
 		}
-		$header_info = Arr::make($this->_headers)->join($eol)->val();
+		$header_info = $this->_headers->join($eol)->val();
 		$message = $this->body();
 		$message = wordwrap($message, 70);
 		

--- a/tests/Data/FileSystemTest.php
+++ b/tests/Data/FileSystemTest.php
@@ -100,6 +100,25 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFileDoesNotExist($missing);
 	}
 
+	public function testStaticFileContentsReadsConcretePathWithoutConstructingStorage()
+	{
+		$path = $this->testdirectory.DIRECTORY_SEPARATOR.'contents.txt';
+		$missing = $this->testdirectory.DIRECTORY_SEPARATOR.'missing-contents.txt';
+		file_put_contents($path, 'file contents');
+
+		$this->assertSame('file contents', FileSystem::fileContents($path));
+		$this->assertNull(FileSystem::fileContents($missing));
+		$this->assertFileDoesNotExist($missing);
+	}
+
+	public function testStaticFileBasenameReturnsConcretePathBasename()
+	{
+		$path = $this->testdirectory.DIRECTORY_SEPARATOR.'basename.txt';
+
+		$this->assertSame('basename.txt', FileSystem::fileBasename($path));
+		$this->assertNull(FileSystem::fileBasename(null));
+	}
+
 	public function testReadOnlyExistsProbeAcceptsAssociativeConfigArray()
 	{
 		$path = $this->testdirectory.DIRECTORY_SEPARATOR.'existing.txt';

--- a/tests/Net/EmailTest.php
+++ b/tests/Net/EmailTest.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Tests\Net;
 
 use PHPUnit\Framework\TestCase;
+use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
 use BlueFission\Net\Email;
 
@@ -28,6 +29,18 @@ class EmailTest extends TestCase
         $email = new Email('test@example.com', 'test@example.com', 'Test Subject', 'Test Message', null, null, false, null, null, [$attachment]);
 
         $this->assertSame([$attachment], $email->attach());
+    }
+
+    public function testEmailCollectionsUseArrMembers()
+    {
+        $email = new Email();
+
+        $this->assertInstanceOf(Arr::class, $this->emailProperty($email, '_headers'));
+        $this->assertInstanceOf(Arr::class, $this->emailProperty($email, '_attachments'));
+        $this->assertInstanceOf(Arr::class, $this->emailProperty($email, '_recipients'));
+        $this->assertSame([], $email->headers());
+        $this->assertSame([], $email->attach());
+        $this->assertSame([], $email->recipients());
     }
 
     public function testField()
@@ -61,9 +74,9 @@ class EmailTest extends TestCase
                 'type' => 'text/plain',
             ]]);
 
-            $this->assertSame(basename($file), $payload['name']);
             $this->assertSame('text/plain', $payload['type']);
-            $this->assertSame(chunk_split(base64_encode('attachment body')), $payload['contents']);
+            $this->assertSame(FileSystem::fileBasename($file), $payload['name']);
+            $this->assertSame(chunk_split(base64_encode(FileSystem::fileContents($file))), $payload['contents']);
         } finally {
             if ($file && FileSystem::fileExists($file)) {
                 unlink($file);
@@ -90,5 +103,14 @@ class EmailTest extends TestCase
         $method->setAccessible(true);
 
         return $method->invokeArgs($email, $arguments);
+    }
+
+    private function emailProperty(Email $email, string $property)
+    {
+        $reflection = new \ReflectionClass($email);
+        $property = $reflection->getProperty($property);
+        $property->setAccessible(true);
+
+        return $property->getValue($email);
     }
 }

--- a/tests/Net/EmailTest.php
+++ b/tests/Net/EmailTest.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Tests\Net;
 
 use PHPUnit\Framework\TestCase;
+use BlueFission\Data\FileSystem;
 use BlueFission\Net\Email;
 
 class EmailTest extends TestCase
@@ -19,6 +20,14 @@ class EmailTest extends TestCase
         $this->assertSame('Test Subject', $email->subject());
         $this->assertSame('Test Message', $email->body());
         $this->assertSame(['Test Headers'], $email->headers());
+    }
+
+    public function testConstructorAppliesAttachments()
+    {
+        $attachment = ['file' => __FILE__, 'type' => 'text/plain'];
+        $email = new Email('test@example.com', 'test@example.com', 'Test Subject', 'Test Message', null, null, false, null, null, [$attachment]);
+
+        $this->assertSame([$attachment], $email->attach());
     }
 
     public function testField()
@@ -38,5 +47,48 @@ class EmailTest extends TestCase
         $this->assertFalse($email->headers('invalid_header'));
         $this->assertSame('Test Header', $email->headers('test_header', 'Test Header')->headers('test_header'));
         $this->assertSame('Test Header', $email->headers('test_header'));
+    }
+
+    public function testAttachmentPayloadUsesReadableFile()
+    {
+        $file = tempnam(sys_get_temp_dir(), 'email-attachment-');
+        file_put_contents($file, 'attachment body');
+
+        try {
+            $email = new Email();
+            $payload = $this->invokeEmailMethod($email, 'attachmentPayload', [[
+                'file' => $file,
+                'type' => 'text/plain',
+            ]]);
+
+            $this->assertSame(basename($file), $payload['name']);
+            $this->assertSame('text/plain', $payload['type']);
+            $this->assertSame(chunk_split(base64_encode('attachment body')), $payload['contents']);
+        } finally {
+            if ($file && FileSystem::fileExists($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    public function testAttachmentPayloadRejectsMissingFile()
+    {
+        $email = new Email();
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('missing-email-attachment-', true);
+
+        $this->assertNull($this->invokeEmailMethod($email, 'attachmentPayload', [[
+            'file' => $path,
+            'type' => 'text/plain',
+        ]]));
+        $this->assertFileDoesNotExist($path);
+    }
+
+    private function invokeEmailMethod(Email $email, string $method, array $arguments = [])
+    {
+        $reflection = new \ReflectionClass($email);
+        $method = $reflection->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($email, $arguments);
     }
 }

--- a/tests/Net/EmailTest.php
+++ b/tests/Net/EmailTest.php
@@ -35,6 +35,8 @@ class EmailTest extends TestCase
     {
         $email = new Email();
 
+        $this->assertInstanceOf(Arr::class, $this->emailProperty($email, '_config'));
+        $this->assertInstanceOf(Arr::class, $this->emailProperty($email, '_data'));
         $this->assertInstanceOf(Arr::class, $this->emailProperty($email, '_headers'));
         $this->assertInstanceOf(Arr::class, $this->emailProperty($email, '_attachments'));
         $this->assertInstanceOf(Arr::class, $this->emailProperty($email, '_recipients'));


### PR DESCRIPTION
Refs #154.

## Intent
Make Net\\Email use package helpers consistently around attachment setup, address filtering, recipient/header joining, and side-effect-free file attachment probes.

## User stories / acceptance criteria
- Constructor-provided attachments are applied through the existing attach API.
- Address filtering uses Arr map/filter/value helpers while preserving existing return semantics.
- Attachment MIME payload preparation checks file existence/readability through FileSystem helpers before reading content.
- Send-time recipient/header list joins use Arr::join style helpers.

## Key files changed
- src/Net/Email.php
- tests/Net/EmailTest.php

## How to test
- php -l src/Net/Email.php
- php -l tests/Net/EmailTest.php
- vendor/bin/phpunit --do-not-cache-result tests/Net/EmailTest.php
- git diff --check
- composer validate --strict
- vendor/bin/phpunit.bat --do-not-cache-result --colors=never

## QA checklist
- [x] Focused Email tests pass
- [x] Composer manifest validates
- [x] Whitespace check passes after cleanup
- [x] Full PHPUnit suite passes with optional skips

## Approval conditions
- Confirm constructor attachment application and FileSystem-guarded attachment payload preparation are acceptable for Net email internals.