### PR TITLE
Align Net helpers with primitives

### DIFF
--- a/src/Net/HTTPClient.php
+++ b/src/Net/HTTPClient.php
@@ -30,7 +30,7 @@ class HTTPClient implements ClientInterface
         // Set the request body if there is one
         $body = (string) $request->getBody();
         if (Val::isNotEmpty($body)) {
-            $this->_curl->assign(json_decode($body, true) ?: $body);
+            $this->_curl->assign($this->requestBodyPayload($body));
         }
 
         $this->_curl
@@ -43,6 +43,11 @@ class HTTPClient implements ClientInterface
             $this->getHeaders(),
             $this->_curl->result()
         );
+    }
+
+    protected function requestBodyPayload(string $body): mixed
+    {
+        return HTTP::jsonDecode($body, true, $body);
     }
 
     protected function getStatusCode(): int

--- a/src/Net/HTTPClient.php
+++ b/src/Net/HTTPClient.php
@@ -29,7 +29,7 @@ class HTTPClient implements ClientInterface
 
         // Set the request body if there is one
         $body = (string) $request->getBody();
-        if (!empty($body)) {
+        if (Val::isNotEmpty($body)) {
             $this->_curl->assign(json_decode($body, true) ?: $body);
         }
 
@@ -55,14 +55,22 @@ class HTTPClient implements ClientInterface
         $headerSize = curl_getinfo($this->_curl->connection(), CURLINFO_HEADER_SIZE);
         $headerString = Str::sub($this->_curl->result(), 0, $headerSize);
         $lines = $this->normalizeHeaderLines($headerString);
-        $headers = [];
+        return $this->parseHeaderLines($lines);
+    }
+
+    protected function parseHeaderLines(array $lines): array
+    {
+        $headers = Arr::make();
         foreach ($lines as $line) {
-            if (Str::pos($line, ':') !== false) {
-                list($key, $value) = explode(':', Str::use(), 2);
-                $headers[trim($key)] = trim($value);
+            $separator = Str::pos($line, ':');
+            if ($separator !== false) {
+                $key = Str::sub($line, 0, $separator);
+                $value = Str::sub($line, $separator + 1);
+                $headers[Str::trim($key)] = Str::trim($value);
             }
         }
-        return $headers;
+
+        return $headers->val();
     }
 
     protected function normalizeHeaderLines($headerString): array
@@ -71,21 +79,23 @@ class HTTPClient implements ClientInterface
             return [];
         }
 
-        $headerString = Val::grab();
-
         if (Str::is($headerString)) {
-            $headerString = Str::replace(Str::grab(), "\r", '');
-            $lines = Str::split($headerString, "\n");
+            $lines = Str::make($headerString)
+                ->replace("\r", '')
+                ->split("\n")
+                ->filter(fn ($line) => Str::isNotEmpty($line))
+                ->values()
+                ->val();
         } elseif (Arr::is($headerString)) {
             $lines = Arr::grab();
         } else {
             return [];
         }
 
-        if (!Arr::isNotEmpty($lines)) {
+        if (Arr::isEmpty($lines)) {
             return [];
         }
 
-        return Arr::grab();
+        return $lines;
     }
 }

--- a/src/Net/IP.php
+++ b/src/Net/IP.php
@@ -2,6 +2,7 @@
 namespace BlueFission\Net;
 
 use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Date;
 use BlueFission\Flag;
@@ -73,6 +74,19 @@ class IP {
 		self::$_ipFile = $file;
 	}
 
+	private static function ipLines($ipList): Arr
+	{
+		return Str::make((string)$ipList)
+			->split("\n")
+			->map(fn ($line) => Str::trim($line))
+			->filter(fn ($line) => Str::isNotEmpty($line))
+			->values();
+	}
+
+	private static function serializeLines($lines, string $delimiter = "\n"): string
+	{
+		return Arr::make($lines)->join($delimiter)->val();
+	}
 
 	private static function update(array $data)
 	{
@@ -83,8 +97,10 @@ class IP {
 		$storage->when( new Event( Event::CONNECTED ), function() use ( $data, $storage ) {
 			if (Arr::is($data)) {
 				$delimiter = "\t";
-				$lines = array_map(fn ($line) => implode($delimiter, $line), $data);
-				$storage->contents( implode("\n", $lines) )->write();
+				$lines = Arr::make($data)
+					->map(fn ($line) => self::serializeLines($line, $delimiter))
+					->values();
+				$storage->contents(self::serializeLines($lines))->write();
 			}
 		})
 
@@ -114,17 +130,22 @@ class IP {
 	{
 		$file = self::$_accessLog;
 
-		if (!file_exists($file)) {
+		if (!FileSystem::fileExists($file)) {
 			return [];
 		}
 
 		$delimiter = "\t";
-		$data = [];
-		$lines = file($file);
-		if (Arr::is($lines)) {
-			$data = array_map(fn ($line) => explode($delimiter, $line), $lines);
+		$contents = FileSystem::fileContents($file);
+		if (Val::isEmpty($contents)) {
+			return [];
 		}
-		return $data;
+
+		return Str::make($contents)
+			->split("\n")
+			->filter(fn ($line) => Str::isNotEmpty(Str::trim($line)))
+			->map(fn ($line) => Str::make($line)->split($delimiter)->val())
+			->values()
+			->val();
 	}
 
 
@@ -157,17 +178,16 @@ class IP {
 		// Write the data to the file upon successful conncection
 		->when( Event::READ , function() use ( &$result, $storage, $ip ) {
 			$ipList = (string)$storage->contents();
-			$ips = array_filter(array_map('trim', explode("\n", $ipList)));
+			$ips = self::ipLines($ipList);
 
-			if (Arr::has($ips, $ip)) {
+			if ($ips->has($ip)) {
 				self::setStatus("IP address $ip already blocked");
 				$result = true;
 				return;
 			}
 
 			$ips[] = $ip;
-			$ipList = implode("\n", $ips);
-			$storage->contents($ipList)->write();
+			$storage->contents(self::serializeLines($ips))->write();
 		})
 
 		// If the save is successful, set the status
@@ -206,9 +226,8 @@ class IP {
 
 		// Write the data to the file upon successful conncection
 		->when( Event::READ , function() use ( &$result, $storage, $ip ) {
-			$ipList = $storage->contents();
-			$ips = explode("\n", $ipList);
-			$index = Arr::search($ip, $ips);
+			$ips = self::ipLines($storage->contents());
+			$index = $ips->search($ip);
 
 			if ($index === false) {
 				self::setStatus("IP address $ip already allowed");
@@ -217,8 +236,7 @@ class IP {
 			}
 
 			unset($ips[$index]);
-			$ipList = implode("\n", $ips);
-			$storage->contents($ipList)->write();
+			$storage->contents(self::serializeLines($ips->values()))->write();
 		})
 
 		// If the save is successful, set the status
@@ -256,9 +274,8 @@ class IP {
 		
 		$ip = ($ip == '') ? self::remote() : $ip;
 		
-		$ipList = file_get_contents(self::$_ipFile);
-		$ips = explode("\n", $ipList);
-		$isBlocked = Arr::has($ips, $ip);
+		$ipList = FileSystem::fileContents(self::$_ipFile);
+		$isBlocked = self::ipLines($ipList)->has($ip);
 		if ($isBlocked) {
 			$status = "Your IP address has been restricted from viewing this content. Please contact the administrator.";
 			if ($exit) exit($status);
@@ -368,12 +385,11 @@ class IP {
 	public static function isDenied($ip)
 	{
 		$isBlocked = false;
-		
+
 		$ip = $ip ?? self::remote();
-		
-		$ips = file(self::$_ipFile);
-		$isBlocked = in_array($ip, $ips);
-		
+
+		$isBlocked = self::ipLines(FileSystem::fileContents(self::$_ipFile))->has($ip);
+
 		return $isBlocked;
 	}
 }

--- a/src/Net/Request.php
+++ b/src/Net/Request.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Net;
 
+use BlueFission\Arr;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
@@ -23,9 +24,14 @@ class Request implements RequestInterface
     ) {
         $this->_method = $method;
         $this->_uri = $uri;
-        $this->_headers = $headers;
+        $this->_headers = Arr::make($headers);
         $this->_body = $body;
         $this->_protocolVersion = $protocolVersion;
+    }
+
+    public function __clone()
+    {
+        $this->_headers = Arr::make($this->_headers->val());
     }
 
     public function getRequestTarget(): string
@@ -81,12 +87,12 @@ class Request implements RequestInterface
 
     public function getHeaders(): array
     {
-        return $this->_headers;
+        return $this->_headers->val();
     }
 
     public function hasHeader($name): bool
     {
-        return isset($this->_headers[$name]);
+        return $this->_headers->hasKey($name);
     }
 
     public function getHeader($name): array
@@ -96,13 +102,13 @@ class Request implements RequestInterface
 
     public function getHeaderLine($name): string
     {
-        return implode(', ', $this->getHeader($name));
+        return Arr::make($this->getHeader($name))->join(', ')->val();
     }
 
     public function withHeader($name, $value): self
     {
         $new = clone $this;
-        $new->_headers[$name] = (array)$value;
+        $new->_headers[$name] = Arr::toArray($value);
         return $new;
     }
 
@@ -110,9 +116,11 @@ class Request implements RequestInterface
     {
         $new = clone $this;
         if ($new->hasHeader($name)) {
-            $new->_headers[$name] = array_merge($new->_headers[$name], (array)$value);
+            $new->_headers[$name] = Arr::make($new->_headers[$name])
+                ->mergeRecursive(Arr::toArray($value))
+                ->val();
         } else {
-            $new->_headers[$name] = (array)$value;
+            $new->_headers[$name] = Arr::toArray($value);
         }
         return $new;
     }

--- a/src/Net/Response.php
+++ b/src/Net/Response.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Net;
 
+use BlueFission\Arr;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -16,10 +17,15 @@ class Response implements ResponseInterface
     public function __construct($statusCode = 200, $headers = [], $body = null, $protocolVersion = '1.1', $reasonPhrase = '')
     {
         $this->_statusCode = $statusCode;
-        $this->_headers = $headers;
+        $this->_headers = Arr::make($headers);
         $this->_body = $body;
         $this->_protocolVersion = $protocolVersion;
         $this->_reasonPhrase = $reasonPhrase;
+    }
+
+    public function __clone()
+    {
+        $this->_headers = Arr::make($this->_headers->val());
     }
 
     public function getStatusCode(): int
@@ -54,12 +60,12 @@ class Response implements ResponseInterface
 
     public function getHeaders(): array
     {
-        return $this->_headers;
+        return $this->_headers->val();
     }
 
     public function hasHeader($name): bool
     {
-        return isset($this->_headers[$name]);
+        return $this->_headers->hasKey($name);
     }
 
     public function getHeader($name): array
@@ -72,13 +78,13 @@ class Response implements ResponseInterface
 
     public function getHeaderLine($name): string
     {
-        return implode(', ', $this->getHeader($name));
+        return Arr::make($this->getHeader($name))->join(', ')->val();
     }
 
     public function withHeader($name, $value): self
     {
         $new = clone $this;
-        $new->_headers[$name] = (array)$value;
+        $new->_headers[$name] = Arr::toArray($value);
         return $new;
     }
 
@@ -86,9 +92,11 @@ class Response implements ResponseInterface
     {
         $new = clone $this;
         if ($new->hasHeader($name)) {
-            $new->_headers[$name] = array_merge($new->_headers[$name], (array)$value);
+            $new->_headers[$name] = Arr::make($new->_headers[$name])
+                ->mergeRecursive(Arr::toArray($value))
+                ->val();
         } else {
-            $new->_headers[$name] = (array)$value;
+            $new->_headers[$name] = Arr::toArray($value);
         }
         return $new;
     }

--- a/tests/Net/HTTPClientTest.php
+++ b/tests/Net/HTTPClientTest.php
@@ -10,6 +10,11 @@ class HTTPClientTest extends TestCase
     public function testHeaderLinesNormalizeThroughStrAndParseThroughArr()
     {
         $client = new class($this->createMock(Curl::class)) extends HTTPClient {
+            public function payload(string $body): mixed
+            {
+                return $this->requestBodyPayload($body);
+            }
+
             public function normalized($headers): array
             {
                 return $this->normalizeHeaderLines($headers);
@@ -33,5 +38,18 @@ class HTTPClientTest extends TestCase
             'Content-Type' => 'application/json',
             'X-Trace' => 'abc:def',
         ], $client->parsed($lines));
+    }
+
+    public function testRequestBodyPayloadUsesHttpJsonDecodeHelper()
+    {
+        $client = new class($this->createMock(Curl::class)) extends HTTPClient {
+            public function payload(string $body): mixed
+            {
+                return $this->requestBodyPayload($body);
+            }
+        };
+
+        $this->assertSame(['ok' => true], $client->payload('{"ok":true}'));
+        $this->assertSame('not-json', $client->payload('not-json'));
     }
 }

--- a/tests/Net/HTTPClientTest.php
+++ b/tests/Net/HTTPClientTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace BlueFission\Tests\Net;
+
+use BlueFission\Connections\Curl;
+use BlueFission\Net\HTTPClient;
+use PHPUnit\Framework\TestCase;
+
+class HTTPClientTest extends TestCase
+{
+    public function testHeaderLinesNormalizeThroughStrAndParseThroughArr()
+    {
+        $client = new class($this->createMock(Curl::class)) extends HTTPClient {
+            public function normalized($headers): array
+            {
+                return $this->normalizeHeaderLines($headers);
+            }
+
+            public function parsed(array $lines): array
+            {
+                return $this->parseHeaderLines($lines);
+            }
+        };
+
+        $lines = $client->normalized("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nX-Trace: abc:def\r\n\r\n");
+
+        $this->assertSame([
+            'HTTP/1.1 200 OK',
+            'Content-Type: application/json',
+            'X-Trace: abc:def',
+        ], $lines);
+
+        $this->assertSame([
+            'Content-Type' => 'application/json',
+            'X-Trace' => 'abc:def',
+        ], $client->parsed($lines));
+    }
+}

--- a/tests/Net/IPTest.php
+++ b/tests/Net/IPTest.php
@@ -92,6 +92,14 @@ class IPTest extends TestCase
 
         IP::allow($ipAddress);
     }
+
+    public function testIsDeniedMatchesTrimmedBlockListEntries()
+    {
+        file_put_contents($this->ipFile, "10.0.0.1\n");
+
+        $this->assertTrue(IP::isDenied('10.0.0.1'));
+        $this->assertFalse(IP::isDenied('10.0.0.2'));
+    }
  
     /**
      * Test log() method returns the status of the log

--- a/tests/Net/RequestResponseTest.php
+++ b/tests/Net/RequestResponseTest.php
@@ -1,0 +1,96 @@
+<?php
+namespace BlueFission\Tests\Net;
+
+use BlueFission\Arr;
+use BlueFission\Net\Request;
+use BlueFission\Net\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UriInterface;
+
+class RequestResponseTest extends TestCase
+{
+    public function testRequestHeadersUseArrStorageAndPsrArrays()
+    {
+        $request = new Request('GET', $this->uri('/start'), [
+            'Accept' => ['text/plain'],
+        ]);
+
+        $this->assertInstanceOf(Arr::class, $this->objectProperty($request, '_headers'));
+        $this->assertSame(['Accept' => ['text/plain']], $request->getHeaders());
+        $this->assertTrue($request->hasHeader('Accept'));
+        $this->assertSame('text/plain', $request->getHeaderLine('Accept'));
+
+        $withHeader = $request->withAddedHeader('Accept', ['text/html', 'text/plain']);
+
+        $this->assertSame(['text/plain'], $request->getHeader('Accept'));
+        $this->assertSame(['text/plain', 'text/html', 'text/plain'], $withHeader->getHeader('Accept'));
+        $this->assertSame('text/plain, text/html, text/plain', $withHeader->getHeaderLine('Accept'));
+    }
+
+    public function testRequestWithUriSetsHostOnArrHeaders()
+    {
+        $request = new Request('GET', $this->uri('/start'));
+        $updated = $request->withUri($this->uri('/next', 'example.org'));
+
+        $this->assertSame(['example.org'], $updated->getHeader('Host'));
+        $this->assertSame([], $request->getHeader('Host'));
+    }
+
+    public function testResponseHeadersUseArrStorageAndPsrArrays()
+    {
+        $response = new Response(200, [
+            'Cache-Control' => ['no-cache'],
+        ]);
+
+        $this->assertInstanceOf(Arr::class, $this->objectProperty($response, '_headers'));
+        $this->assertSame(['Cache-Control' => ['no-cache']], $response->getHeaders());
+        $this->assertTrue($response->hasHeader('Cache-Control'));
+        $this->assertSame('no-cache', $response->getHeaderLine('Cache-Control'));
+
+        $withHeader = $response->withAddedHeader('Cache-Control', ['private', 'no-cache']);
+
+        $this->assertSame(['no-cache'], $response->getHeader('Cache-Control'));
+        $this->assertSame(['no-cache', 'private', 'no-cache'], $withHeader->getHeader('Cache-Control'));
+        $this->assertSame('no-cache, private, no-cache', $withHeader->getHeaderLine('Cache-Control'));
+    }
+
+    private function uri(string $path, string $host = 'example.com'): UriInterface
+    {
+        return new class($path, $host) implements UriInterface {
+            private string $path;
+            private string $host;
+
+            public function __construct(string $path, string $host)
+            {
+                $this->path = $path;
+                $this->host = $host;
+            }
+
+            public function getScheme(): string { return 'https'; }
+            public function getAuthority(): string { return $this->host; }
+            public function getUserInfo(): string { return ''; }
+            public function getHost(): string { return $this->host; }
+            public function getPort(): ?int { return null; }
+            public function getPath(): string { return $this->path; }
+            public function getQuery(): string { return ''; }
+            public function getFragment(): string { return ''; }
+            public function withScheme(string $scheme): UriInterface { return $this; }
+            public function withUserInfo(string $user, ?string $password = null): UriInterface { return $this; }
+            public function withHost(string $host): UriInterface { $new = clone $this; $new->host = $host; return $new; }
+            public function withPort(?int $port): UriInterface { return $this; }
+            public function withPath(string $path): UriInterface { $new = clone $this; $new->path = $path; return $new; }
+            public function withQuery(string $query): UriInterface { return $this; }
+            public function withFragment(string $fragment): UriInterface { return $this; }
+            public function __toString(): string { return 'https://' . $this->host . $this->path; }
+        };
+    }
+
+    private function objectProperty(object $object, string $property)
+    {
+        $reflection = new \ReflectionClass($object);
+        $property = $reflection->getProperty($property);
+        $property->setAccessible(true);
+
+        return $property->getValue($object);
+    }
+}


### PR DESCRIPTION
## Intent
Continue issue #154 by aligning Net request/response/header and IP list handling with DevElation primitives while preserving public PSR return contracts.

## User stories / acceptance criteria
- As a consumer, PSR request and response headers still return plain arrays and immutable clones.
- As a maintainer, internal header storage uses Arr so header logic remains helper-driven.
- As a maintainer, HTTP client header parsing uses explicit Str/Arr helpers instead of static last-value side effects.
- As a consumer, IP block-list checks normalize stored line values before membership checks.

## Key files changed
- src/Net/Request.php
- src/Net/Response.php
- src/Net/HTTPClient.php
- src/Net/IP.php
- tests/Net/RequestResponseTest.php
- tests/Net/HTTPClientTest.php
- tests/Net/IPTest.php

## How to test
- php -l src/Net/Request.php
- php -l src/Net/Response.php
- php -l src/Net/HTTPClient.php
- php -l src/Net/IP.php
- vendor/bin/phpunit --do-not-cache-result tests/Net
- composer validate --strict
- git diff --check
- vendor/bin/phpunit.bat --do-not-cache-result --colors=never

## QA checklist
- Focused Net suite passes.
- Full PHPUnit suite passes.
- Composer validation passes.
- Whitespace check passes.

## Approval conditions
Approve when the Net helper conversions are scoped, PSR header immutability is preserved, and CI remains green.

Closes part of #154