### PR TITLE
Align CLI display helpers

### DIFF
--- a/src/Cli/Util/Canvas.php
+++ b/src/Cli/Util/Canvas.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Cli\Util;
 
 use BlueFission\Arr;
+use BlueFission\Num;
 use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\Val;
@@ -36,8 +37,8 @@ class Canvas extends Obj
         $fill = Dev::apply('_in', $fill);
 
         $this->assign([
-            'width' => max(0, $width),
-            'height' => max(0, $height),
+            'width' => (int)Num::max(0, $width),
+            'height' => (int)Num::max(0, $height),
             'fill' => $this->normalizeChar($fill),
         ]);
 
@@ -126,7 +127,7 @@ class Canvas extends Obj
 
         $prior = $previous->toLines();
         $diffs = [];
-        $max = max(Arr::count($current), Arr::count($prior));
+        $max = (int)Num::max(Arr::count($current), Arr::count($prior));
 
         for ($index = 0; $index < $max; $index++) {
             $line = $current[$index] ?? '';
@@ -174,8 +175,8 @@ class Canvas extends Obj
 
     protected function resetBuffer(): void
     {
-        $width = max(0, (int)$this->field('width'));
-        $height = max(0, (int)$this->field('height'));
+        $width = (int)Num::max(0, (int)$this->field('width'));
+        $height = (int)Num::max(0, (int)$this->field('height'));
         $fill = $this->normalizeChar((string)$this->field('fill'));
 
         $this->buffer = [];

--- a/src/Cli/Util/Canvas.php
+++ b/src/Cli/Util/Canvas.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Cli\Util;
 
+use BlueFission\Arr;
 use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\Val;
@@ -96,10 +97,11 @@ class Canvas extends Obj
 
     public function toLines(): array
     {
-        $lines = [];
-        foreach ($this->buffer as $row) {
-            $lines[] = implode('', $row);
-        }
+        $lines = Arr::make($this->buffer)
+            ->map(function ($row) {
+                return Arr::make($row)->join('')->val();
+            })
+            ->val();
 
         return Dev::apply('_out', $lines);
     }
@@ -107,7 +109,7 @@ class Canvas extends Obj
     public function render(): string
     {
         Dev::do('_before', [$this]);
-        $output = implode(PHP_EOL, $this->toLines());
+        $output = Arr::make($this->toLines())->join(PHP_EOL)->val();
         $output = Dev::apply('_out', $output);
         $this->trigger(Event::PROCESSED, new Meta(data: $output));
         Dev::do('_after', [$output, $this]);
@@ -124,7 +126,7 @@ class Canvas extends Obj
 
         $prior = $previous->toLines();
         $diffs = [];
-        $max = max(count($current), count($prior));
+        $max = max(Arr::count($current), Arr::count($prior));
 
         for ($index = 0; $index < $max; $index++) {
             $line = $current[$index] ?? '';
@@ -141,7 +143,7 @@ class Canvas extends Obj
     {
         Dev::do('_before', [$this, $previous]);
         $diffs = $this->diffLines($previous);
-        if (empty($diffs)) {
+        if (Arr::count($diffs) === 0) {
             return '';
         }
 

--- a/src/Cli/Util/Cursor.php
+++ b/src/Cli/Util/Cursor.php
@@ -1,6 +1,7 @@
 <?php
 namespace BlueFission\Cli\Util;
 
+use BlueFission\Cli\Util\Support\ManagesUtilityState;
 use BlueFission\Obj;
 use BlueFission\DataTypes;
 use BlueFission\Behavioral\Behaviors\Action;
@@ -10,6 +11,8 @@ use BlueFission\DevElation as Dev;
 
 class Cursor extends Obj
 {
+    use ManagesUtilityState;
+
     protected $_data = [
         'x' => 1,
         'y' => 1,
@@ -35,18 +38,16 @@ class Cursor extends Obj
         $this->setValue('visible', $visible);
 
         $this->behavior(new Action(Action::UPDATE), function ($behavior, $args) {
-            $meta = ($args instanceof Meta) ? $args : null;
-            if ($meta && is_array($meta->data ?? null)) {
-                $data = $meta->data;
-                if (array_key_exists('x', $data)) {
-                    $this->setValue('x', max(1, (int)$data['x']));
-                }
-                if (array_key_exists('y', $data)) {
-                    $this->setValue('y', max(1, (int)$data['y']));
-                }
-                if (array_key_exists('visible', $data)) {
-                    $this->setValue('visible', (bool)$data['visible']);
-                }
+            $meta = $this->behaviorMeta($args);
+            $data = $this->behaviorData($args);
+            if ($data->hasKey('x')) {
+                $this->setValue('x', max(1, (int)$data['x']));
+            }
+            if ($data->hasKey('y')) {
+                $this->setValue('y', max(1, (int)$data['y']));
+            }
+            if ($data->hasKey('visible')) {
+                $this->setValue('visible', (bool)$data['visible']);
             }
             $this->trigger(Event::CHANGE, $meta);
         });
@@ -113,24 +114,5 @@ class Cursor extends Obj
     public function visible(): bool
     {
         return (bool)$this->getValue('visible');
-    }
-
-    protected function setValue(string $field, $value): void
-    {
-        $current = $this->_data[$field] ?? null;
-        if ($current instanceof \BlueFission\IVal) {
-            $current->val($value);
-            return;
-        }
-        $this->_data[$field] = $value;
-    }
-
-    protected function getValue(string $field)
-    {
-        $current = $this->_data[$field] ?? null;
-        if ($current instanceof \BlueFission\IVal) {
-            return $current->val();
-        }
-        return $current;
     }
 }

--- a/src/Cli/Util/ProgressBar.php
+++ b/src/Cli/Util/ProgressBar.php
@@ -3,6 +3,7 @@ namespace BlueFission\Cli\Util;
 
 use BlueFission\Arr;
 use BlueFission\Cli\Util\Support\ManagesUtilityState;
+use BlueFission\Num;
 use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\Val;
@@ -45,9 +46,9 @@ class ProgressBar extends Obj
         $fillChar = Dev::apply('_in', $fillChar);
         $emptyChar = Dev::apply('_in', $emptyChar);
 
-        $this->setValue('total', max(0, $total));
+        $this->setValue('total', (int)Num::max(0, $total));
         $this->setValue('current', 0);
-        $this->setValue('width', max(1, $width));
+        $this->setValue('width', (int)Num::max(1, $width));
         $this->setValue('fillChar', $fillChar);
         $this->setValue('emptyChar', $emptyChar);
 
@@ -55,13 +56,13 @@ class ProgressBar extends Obj
             $meta = $this->behaviorMeta($args);
             $data = $this->behaviorData($args);
             if ($data->hasKey('total')) {
-                $this->setValue('total', max(0, (int)$data['total']));
+                $this->setValue('total', (int)Num::max(0, (int)$data['total']));
             }
             if ($data->hasKey('current')) {
-                $this->setValue('current', max(0, (int)$data['current']));
+                $this->setValue('current', (int)Num::max(0, (int)$data['current']));
             }
             if ($data->hasKey('width')) {
-                $this->setValue('width', max(1, (int)$data['width']));
+                $this->setValue('width', (int)Num::max(1, (int)$data['width']));
             }
             if ($data->hasKey('showPercent')) {
                 $this->setValue('showPercent', (bool)$data['showPercent']);
@@ -121,11 +122,11 @@ class ProgressBar extends Obj
 
         $progress = 0.0;
         if ($total > 0) {
-            $progress = min(1, $currentValue / $total);
+            $progress = Num::min(1, Num::make($currentValue)->by($total)->val());
         }
 
-        $filled = (int)floor($progress * $width);
-        $empty = $width - $filled;
+        $filled = Num::make($progress)->times($width)->int();
+        $empty = Num::make($width)->minus($filled)->int();
 
         $bar = Str::make('[')
             ->append(Str::make((string)$this->getValue('fillChar'))->repeat($filled))
@@ -136,12 +137,13 @@ class ProgressBar extends Obj
         $parts = Arr::make([$bar]);
 
         if ($this->getValue('showPercent')) {
-            $parts->push(str_pad((string)round($progress * 100), 3, ' ', STR_PAD_LEFT) . '%');
+            $percent = Num::make($progress)->times(100)->round()->val();
+            $parts->push(str_pad((string)$percent, 3, ' ', STR_PAD_LEFT) . '%');
         }
 
         if ($this->getValue('showCount')) {
             $parts->push(Str::make('(')
-                ->append(min($currentValue, $total))
+                ->append(Num::min($currentValue, $total))
                 ->append('/')
                 ->append($total)
                 ->append(')')

--- a/src/Cli/Util/ProgressBar.php
+++ b/src/Cli/Util/ProgressBar.php
@@ -2,6 +2,7 @@
 namespace BlueFission\Cli\Util;
 
 use BlueFission\Arr;
+use BlueFission\Cli\Util\Support\ManagesUtilityState;
 use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\Val;
@@ -13,6 +14,8 @@ use BlueFission\DevElation as Dev;
 
 class ProgressBar extends Obj
 {
+    use ManagesUtilityState;
+
     protected $_data = [
         'total' => 0,
         'current' => 0,
@@ -49,24 +52,22 @@ class ProgressBar extends Obj
         $this->setValue('emptyChar', $emptyChar);
 
         $this->behavior(new Action(Action::UPDATE), function ($behavior, $args) {
-            $meta = ($args instanceof Meta) ? $args : null;
-            if ($meta && Arr::is($meta->data ?? null)) {
-                $data = Arr::make($meta->data);
-                if ($data->hasKey('total')) {
-                    $this->setValue('total', max(0, (int)$data['total']));
-                }
-                if ($data->hasKey('current')) {
-                    $this->setValue('current', max(0, (int)$data['current']));
-                }
-                if ($data->hasKey('width')) {
-                    $this->setValue('width', max(1, (int)$data['width']));
-                }
-                if ($data->hasKey('showPercent')) {
-                    $this->setValue('showPercent', (bool)$data['showPercent']);
-                }
-                if ($data->hasKey('showCount')) {
-                    $this->setValue('showCount', (bool)$data['showCount']);
-                }
+            $meta = $this->behaviorMeta($args);
+            $data = $this->behaviorData($args);
+            if ($data->hasKey('total')) {
+                $this->setValue('total', max(0, (int)$data['total']));
+            }
+            if ($data->hasKey('current')) {
+                $this->setValue('current', max(0, (int)$data['current']));
+            }
+            if ($data->hasKey('width')) {
+                $this->setValue('width', max(1, (int)$data['width']));
+            }
+            if ($data->hasKey('showPercent')) {
+                $this->setValue('showPercent', (bool)$data['showPercent']);
+            }
+            if ($data->hasKey('showCount')) {
+                $this->setValue('showCount', (bool)$data['showCount']);
             }
             $this->trigger(Event::CHANGE, $meta);
         });
@@ -153,24 +154,5 @@ class ProgressBar extends Obj
         $this->trigger(Event::PROCESSED, new Meta(data: $output));
         Dev::do('_after', [$output, $this]);
         return $output;
-    }
-
-    protected function setValue(string $field, $value): void
-    {
-        $current = $this->_data[$field] ?? null;
-        if ($current instanceof \BlueFission\IVal) {
-            $current->val($value);
-            return;
-        }
-        $this->_data[$field] = $value;
-    }
-
-    protected function getValue(string $field)
-    {
-        $current = $this->_data[$field] ?? null;
-        if ($current instanceof \BlueFission\IVal) {
-            return $current->val();
-        }
-        return $current;
     }
 }

--- a/src/Cli/Util/ProgressBar.php
+++ b/src/Cli/Util/ProgressBar.php
@@ -1,7 +1,9 @@
 <?php
 namespace BlueFission\Cli\Util;
 
+use BlueFission\Arr;
 use BlueFission\Obj;
+use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\DataTypes;
 use BlueFission\Behavioral\Behaviors\Action;
@@ -48,21 +50,21 @@ class ProgressBar extends Obj
 
         $this->behavior(new Action(Action::UPDATE), function ($behavior, $args) {
             $meta = ($args instanceof Meta) ? $args : null;
-            if ($meta && is_array($meta->data ?? null)) {
-                $data = $meta->data;
-                if (array_key_exists('total', $data)) {
+            if ($meta && Arr::is($meta->data ?? null)) {
+                $data = Arr::make($meta->data);
+                if ($data->hasKey('total')) {
                     $this->setValue('total', max(0, (int)$data['total']));
                 }
-                if (array_key_exists('current', $data)) {
+                if ($data->hasKey('current')) {
                     $this->setValue('current', max(0, (int)$data['current']));
                 }
-                if (array_key_exists('width', $data)) {
+                if ($data->hasKey('width')) {
                     $this->setValue('width', max(1, (int)$data['width']));
                 }
-                if (array_key_exists('showPercent', $data)) {
+                if ($data->hasKey('showPercent')) {
                     $this->setValue('showPercent', (bool)$data['showPercent']);
                 }
-                if (array_key_exists('showCount', $data)) {
+                if ($data->hasKey('showCount')) {
                     $this->setValue('showCount', (bool)$data['showCount']);
                 }
             }
@@ -124,19 +126,29 @@ class ProgressBar extends Obj
         $filled = (int)floor($progress * $width);
         $empty = $width - $filled;
 
-        $bar = '[' . str_repeat((string)$this->getValue('fillChar'), $filled) . str_repeat((string)$this->getValue('emptyChar'), $empty) . ']';
+        $bar = Str::make('[')
+            ->append(Str::make((string)$this->getValue('fillChar'))->repeat($filled))
+            ->append(Str::make((string)$this->getValue('emptyChar'))->repeat($empty))
+            ->append(']')
+            ->val();
 
-        $parts = [$bar];
+        $parts = Arr::make([$bar]);
 
         if ($this->getValue('showPercent')) {
-            $parts[] = str_pad((string)round($progress * 100), 3, ' ', STR_PAD_LEFT) . '%';
+            $parts->push(str_pad((string)round($progress * 100), 3, ' ', STR_PAD_LEFT) . '%');
         }
 
         if ($this->getValue('showCount')) {
-            $parts[] = '(' . min($currentValue, $total) . '/' . $total . ')';
+            $parts->push(Str::make('(')
+                ->append(min($currentValue, $total))
+                ->append('/')
+                ->append($total)
+                ->append(')')
+                ->val()
+            );
         }
 
-        $output = implode(' ', $parts);
+        $output = $parts->join(' ')->val();
         $output = Dev::apply('_out', $output);
         $this->trigger(Event::PROCESSED, new Meta(data: $output));
         Dev::do('_after', [$output, $this]);

--- a/src/Cli/Util/Spinner.php
+++ b/src/Cli/Util/Spinner.php
@@ -3,6 +3,7 @@ namespace BlueFission\Cli\Util;
 
 use BlueFission\Obj;
 use BlueFission\Arr;
+use BlueFission\Cli\Util\Support\ManagesUtilityState;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\DataTypes;
@@ -13,6 +14,8 @@ use BlueFission\DevElation as Dev;
 
 class Spinner extends Obj
 {
+    use ManagesUtilityState;
+
     protected $_data = [
         'label' => '',
         'frames' => ['|', '/', '-', '\\'],
@@ -58,19 +61,17 @@ class Spinner extends Obj
         });
 
         $this->behavior(new Action(Action::UPDATE), function ($behavior, $args) {
-            $meta = ($args instanceof Meta) ? $args : null;
-            if ($meta && Arr::is($meta->data ?? null)) {
-                $data = Arr::make($meta->data);
-                if ($data->hasKey('label')) {
-                    $this->setValue('label', (string)$data['label']);
-                }
-                if ($data->hasKey('frames') && Arr::is($data['frames'])) {
-                    $this->setValue('frames', $data['frames']);
-                    $this->setValue('index', 0);
-                }
-                if ($data->hasKey('intervalMs')) {
-                    $this->setValue('intervalMs', max(10, (int)$data['intervalMs']));
-                }
+            $meta = $this->behaviorMeta($args);
+            $data = $this->behaviorData($args);
+            if ($data->hasKey('label')) {
+                $this->setValue('label', (string)$data['label']);
+            }
+            if ($data->hasKey('frames') && Arr::is($data['frames'])) {
+                $this->setValue('frames', $data['frames']);
+                $this->setValue('index', 0);
+            }
+            if ($data->hasKey('intervalMs')) {
+                $this->setValue('intervalMs', max(10, (int)$data['intervalMs']));
             }
             $this->trigger(Event::CHANGE, $meta);
         });
@@ -167,25 +168,6 @@ class Spinner extends Obj
         $this->setValue('index', $index);
         $this->trigger(Event::CHANGE);
         return $this;
-    }
-
-    protected function setValue(string $field, $value): void
-    {
-        $current = $this->_data[$field] ?? null;
-        if ($current instanceof \BlueFission\IVal) {
-            $current->val($value);
-            return;
-        }
-        $this->_data[$field] = $value;
-    }
-
-    protected function getValue(string $field)
-    {
-        $current = $this->_data[$field] ?? null;
-        if ($current instanceof \BlueFission\IVal) {
-            return $current->val();
-        }
-        return $current;
     }
 
     protected function timestampMs(): float

--- a/src/Cli/Util/Spinner.php
+++ b/src/Cli/Util/Spinner.php
@@ -4,6 +4,7 @@ namespace BlueFission\Cli\Util;
 use BlueFission\Obj;
 use BlueFission\Arr;
 use BlueFission\Cli\Util\Support\ManagesUtilityState;
+use BlueFission\Num;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\DataTypes;
@@ -44,7 +45,7 @@ class Spinner extends Obj
 
         $this->setValue('label', (string)$label);
         $this->setValue('frames', Arr::is($frames) ? $frames : $this->_data['frames']);
-        $this->setValue('intervalMs', max(10, (int)$intervalMs));
+        $this->setValue('intervalMs', (int)Num::max(10, (int)$intervalMs));
         $this->setValue('index', 0);
         $this->setValue('running', false);
         $this->setValue('lastTick', 0.0);
@@ -71,7 +72,7 @@ class Spinner extends Obj
                 $this->setValue('index', 0);
             }
             if ($data->hasKey('intervalMs')) {
-                $this->setValue('intervalMs', max(10, (int)$data['intervalMs']));
+                $this->setValue('intervalMs', (int)Num::max(10, (int)$data['intervalMs']));
             }
             $this->trigger(Event::CHANGE, $meta);
         });
@@ -164,7 +165,7 @@ class Spinner extends Obj
         $frames = Arr::make($this->getValue('frames'));
         $count = $frames->count();
         $index = (int)$this->getValue('index');
-        $index = $count > 0 ? ($index + 1) % $count : 0;
+        $index = $count > 0 ? Num::make($index)->plus(1)->int() % $count : 0;
         $this->setValue('index', $index);
         $this->trigger(Event::CHANGE);
         return $this;
@@ -172,6 +173,6 @@ class Spinner extends Obj
 
     protected function timestampMs(): float
     {
-        return microtime(true) * 1000;
+        return Num::make(microtime(true))->times(1000)->val();
     }
 }

--- a/src/Cli/Util/Spinner.php
+++ b/src/Cli/Util/Spinner.php
@@ -3,6 +3,7 @@ namespace BlueFission\Cli\Util;
 
 use BlueFission\Obj;
 use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\DataTypes;
 use BlueFission\Behavioral\Behaviors\Action;
@@ -58,16 +59,16 @@ class Spinner extends Obj
 
         $this->behavior(new Action(Action::UPDATE), function ($behavior, $args) {
             $meta = ($args instanceof Meta) ? $args : null;
-            if ($meta && is_array($meta->data ?? null)) {
-                $data = $meta->data;
-                if (array_key_exists('label', $data)) {
+            if ($meta && Arr::is($meta->data ?? null)) {
+                $data = Arr::make($meta->data);
+                if ($data->hasKey('label')) {
                     $this->setValue('label', (string)$data['label']);
                 }
-                if (array_key_exists('frames', $data) && Arr::is($data['frames'])) {
+                if ($data->hasKey('frames') && Arr::is($data['frames'])) {
                     $this->setValue('frames', $data['frames']);
                     $this->setValue('index', 0);
                 }
-                if (array_key_exists('intervalMs', $data)) {
+                if ($data->hasKey('intervalMs')) {
                     $this->setValue('intervalMs', max(10, (int)$data['intervalMs']));
                 }
             }
@@ -138,7 +139,7 @@ class Spinner extends Obj
         $label = (string)$this->getValue('label');
         $frame = $this->frame();
 
-        $output = trim($label . ' ' . $frame);
+        $output = Str::make($label)->append(' ')->append($frame)->trim()->val();
         $output = Dev::apply('_out', $output);
         $this->trigger(Event::PROCESSED, new Meta(data: $output));
         Dev::do('_after', [$output, $this]);
@@ -147,20 +148,20 @@ class Spinner extends Obj
 
     public function frame(): string
     {
-        $frames = $this->getValue('frames');
-        if (!Arr::is($frames) || count($frames) === 0) {
+        $frames = Arr::make($this->getValue('frames'));
+        if ($frames->isEmpty()) {
             return '';
         }
 
         $index = (int)$this->getValue('index');
-        $frame = $frames[$index % count($frames)] ?? '';
+        $frame = $frames[$index % $frames->count()] ?? '';
         return (string)$frame;
     }
 
     public function advance(): self
     {
-        $frames = $this->getValue('frames');
-        $count = Arr::is($frames) ? count($frames) : 0;
+        $frames = Arr::make($this->getValue('frames'));
+        $count = $frames->count();
         $index = (int)$this->getValue('index');
         $index = $count > 0 ? ($index + 1) % $count : 0;
         $this->setValue('index', $index);

--- a/src/Cli/Util/StatusBar.php
+++ b/src/Cli/Util/StatusBar.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Cli\Util;
 
+use BlueFission\Arr;
 use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\DataTypes;
@@ -27,9 +28,9 @@ class StatusBar extends Obj
     {
         $label = Dev::apply('_in', $label);
         $value = Dev::apply('_in', $value);
-        $items = $this->arrayValue($this->field('items'));
+        $items = Arr::make($this->arrayValue($this->field('items')));
         $items[$label] = $value;
-        $this->field('items', $items);
+        $this->field('items', $items->val());
         $this->trigger(Event::CHANGE, new Meta(data: ['label' => $label]));
 
         return $this;
@@ -37,9 +38,9 @@ class StatusBar extends Obj
 
     public function remove(string $label): self
     {
-        $items = $this->arrayValue($this->field('items'));
+        $items = Arr::make($this->arrayValue($this->field('items')));
         unset($items[$label]);
-        $this->field('items', $items);
+        $this->field('items', $items->val());
         $this->trigger(Event::CHANGE, new Meta(data: ['label' => $label]));
 
         return $this;
@@ -55,14 +56,14 @@ class StatusBar extends Obj
     public function render(?int $width = null): string
     {
         Dev::do('_before', [$this, $width]);
-        $items = $this->arrayValue($this->field('items'));
-        $parts = [];
-        foreach ($items as $label => $value) {
-            $parts[] = $label . ': ' . $value;
-        }
+        $items = Arr::make($this->arrayValue($this->field('items')));
+        $parts = Arr::make();
+        $items->each(function ($value, $label) use ($parts) {
+            $parts->push(Str::make((string)$label)->append(': ')->append($value)->val());
+        });
 
         $separator = (string)$this->field('separator');
-        $line = implode($separator, $parts);
+        $line = $parts->join($separator)->val();
 
         $targetWidth = $width ?? (int)$this->field('width');
         if ($targetWidth > 0) {
@@ -77,7 +78,7 @@ class StatusBar extends Obj
 
     protected function arrayValue($value): array
     {
-        if (is_array($value)) {
+        if (Arr::is($value)) {
             return $value;
         }
 
@@ -90,19 +91,20 @@ class StatusBar extends Obj
 
     protected function fitWidth(string $line, int $width): string
     {
-        $length = Str::len($line);
+        $line = Str::make($line);
+        $length = $line->size();
         if ($length === $width) {
-            return $line;
+            return $line->val();
         }
 
         if ($length < $width) {
-            return $line . str_repeat(' ', $width - $length);
+            return $line->append(Str::make(' ')->repeat($width - $length))->val();
         }
 
         if ($width <= 3) {
-            return Str::sub($line, 0, $width);
+            return $line->sub(0, $width);
         }
 
-        return Str::sub($line, 0, $width - 3) . '...';
+        return Str::make($line->sub(0, $width - 3))->append('...')->val();
     }
 }

--- a/src/Cli/Util/Support/ManagesUtilityState.php
+++ b/src/Cli/Util/Support/ManagesUtilityState.php
@@ -1,0 +1,44 @@
+<?php
+namespace BlueFission\Cli\Util\Support;
+
+use BlueFission\Arr;
+use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\IVal;
+
+trait ManagesUtilityState
+{
+    protected function setValue(string $field, mixed $value): void
+    {
+        $current = $this->_data[$field] ?? null;
+        if ($current instanceof IVal) {
+            $current->val($value);
+            return;
+        }
+
+        $this->_data[$field] = $value;
+    }
+
+    protected function getValue(string $field, mixed $default = null): mixed
+    {
+        $current = $this->_data[$field] ?? $default;
+        if ($current instanceof IVal) {
+            return $current->val();
+        }
+
+        return $current;
+    }
+
+    protected function behaviorMeta(mixed $args): ?Meta
+    {
+        return $args instanceof Meta ? $args : null;
+    }
+
+    protected function behaviorData(mixed $args): Arr
+    {
+        $meta = $this->behaviorMeta($args);
+
+        return ($meta && Arr::is($meta->data ?? null))
+            ? Arr::make($meta->data)
+            : Arr::make();
+    }
+}

--- a/src/Cli/Util/Table.php
+++ b/src/Cli/Util/Table.php
@@ -2,6 +2,7 @@
 namespace BlueFission\Cli\Util;
 
 use BlueFission\Arr;
+use BlueFission\Num;
 use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\Behavioral\Behaviors\Event;
@@ -30,7 +31,7 @@ class Table extends Obj
         $rowCount = Arr::count($rows);
         $colCount = Arr::count($headers);
         for ($i = 0; $i < $rowCount; $i++) {
-            $colCount = max($colCount, Arr::count($rows[$i]));
+            $colCount = (int)Num::max($colCount, Arr::count($rows[$i]));
         }
 
         $headers = self::normalizeRow($headers, $colCount);
@@ -41,11 +42,11 @@ class Table extends Obj
 
         $widths = array_fill(0, $colCount, 0);
         for ($i = 0; $i < $colCount; $i++) {
-            $widths[$i] = max($widths[$i], Str::len(Ansi::strip((string)$headers[$i])));
+            $widths[$i] = (int)Num::max($widths[$i], Str::len(Ansi::strip((string)$headers[$i])));
         }
         foreach ($normalizedRows as $row) {
             for ($i = 0; $i < $colCount; $i++) {
-                $widths[$i] = max($widths[$i], Str::len(Ansi::strip((string)$row[$i])));
+                $widths[$i] = (int)Num::max($widths[$i], Str::len(Ansi::strip((string)$row[$i])));
             }
         }
 
@@ -80,7 +81,10 @@ class Table extends Obj
     {
         $parts = Arr::make();
         foreach ($widths as $width) {
-            $parts->push(Str::make('-')->repeat($width + ($padding * 2))->val());
+            $parts->push(Str::make('-')
+                ->repeat(Num::make($padding)->times(2)->plus($width)->int())
+                ->val()
+            );
         }
         return Str::make('+')->append($parts->join('+'))->append('+')->val();
     }
@@ -92,14 +96,14 @@ class Table extends Obj
             $text = (string)$cell;
             $visible = Str::len(Ansi::strip($text));
             $width = $widths[$index];
-            $space = max(0, $width - $visible);
+            $space = (int)Num::max(0, Num::make($width)->minus($visible)->val());
             $alignment = $align->hasKey($index) ? $align[$index] : 'left';
 
             if ($alignment === 'right') {
                 $text = Str::make(' ')->repeat($space)->append($text)->val();
             } elseif ($alignment === 'center') {
-                $left = (int)floor($space / 2);
-                $right = $space - $left;
+                $left = Num::make($space)->by(2)->int();
+                $right = Num::make($space)->minus($left)->int();
                 $text = Str::make(' ')
                     ->repeat($left)
                     ->append($text)

--- a/src/Cli/Util/Table.php
+++ b/src/Cli/Util/Table.php
@@ -1,6 +1,7 @@
 <?php
 namespace BlueFission\Cli\Util;
 
+use BlueFission\Arr;
 use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\Behavioral\Behaviors\Event;
@@ -22,19 +23,20 @@ class Table extends Obj
         $options = Dev::apply('_in', $options);
         Dev::do('_before', [$headers, $rows, $options, $this]);
 
-        $padding = isset($options['padding']) ? (int)$options['padding'] : 1;
-        $align = $options['align'] ?? [];
+        $options = Arr::make($options);
+        $padding = $options->hasKey('padding') ? (int)$options['padding'] : 1;
+        $align = Arr::make($options->hasKey('align') ? (array)$options['align'] : []);
 
-        $rowCount = count($rows);
-        $colCount = count($headers);
+        $rowCount = Arr::count($rows);
+        $colCount = Arr::count($headers);
         for ($i = 0; $i < $rowCount; $i++) {
-            $colCount = max($colCount, count($rows[$i]));
+            $colCount = max($colCount, Arr::count($rows[$i]));
         }
 
         $headers = self::normalizeRow($headers, $colCount);
-        $normalizedRows = [];
+        $normalizedRows = Arr::make();
         foreach ($rows as $row) {
-            $normalizedRows[] = self::normalizeRow($row, $colCount);
+            $normalizedRows->push(self::normalizeRow($row, $colCount));
         }
 
         $widths = array_fill(0, $colCount, 0);
@@ -47,18 +49,18 @@ class Table extends Obj
             }
         }
 
-        $lines = [];
-        $lines[] = self::borderLine($widths, $padding);
+        $lines = Arr::make();
+        $lines->push(self::borderLine($widths, $padding));
         if ($headers) {
-            $lines[] = self::rowLine($headers, $widths, $padding, $align);
-            $lines[] = self::borderLine($widths, $padding);
+            $lines->push(self::rowLine($headers, $widths, $padding, $align));
+            $lines->push(self::borderLine($widths, $padding));
         }
         foreach ($normalizedRows as $row) {
-            $lines[] = self::rowLine($row, $widths, $padding, $align);
+            $lines->push(self::rowLine($row, $widths, $padding, $align));
         }
-        $lines[] = self::borderLine($widths, $padding);
+        $lines->push(self::borderLine($widths, $padding));
 
-        $output = implode(PHP_EOL, $lines);
+        $output = $lines->join(PHP_EOL)->val();
         $output = Dev::apply('_out', $output);
         $this->trigger(Event::PROCESSED, new Meta(data: $output));
         Dev::do('_after', [$output, $this]);
@@ -67,45 +69,54 @@ class Table extends Obj
 
     protected static function normalizeRow(array $row, int $colCount): array
     {
-        $values = array_values($row);
-        for ($i = count($values); $i < $colCount; $i++) {
-            $values[] = '';
+        $values = Arr::make($row)->values();
+        for ($i = $values->count(); $i < $colCount; $i++) {
+            $values->push('');
         }
-        return $values;
+        return $values->val();
     }
 
     protected static function borderLine(array $widths, int $padding): string
     {
-        $parts = [];
+        $parts = Arr::make();
         foreach ($widths as $width) {
-            $parts[] = str_repeat('-', $width + ($padding * 2));
+            $parts->push(Str::make('-')->repeat($width + ($padding * 2))->val());
         }
-        return '+' . implode('+', $parts) . '+';
+        return Str::make('+')->append($parts->join('+'))->append('+')->val();
     }
 
-    protected static function rowLine(array $row, array $widths, int $padding, array $align): string
+    protected static function rowLine(array $row, array $widths, int $padding, Arr $align): string
     {
-        $parts = [];
+        $parts = Arr::make();
         foreach ($row as $index => $cell) {
             $text = (string)$cell;
             $visible = Str::len(Ansi::strip($text));
             $width = $widths[$index];
             $space = max(0, $width - $visible);
-            $alignment = $align[$index] ?? 'left';
+            $alignment = $align->hasKey($index) ? $align[$index] : 'left';
 
             if ($alignment === 'right') {
-                $text = str_repeat(' ', $space) . $text;
+                $text = Str::make(' ')->repeat($space)->append($text)->val();
             } elseif ($alignment === 'center') {
                 $left = (int)floor($space / 2);
                 $right = $space - $left;
-                $text = str_repeat(' ', $left) . $text . str_repeat(' ', $right);
+                $text = Str::make(' ')
+                    ->repeat($left)
+                    ->append($text)
+                    ->append(Str::make(' ')->repeat($right))
+                    ->val();
             } else {
-                $text = $text . str_repeat(' ', $space);
+                $text = Str::make($text)->append(Str::make(' ')->repeat($space))->val();
             }
 
-            $parts[] = str_repeat(' ', $padding) . $text . str_repeat(' ', $padding);
+            $parts->push(Str::make(' ')
+                ->repeat($padding)
+                ->append($text)
+                ->append(Str::make(' ')->repeat($padding))
+                ->val()
+            );
         }
 
-        return '|' . implode('|', $parts) . '|';
+        return Str::make('|')->append($parts->join('|'))->append('|')->val();
     }
 }

--- a/src/Cli/Util/Working.php
+++ b/src/Cli/Util/Working.php
@@ -62,22 +62,22 @@ class Working extends Obj
 
         $this->behavior(new Action(Action::UPDATE), function ($behavior, $args) {
             $meta = ($args instanceof Meta) ? $args : null;
-            if ($meta && is_array($meta->data ?? null)) {
-                $data = $meta->data;
-                if (array_key_exists('label', $data)) {
+            if ($meta && Arr::is($meta->data ?? null)) {
+                $data = Arr::make($meta->data);
+                if ($data->hasKey('label')) {
                     $this->setValue('label', (string)$data['label']);
                     $this->_spinner->label((string)$data['label']);
                 }
-                if (array_key_exists('frames', $data) && Arr::is($data['frames'])) {
+                if ($data->hasKey('frames') && Arr::is($data['frames'])) {
                     $this->setValue('frames', $data['frames']);
                     $this->_spinner->frames($data['frames']);
                 }
-                if (array_key_exists('intervalMs', $data)) {
+                if ($data->hasKey('intervalMs')) {
                     $interval = max(10, (int)$data['intervalMs']);
                     $this->setValue('intervalMs', $interval);
                     $this->_spinner->interval($interval);
                 }
-                if (array_key_exists('outputHandler', $data)) {
+                if ($data->hasKey('outputHandler')) {
                     $this->setValue('outputHandler', $data['outputHandler']);
                 }
             }

--- a/src/Cli/Util/Working.php
+++ b/src/Cli/Util/Working.php
@@ -3,6 +3,7 @@ namespace BlueFission\Cli\Util;
 
 use BlueFission\Obj;
 use BlueFission\Arr;
+use BlueFission\Cli\Util\Support\ManagesUtilityState;
 use BlueFission\Val;
 use BlueFission\DataTypes;
 use BlueFission\Async\Promise;
@@ -13,6 +14,8 @@ use BlueFission\DevElation as Dev;
 
 class Working extends Obj
 {
+    use ManagesUtilityState;
+
     protected Spinner $_spinner;
 
     protected $_data = [
@@ -61,25 +64,23 @@ class Working extends Obj
         });
 
         $this->behavior(new Action(Action::UPDATE), function ($behavior, $args) {
-            $meta = ($args instanceof Meta) ? $args : null;
-            if ($meta && Arr::is($meta->data ?? null)) {
-                $data = Arr::make($meta->data);
-                if ($data->hasKey('label')) {
-                    $this->setValue('label', (string)$data['label']);
-                    $this->_spinner->label((string)$data['label']);
-                }
-                if ($data->hasKey('frames') && Arr::is($data['frames'])) {
-                    $this->setValue('frames', $data['frames']);
-                    $this->_spinner->frames($data['frames']);
-                }
-                if ($data->hasKey('intervalMs')) {
-                    $interval = max(10, (int)$data['intervalMs']);
-                    $this->setValue('intervalMs', $interval);
-                    $this->_spinner->interval($interval);
-                }
-                if ($data->hasKey('outputHandler')) {
-                    $this->setValue('outputHandler', $data['outputHandler']);
-                }
+            $meta = $this->behaviorMeta($args);
+            $data = $this->behaviorData($args);
+            if ($data->hasKey('label')) {
+                $this->setValue('label', (string)$data['label']);
+                $this->_spinner->label((string)$data['label']);
+            }
+            if ($data->hasKey('frames') && Arr::is($data['frames'])) {
+                $this->setValue('frames', $data['frames']);
+                $this->_spinner->frames($data['frames']);
+            }
+            if ($data->hasKey('intervalMs')) {
+                $interval = max(10, (int)$data['intervalMs']);
+                $this->setValue('intervalMs', $interval);
+                $this->_spinner->interval($interval);
+            }
+            if ($data->hasKey('outputHandler')) {
+                $this->setValue('outputHandler', $data['outputHandler']);
             }
             $this->trigger(Event::CHANGE, $meta);
         });
@@ -203,24 +204,5 @@ class Working extends Obj
         }
 
         return $work();
-    }
-
-    protected function setValue(string $field, $value): void
-    {
-        $current = $this->_data[$field] ?? null;
-        if ($current instanceof \BlueFission\IVal) {
-            $current->val($value);
-            return;
-        }
-        $this->_data[$field] = $value;
-    }
-
-    protected function getValue(string $field)
-    {
-        $current = $this->_data[$field] ?? null;
-        if ($current instanceof \BlueFission\IVal) {
-            return $current->val();
-        }
-        return $current;
     }
 }


### PR DESCRIPTION
## Intent
Continue issue #154 by carrying CLI display utility state and rendering through DevElation primitives where they fit the method lifecycle.

## User stories / acceptance criteria
- As a CLI consumer, progress bars, spinners, working indicators, tables, status bars, and canvases keep their existing output behavior.
- As a maintainer, behavior metadata reads use Arr-backed key access.
- As a maintainer, render line assembly uses Arr and Str lifecycles instead of raw array/string assembly where practical.

## Key files changed
- src/Cli/Util/Canvas.php
- src/Cli/Util/ProgressBar.php
- src/Cli/Util/Spinner.php
- src/Cli/Util/StatusBar.php
- src/Cli/Util/Table.php
- src/Cli/Util/Working.php

## How to test
- php -l src/Cli/Util/Canvas.php
- php -l src/Cli/Util/ProgressBar.php
- php -l src/Cli/Util/Spinner.php
- php -l src/Cli/Util/StatusBar.php
- php -l src/Cli/Util/Table.php
- php -l src/Cli/Util/Working.php
- vendor/bin/phpunit --do-not-cache-result tests/Cli
- composer validate --strict
- git diff --check
- vendor/bin/phpunit.bat --do-not-cache-result --colors=never --no-progress --no-results

## QA checklist
- Focused CLI suite passes.
- Full PHPUnit suite passes.
- Composer validation passes.
- Whitespace check passes.

## Approval conditions
Approve when CLI display output remains stable and the internal render lifecycles are helper-backed without reducing readability.

Part of #154