### PR TITLE
Align FieldDefinition helper usage

### DIFF
--- a/src/Data/Schema/FieldDefinition.php
+++ b/src/Data/Schema/FieldDefinition.php
@@ -2,8 +2,10 @@
 
 namespace BlueFission\Data\Schema;
 
+use BlueFission\Arr;
 use BlueFission\Obj;
 use BlueFission\DataTypes;
+use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\DevElation as Dev;
 
@@ -45,15 +47,15 @@ class FieldDefinition extends Obj
         }
 
         $constraints = $config['constraints'] ?? [];
-        if (Val::isNotNull($constraints) && !is_array($constraints)) {
+        if (Val::isNotNull($constraints) && !Arr::is($constraints)) {
             $constraints = [$constraints];
         }
 
-        $hasDefault = array_key_exists('default', $config);
+        $hasDefault = Arr::hasKey($config, 'default');
 
         $this->assign([
             'name' => $name,
-            'type' => is_string($type) ? $type : '',
+            'type' => Str::is($type) ? $type : '',
             'required' => (bool)($config['required'] ?? false),
             'nullable' => (bool)($config['nullable'] ?? false),
             'default' => $config['default'] ?? null,
@@ -106,7 +108,7 @@ class FieldDefinition extends Obj
     public function constraints(): array
     {
         $value = $this->field('constraints');
-        return is_array($value) ? $value : [];
+        return Arr::is($value) ? $value : [];
     }
 
     public function items()

--- a/tests/Data/SchemaTest.php
+++ b/tests/Data/SchemaTest.php
@@ -80,4 +80,22 @@ class SchemaTest extends \PHPUnit\Framework\TestCase
         $errors = $schema->errors();
         $this->assertArrayHasKey('name', $errors);
     }
+
+    public function testFieldDefinitionNormalizesDefaultsAndConstraints()
+    {
+        $constraint = function (&$value) {
+            return $value !== null;
+        };
+
+        $definition = new FieldDefinition('score', [
+            'type' => \BlueFission\DataTypes::INTEGER,
+            'default' => null,
+            'constraints' => $constraint,
+        ]);
+
+        $this->assertSame('integer', $definition->type());
+        $this->assertTrue($definition->hasDefault());
+        $this->assertNull($definition->defaultValue());
+        $this->assertSame([$constraint], $definition->constraints());
+    }
 }


### PR DESCRIPTION
Refs #154.

## Intent
Make Data\\Schema\\FieldDefinition use package primitives for config key checks, string checks, and constraints array normalization.

## User stories / acceptance criteria
- Default detection continues to treat a present null default as an explicit default.
- Scalar constraints continue to normalize to an array.
- DataTypes enum values continue to normalize to their scalar type value.
- FieldDefinition keeps the same public API while matching Schema helper style.

## Key files changed
- src/Data/Schema/FieldDefinition.php
- tests/Data/SchemaTest.php

## How to test
- php -l src/Data/Schema/FieldDefinition.php
- php -l tests/Data/SchemaTest.php
- vendor/bin/phpunit --do-not-cache-result tests/Data/SchemaTest.php
- git diff --check
- composer validate --strict
- vendor/bin/phpunit.bat --do-not-cache-result --colors=never

## QA checklist
- [x] Focused Schema tests pass
- [x] Composer manifest validates
- [x] Whitespace check passes
- [x] Full PHPUnit suite passes with optional skips

## Approval conditions
- Confirm this helper style is acceptable for schema field configuration internals.