### PR TITLE
Add global helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,24 @@ Welcome to the central documentation of **DevElation**, a comprehensive PHP libr
 
 ## Philosophy
 
-DevElation is built with the philosophy of reducing code complexity and promoting interconnectedness. It embraces the notion that robust and intelligent application development can be made more approachable through a suite of well-organized, intuitive modules. With a focus on automation, smart application components, and AI integration readiness, DevElation aims to be the cornerstone for framework builders in these domains.
+DevElation is built with the philosophy of reducing code complexity and promoting interconnectedness. It embraces the notion that robust application development can be made more approachable through a suite of well-organized, intuitive modules. The library is not just a bag of utility functions; it is a set of hookable value objects, data objects, behaviors, services, and helpers that are meant to participate in an application lifecycle.
 
-Central to DevElation's design is the principle of rapid prototyping, enabled by a consistent interface across its wide range of classes. Whether you're interacting with MySQL, Mongo, File, or Session storage, the method signatures and arguments are intentionally aligned. This uniformity means that developers can swap out entire data layers with minimal changes to the codebase, streamlining the process of scaling applications from simple prototypes to complex, robust systems.
+Central to DevElation's design is the principle of rapid prototyping without throwing away architecture. Primitives such as `Val`, `Str`, `Arr`, `Num`, `Flag`, `Date`, `Func`, and `Obj` should be treated as first-class citizens when values are captured, mutated, validated, observed, or passed through more than a trivial boundary. Static helpers remain appropriate for one-off hookable operations, while fluent objects are preferred when a value has a lifecycle.
 
-The library's dependency injection-friendly architecture means that scaling and enhancing functionality is as simple as changing the injected class. For example, an application initially designed with File storage can seamlessly transition to a Mongo database by substituting the File class with a Mongo class, with no need for extensive codebase changes. This not only accelerates development time but also promotes a clean and modular approach to application design.
+The library's dependency injection-friendly architecture means that scaling and enhancing functionality is often a matter of changing the injected class or storage backend. File, session, memory, SQL, Mongo, queue, schema, graph, service, connection, CLI, HTTP, HTML, and parsing classes are intentionally shaped around repeatable signatures so consumers can grow from simple scripts to structured systems without rewriting every call site.
 
-The pervasive event-driven approach throughout DevElation—where even the simplest data types are empowered with event handling capabilities—speaks to the library's commitment to creating intricate yet manageable systems. By offloading complexity to individual components, each element of the codebase contributes to a finely-tuned orchestration of operations. The result is a system where functionality is distributed yet cohesive, ensuring that enhancements can be made without increasing the burden on the core logic of the application.
+The pervasive event-driven approach throughout DevElation, where even simple data types can participate in events, hooks, filters, constraints, snapshots, and dynamic slots, reflects the library's commitment to intricate yet manageable systems. Complexity should live with the object that owns the data or behavior, not in scattered procedural glue.
 
-This granular empowerment leads to a development environment where maintainability and readability are not at odds with the power and sophistication of the systems being developed. With DevElation, creating dynamic, intelligent, and complex functionalities doesn't lead to cluttered code; instead, it fosters an ecosystem where each piece intelligently contributes to the whole.
+This granular empowerment leads to a development style where maintainability and readability are not at odds with power. DevElation code should prefer package-owned classes and interfaces when they already exist, keep features general and reusable, avoid consumer-specific coupling, and expose stable APIs that can be inherited, decorated, filtered, or composed.
 
-Furthermore, DevElation isn't just a standalone library; it forms the backbone of the BlueFission Opus project development framework. Opus leverages DevElation's core capabilities, extending them into a full-fledged framework that supports the construction of advanced and intelligent web applications. The shared philosophy underpinning both DevElation and Opus ensures that developers who are familiar with DevElation can effortlessly transition to using the Opus framework, with the assurance that they are building on top of a reliable and proven foundation.
+In practice:
+
+- Use DevElation objects for values and structures that will be worked with repeatedly.
+- Use static helpers for single hookable operations.
+- Use global helper functions as constructor/factory shortcuts only.
+- Let returned objects own their fluent behavior.
+- Prefer DevElation data, connection, service, CLI, HTML, parsing, security, and system utilities over ad-hoc raw PHP when the package already owns the capability.
+- Keep public features package-owned and broadly useful; consuming projects should consume or extend DevElation, not define its internal concerns.
 
 ## Features Overview
 
@@ -33,17 +40,50 @@ A collection of wrapper classes around PHP's primitive data types that offer enh
 
 Static helpers: most `Val`/`Obj`-based classes expose their underscored instance helpers as static shorthand. For example, `Str` has an internal `_pluralize()` instance method which can be invoked statically via `Str::pluralize('comment')` thanks to `Val::__callStatic`. This pattern is used throughout the library and examples.
 
+Global helper functions: Composer autoloads `src/functions.php`, which provides short factory entrypoints for the highest-use object lifecycles. These helpers instantiate or factory-wrap objects; they do not replace object methods. Chain from the returned object for behavior.
+
+```php
+use BlueFission\DataTypes;
+
+$title = str(' release notes ')->trim()->capitalize()->val();
+$items = arr(['first', 'second'])->reverse()->join(', ')->val();
+$record = obj(['count' => 3], ['count' => DataTypes::NUMBER]);
+$document = doc()->contents('Draft text');
+```
+
+Available helpers:
+
+- `val(mixed $value = null): Val`
+- `str(mixed $value = null): Str`
+- `arr(mixed $value = null): Arr`
+- `num(mixed $value = null): Num`
+- `flag(mixed $value = null): Flag`
+- `func(mixed $value = null): Func`
+- `obj(array|object|null $data = null, array $types = []): Obj`
+- `collect(mixed $value = null): Collection`
+- `datetime(mixed $value = null): Date`
+- `filesystem(mixed $config = null): FileSystem`
+- `doc(): Data\File`
+- `directory(?IData $storage = null): Data\Directory`
+
+The names intentionally avoid PHP built-ins such as `file()` and `date()`. Use
+`doc()` for a DevElation file object and `datetime()` for a DevElation date
+object.
+
 Helper API notes:
 
+- Prefer an object lifecycle when a value is changed or inspected more than a couple of times. Prefer static helpers for one-off hookable operations.
+- Use `Val::make($value)`, `Val::copy()`, `Val::as($target)`, `snapshot()`, `recall()`, `reset()`, and `if(...)->then(...)->otherwise(...)` when generic values need lifecycle, branching, or change tracking.
 - Use `Arr::has($array, $value)` for value checks. Use `Arr::hasKey($array, $key)` for key checks, and `Arr::hasValue($array, $value, true)` or `Arr::contains($array, $value, true)` when strict value matching matters.
 - Use `Arr::merge($base, $next)` when associative keys should be replaced recursively and numeric list values should be appended when unique. Use `Arr::append($base, $next)` for append-only numeric list behavior.
-- Use `Arr::filter($array, $callback)`, `Arr::map($array, $callback)`, `Arr::diff($left, $right)`, `Arr::intersect($left, $right)`, and `Arr::slice($array, $offset, $length)` for common array transforms that should stay on the DevElation helper surface.
+- Use `Arr::filter($array, $callback)`, `Arr::map($array, $callback)`, `Arr::diff($left, $right)`, `Arr::intersect($left, $right)`, `Arr::slice($array, $offset, $length)`, `Arr::splice($array, $replacement, $offset, $length)`, `Arr::join($array, $separator)`, and `Arr::reverse($array, $preserveKeys)` for common array transforms that should stay on the DevElation helper surface.
 - `Arr::map()` / `Arr::filter()` and `Collection::map()` / `Collection::filter()` share traversal semantics: callbacks may accept `value` or `value, key`, and retained or mapped values preserve their original keys.
 - Use `Arr::values($array)` to reindex list values while preserving order. Use `BlueFission\Net\HTTP::pathSegment($segment)` to encode a single URL path segment; `HTTP::urlScheme()`, `HTTP::urlHost()`, `HTTP::urlPort()`, `HTTP::urlPath()`, or `HTTP::urlParts()` for normalized URL component parsing; `HTTP::jsonDecode()` for deterministic JSON fallback handling; and `HTTP::headerLine()`, `HTTP::statusText()`, or `HTTP::statusLine()` for side-effect-free HTTP metadata helpers.
 - Use `Arr::mergeRecursive($base, $next)` when associative keys should be replaced recursively and numeric lists should append in order while preserving duplicates.
 - Use `Str::repeat($value, $times)` or the explicit `Str::strRepeat($value, $times)` alias as the canonical static helper for `str_repeat`-style behavior. Repeat counts must be non-negative; existing instance usage such as `Str::make(' ')->repeat(4)->val()` remains supported.
-- Use `Str::startsWith($value, $needle)`, `Str::endsWith($value, $needle)`, and `Str::match($left, $right, Str::IGNORE_CASE)` for string boundary and equality checks. Values are string-cast before comparison and whitespace remains significant.
+- Use `Str::startsWith($value, $needle)`, `Str::endsWith($value, $needle)`, `Str::match($left, $right, Str::IGNORE_CASE)`, `Str::snake($value)`, `Str::pluralize($value)`, and `Str::size($value)` for string boundary, equality, casing, inflection, and length checks. Values are string-cast before comparison and whitespace remains significant.
 - Use `Date::formatTimestamp($timestamp, 'Y-m-d')` as a concise replacement for `date($format, $timestamp)`.
+- Use `Num::plus()`, `Num::minus()`, `Num::times()`, and `Num::by()` as readable aliases for fluent math. Math helpers unwrap `Val` objects when appropriate.
 - Use `Num::isIntStrict()`, `Num::isFloatStrict()` / `Num::isDoubleStrict()`, and `Flag::isBoolStrict()` / `Flag::isBooleanStrict()` when native scalar type checks must not coerce strings or numeric values.
 - Use `Num::deg2rad($degrees)`, `Num::rad2deg($radians)`, `Num::sin($radians)`, `Num::cos($radians)`, and `Num::atan2($y, $x)` for hookable angle and trigonometry helpers. Angles passed to trigonometry helpers are radians.
 - `BlueFission\Data\FileSystem::fileExists($path)` checks concrete file paths without initializing storage state. `BlueFission\Data\File::exists()` / `isReachable()` and `BlueFission\Data\Directory::exists()` / `isReachable()` can check explicit paths or hierarchy labels without creating missing paths.
@@ -127,11 +167,33 @@ Sample applications that demonstrate DevElation’s flexibility:
 - Simple comment thread with voting using `Arr`, `Str`, `Session` storage, HTML helpers, and templates: `examples/comments/index.php`
 - CLI territory game using the behavioral engine (`Behaves`) and an `Arr`-backed log: `examples/game/gangs.php`
 - CLI status report using args, tables, and progress bars: `examples/cli/report.php`
-- Helper workflow using current primitive, file, HTTP, date, flag, and security helpers: `examples/helpers/workflow.php`
+- Helper workflow using global factory helpers plus primitive, file, HTTP, date, flag, and security objects: `examples/helpers/workflow.php`
 - HTTP/API packet builder using request normalization, headers, JSON, and status helpers: `examples/http/api_packet.php`
 - Additional walkthroughs live in `examples/README.md`
 
 ## Quick Start Examples
+
+### Fluent values and global helper entrypoints
+
+```php
+use BlueFission\DataTypes;
+
+$names = arr(['Ada Lovelace', 'Grace Hopper'])
+    ->map(fn (string $name): string => str($name)->trim()->val())
+    ->reverse()
+    ->join(', ')
+    ->val();
+
+$record = obj(['count' => 3], ['count' => DataTypes::NUMBER]);
+$record->exposeValueObject();
+$total = $record->field('count')->plus(num(2))->val();
+
+$document = doc()->contents('Processed: ' . $names);
+$timestamp = datetime('2026-07-04')->timestamp();
+```
+
+Global helpers are entrypoints into DevElation objects. They should create the
+object; the object should own the behavior.
 
 ### CLI utilities: args, tables, and progress
 
@@ -233,6 +295,11 @@ Install DevElation with Composer:
 ```bash
 composer require bluefission/develation
 ```
+
+Composer autoload registers DevElation classes and the global helper function
+file. After requiring `vendor/autoload.php`, helpers such as `arr()`, `str()`,
+`obj()`, `collect()`, `datetime()`, `filesystem()`, `doc()`, and `directory()`
+are available.
 
 The core package does not require the optional Ratchet websocket transport. If
 you use `BlueFission\Async\Sock`, install Ratchet in applications that can

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         },
         "classmap": [
            "src/"
+        ],
+        "files": [
+            "src/functions.php"
         ]
     },
     "autoload-dev": {

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,8 @@
 ## DevElation Examples Overview
 
-This directory contains small, self-contained example apps that are meant to double as tutorials for “thinking in DevElation”. Each example leans on core library concepts instead of ad‑hoc PHP.
+This directory contains small, self-contained example apps that are meant to double as tutorials for “thinking in DevElation”. Each example leans on core library concepts instead of ad-hoc PHP.
+
+The examples favor DevElation primitives, data objects, storage objects, HTML helpers, CLI helpers, and behavior/state machinery when those classes own the capability. Global helper functions such as `arr()`, `str()`, `num()`, `flag()`, `obj()`, `collect()`, `datetime()`, `filesystem()`, `doc()`, and `directory()` are used as object entrypoints only; the returned objects still own traversal, mutation, formatting, IO, and behavior.
 
 Run `composer install` first. The examples share `examples/support.php`, which loads Composer, keeps local runtime files under `.localappdata/examples`, and provides tiny helpers for input normalization, safe HTML output, IDs, and logging.
 
@@ -13,7 +15,7 @@ Run `composer install` first. The examples share `examples/support.php`, which l
   - `Data\Storage\Session`: using DevElation’s storage pipeline (`activate()`, `read()`, `assign()`, `write()`) instead of working directly with `$_SESSION`.
   - `HTML\Template` + Vibe templates: binding an associative array (`$viewData`) into `todo.vibe` and `layout.vibe` for declarative rendering.
 - **How to run**:
-  - Point a PHP‑capable web server at the project root (or use the Laravel/Opus harness) and open `examples/todo/index.php` through the web server.
+  - Point a PHP-capable web server at the project root and open `examples/todo/index.php` through the web server.
 
 ### 2. Comment Thread – `examples/comments/index.php`
 
@@ -51,13 +53,14 @@ Run `composer install` first. The examples share `examples/support.php`, which l
 
 - **Purpose**: Non-interactive walkthrough of the current helper surface for package users and contributors.
 - **Key DevElation concepts**:
-  - `Arr`: filtering, mapping, values, reverse ordering, and static `Arr::count()`.
+  - Global helper functions: `arr()`, `collect()`, `str()`, `num()`, `flag()`, `datetime()`, `filesystem()`, and `doc()` as constructor/factory shortcuts.
+  - `Arr`: filtering, mapping, values, reverse ordering, and `count()` through the value object.
   - `Collections\Collection`: key-aware filtering and mapping with the same traversal semantics as `Arr`.
-  - `Str`: repeat helpers, case-insensitive `match()`, trimming, and static helper dispatch.
-  - `Num`: degree/radian conversion plus sine and cosine.
+  - `Str`: repeat helpers, case-insensitive `match()`, trimming, casing, and static helper dispatch.
+  - `Num`: degree/radian conversion plus sine and cosine through a fluent numeric object.
   - `Flag`: normalized boolean parsing.
-  - `Date`: timestamp formatting.
-  - `Data\File`, `Data\FileSystem`: safe existence checks, directory entries, and file lines.
+  - `Date`: timestamp and date formatting through the `datetime()` entrypoint.
+  - `Data\File`, `Data\FileSystem`: safe existence checks, directory entries, and file lines through `doc()` and `filesystem()`.
   - `Net\HTTP`: URL path segment, host, and status-line helpers.
   - `Security\Hash`: deterministic content IDs for structured values.
 - **How to run**:

--- a/examples/helpers/workflow.php
+++ b/examples/helpers/workflow.php
@@ -4,67 +4,62 @@ declare(strict_types=1);
 
 require __DIR__ . '/../support.php';
 
-use BlueFission\Arr;
-use BlueFission\Collections\Collection;
-use BlueFission\Data\File;
-use BlueFission\Data\FileSystem;
-use BlueFission\Date;
-use BlueFission\Flag;
 use BlueFission\Net\HTTP;
-use BlueFission\Num;
 use BlueFission\Security\Hash;
 use BlueFission\Str;
 
 $fixtureDir = __DIR__ . DIRECTORY_SEPARATOR . 'fixtures';
 $namesPath = $fixtureDir . DIRECTORY_SEPARATOR . 'names.txt';
 
-$filesystem = new FileSystem($namesPath);
-$names = Arr::make($filesystem->lines("\n"))
-    ->filter(fn (string $name): bool => Str::isNotEmpty(Str::trim($name)))
-    ->map(fn (string $name): string => Str::trim($name))
+$filesystem = filesystem($namesPath);
+$names = arr($filesystem->lines("\n"))
+    ->filter(fn (string $name): bool => str($name)->trim()->isNotEmpty())
+    ->map(fn (string $name): string => str($name)->trim()->val())
     ->values();
 
-$nameSummaries = (new Collection($names->val()))
+$nameSummaries = collect($names->val())
     ->filter(fn (string $name, int $index): bool => $index < 2 || Str::contains($name, 'Johnson'))
     ->map(fn (string $name, int $index): array => [
         'index' => $index,
         'name' => $name,
-        'slug' => Str::lower(Str::replace($name, ' ', '-')),
-        'length' => Str::len($name),
+        'slug' => str($name)->replace(' ', '-')->lower()->val(),
+        'length' => str($name)->size(),
     ])
     ->toArray();
 
-$angles = Arr::make([0, 45, 90, 180])
+$angles = arr([0, 45, 90, 180])
     ->map(function (int $degrees): array {
-        $radians = Num::deg2rad($degrees);
+        $radians = num($degrees)->deg2rad()->val();
 
         return [
             'degrees' => $degrees,
-            'radians' => Num::round($radians, 6),
-            'sin' => Num::round(Num::sin($radians), 6),
-            'cos' => Num::round(Num::cos($radians), 6),
+            'radians' => num($radians)->round(6)->val(),
+            'sin' => num($radians)->sin()->round(6)->val(),
+            'cos' => num($radians)->cos()->round(6)->val(),
         ];
     })
     ->values()
     ->val();
 
-$directory = new FileSystem([
+$directory = filesystem([
     'root' => $fixtureDir,
     'filter' => [],
     'doNotConfirm' => true,
 ]);
 
+$marker = str('=')->repeat(3)->val();
+
 $report = [
-    'title' => Str::strRepeat('=', 3) . ' DevElation helper workflow ' . Str::strRepeat('=', 3),
-    'processed_on' => Date::formatTimestamp(time()),
-    'source_file_exists' => (new File())->exists($namesPath),
-    'source_file_reachable' => (new File())->isReachable($namesPath),
+    'title' => $marker . ' DevElation helper workflow ' . $marker,
+    'processed_on' => datetime()->val(),
+    'source_file_exists' => doc()->exists($namesPath),
+    'source_file_reachable' => doc()->isReachable($namesPath),
     'fixture_entries' => $directory->entries(),
-    'name_count' => Arr::count($names->val()),
+    'name_count' => arr($names->val())->count(),
     'names_latest_first' => $names->reverse()->val(),
     'collection_name_summaries' => $nameSummaries,
-    'admin_match' => Str::match('Admin', 'admin', Str::IGNORE_CASE),
-    'enabled_flag' => Flag::parseBool('yes'),
+    'admin_match' => str('Admin')->match('admin', Str::IGNORE_CASE),
+    'enabled_flag' => flag('yes')->parseBool(),
     'status_line' => HTTP::statusLine(200),
     'encoded_path_segment' => HTTP::pathSegment('Example Report.md'),
     'url_host' => HTTP::urlHost('https://example.test:8443/docs?tab=api'),

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,5 +1,86 @@
 Your roadmap for DevElation and Automata is quite comprehensive and ambitious. Here are some suggestions on how to proceed with the implementation of your goals:
 
+### Global Helper Function Roadmap
+
+Global helpers should remain constructor and factory shortcuts for high-use
+DevElation objects. They should not become alternate names for object methods,
+static helper calls, transforms, or one-off feature shortcuts. The expected
+pattern is:
+
+```php
+$name = str('Ada Lovelace')->snake()->val();
+$items = arr(['first', 'second'])->reverse()->val();
+$record = obj(['name' => 'Ada'], ['name' => DataTypes::STRING]);
+$document = doc()->contents('Draft text');
+```
+
+Helpers should be considered when they improve fluency, reduce ceremony around
+common object lifecycles, preserve hook/event behavior, and keep the resulting
+object in charge of its own feature surface. They should be avoided when they
+would hide IO, locks, resource lifecycle, ambiguous global names, by-reference
+semantics, or method behavior that already chains cleanly from an instantiated
+object.
+
+| Candidate | Strength | Suggested shape | Rationale |
+| --- | --- | --- | --- |
+| `schema()` | Strong | `schema(array $fields = [], array $config = [])` | Schema construction is common, package-owned, and naturally object-first. |
+| `fieldDef()` | Moderate | `fieldDef(string $name, array $config = [])` | Useful with schemas, but the name should avoid vague `field()` collisions. |
+| `node()` | Moderate | `node(string $id, mixed $data = null, array $edges = [], array $meta = [])` | Graph work benefits from short constructors, but only if graph helpers are being used heavily in examples. |
+| `graph()` | Strong | `graph(array $graph = [], bool $directed = true)` | A natural object lifecycle helper for graph workflows and prototypes. |
+| `template()` | Strong | `template(mixed $config = null)` | Template objects are common in examples and applications, and the name is clear. |
+| `parser()` | Moderate | `parser(string $input = '', string $open = '{', string $close = '}')` | Valuable for parsing workflows, but constructor arguments are more domain-specific than primitive helpers. |
+| `console()` | Strong | `console(mixed $config = null)` | CLI applications repeatedly instantiate console utilities and then chain output helpers. |
+| `args()` | Strong | `args(array $config = [])` | Command-line argument parsing is a frequent application boundary with a clear object lifecycle. |
+| `prompt()` | Moderate | `prompt()` | Useful in CLI flows, but the narrower utility may be less universal than `console()` or `args()`. |
+| `logger()` | Moderate | `logger(mixed $config = null)` | Logging is common, but name collision risk and side-effect expectations need care. Avoid `log()` because PHP already defines it for natural logarithms. |
+| `uri()` | Strong | `uri(string $path = '')` | URI objects are broadly useful and construction is side-effect-free. |
+| `request()` | Moderate | `request(...)` | Useful, but DevElation has multiple request concepts. Add only after the target request class and constructor contract are unambiguous. |
+| `response()` | Moderate | `response(...)` | Same concern as `request()`. Keep side-effect-free and object-returning if added. |
+| `email()` | Moderate | `email(...)` | The email object has several constructor fields. Useful, but should not send or validate transport as a helper side effect. |
+| `curl()` | Weak | `curl(mixed $config = null)` | It is an object constructor, but the name is broad and associated with external IO. Prefer explicit examples before adding. |
+| `stream()` | Weak | `stream(mixed $config = null)` | Resource lifecycle and external target ambiguity make this less suitable as a global helper. |
+| `stdio()` | Moderate | `stdio(mixed $config = null)` | Good for CLI, but should be side-effect-free and not read input during helper construction. |
+| `service()` | Moderate | `service()` | Service lifecycles are central, but naming and initialization should be settled before globalizing. |
+| `gateway()` | Weak | `gateway()` | Too application-framework-specific unless service helpers become a focused milestone. |
+| `app()` | Weak | `app(array $config = [])` | Common in frameworks and likely to collide conceptually. Use only if DevElation defines a clear application-kernel convention. |
+| `event()` | Moderate | `event(string $name)` | Behavior construction is common, but `event` is generic and may collide with framework conventions. |
+| `state()` | Moderate | `state(string $name)` | Same as `event()`. Useful if behavior helpers are added as a group. |
+| `action()` | Moderate | `action(string $name)` | Same as `event()`. Avoid any helper behavior that performs the action. |
+| `meta()` | Strong | `meta(...)` | Metadata construction is side-effect-free and commonly paired with behavior dispatch. |
+| `hasher()` | Moderate | `hasher(?string $algo = null)` | Security hash helper is useful, but `hash()` is a PHP built-in and must not be shadowed. |
+| `memoryStore()` | Weak | `memoryStore(mixed $config = null)` | Storage helpers can be useful, but storage names should be explicit and should not imply connection or activation. |
+| `sessionStore()` | Weak | `sessionStore(mixed $config = null)` | Session behavior has side-effect expectations. Add only with docs that construction does not activate or write. |
+| `diskStore()` | Weak | `diskStore(mixed $config = null)` | Useful in data workflows but should wait for a coherent storage-helper naming set. |
+| `mysqlStore()` / `sqliteStore()` | Weak | `mysqlStore(mixed $config = null)` | Database helpers are better deferred until constructor-only, no-connect behavior is guaranteed and documented. |
+
+Names to avoid:
+
+- `file()` because PHP already defines it. Use `doc()` for the DevElation file
+  object helper.
+- `date()` because PHP already defines it. Use `datetime()` for the DevElation
+  date object helper.
+- `hash()` because PHP already defines it. Prefer `hasher()` if a security hash
+  helper is added.
+- `log()` because PHP already defines it for natural logarithms. Prefer
+  `logger()` if a log object helper is added.
+- `map()`, `filter()`, `match()`, `merge()`, `json()`, `header()`, and similar
+  verbs because these are operations, not object lifecycles.
+- Broad framework names such as `app()`, `config()`, `env()`, `route()`, or
+  `view()` unless DevElation owns a clear, stable convention for that helper.
+
+Recommended sequencing:
+
+1. Land the base helper file with primitive, collection, object, date, file,
+   directory, and filesystem instantiation helpers.
+2. Add docs and examples that show helpers as entrypoints into fluent objects,
+   not replacements for methods.
+3. Consider `schema()`, `graph()`, `template()`, `console()`, `args()`, `uri()`,
+   and `meta()` as the next strongest candidates.
+4. Defer request/response, connection, service, and storage helpers until their
+   target class, constructor side effects, and naming conventions are clear.
+5. Reject operation helpers unless they instantiate an object and return it.
+   The object method or static helper surface should own the actual operation.
+
 ### Data Pipeline and Stream Processing
 A data pipeline refers to a set of data processing elements connected in series, where the output of one element is the input of the next. Stream processing is the real-time processing of data continuously, sequentially, and in parallel.
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,125 @@
+<?php
+
+use BlueFission\Arr;
+use BlueFission\Date;
+use BlueFission\Flag;
+use BlueFission\Func;
+use BlueFission\Num;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+use BlueFission\Collections\Collection;
+use BlueFission\Data\Directory;
+use BlueFission\Data\File;
+use BlueFission\Data\FileSystem;
+use BlueFission\Data\IData;
+
+if (!function_exists('val')) {
+    function val(mixed $value = null): Val
+    {
+        return Val::make($value);
+    }
+}
+
+if (!function_exists('str')) {
+    function str(mixed $value = null): Str
+    {
+        return Str::make($value);
+    }
+}
+
+if (!function_exists('arr')) {
+    function arr(mixed $value = null): Arr
+    {
+        return Arr::make($value);
+    }
+}
+
+if (!function_exists('num')) {
+    function num(mixed $value = null): Num
+    {
+        return Num::make($value);
+    }
+}
+
+if (!function_exists('flag')) {
+    function flag(mixed $value = null): Flag
+    {
+        return Flag::make($value);
+    }
+}
+
+if (!function_exists('func')) {
+    function func(mixed $value = null): Func
+    {
+        return Func::make($value);
+    }
+}
+
+if (!function_exists('obj')) {
+    function obj(array|object|null $data = null): Obj
+    {
+        $object = new Obj();
+
+        if ($data !== null) {
+            $object->assign($data);
+        }
+
+        return $object;
+    }
+}
+
+if (!function_exists('collect')) {
+    function collect(mixed $value = null): Collection
+    {
+        return new Collection($value);
+    }
+}
+
+if (!function_exists('bf_date')) {
+    function bf_date(mixed $value = null): Date
+    {
+        return Date::make($value);
+    }
+}
+
+if (!function_exists('filesystem')) {
+    function filesystem(mixed $config = null): FileSystem
+    {
+        return new FileSystem($config);
+    }
+}
+
+if (!function_exists('bf_file')) {
+    function bf_file(?string $path = null, mixed $contents = null): File
+    {
+        $file = new File();
+
+        if ($path !== null) {
+            $file->label($path);
+        }
+
+        if ($contents !== null) {
+            $file->contents($contents);
+        }
+
+        return $file;
+    }
+}
+
+if (!function_exists('directory')) {
+    function directory(mixed $pathOrStorage = null): Directory
+    {
+        $storage = $pathOrStorage instanceof IData
+            ? $pathOrStorage
+            : new FileSystem(Arr::is($pathOrStorage) ? $pathOrStorage : ['root' => (string)($pathOrStorage ?? ''), 'filter' => []]);
+
+        $directory = new class($storage) extends Directory {};
+
+        if (Str::is($pathOrStorage) && $pathOrStorage !== '') {
+            $directory->label($pathOrStorage);
+        }
+
+        return $directory;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -57,9 +57,20 @@ if (!function_exists('func')) {
 }
 
 if (!function_exists('obj')) {
-    function obj(): Obj
+    function obj(array|object|null $data = null, array $types = []): Obj
     {
-        return new Obj();
+        return new class($data, $types) extends Obj {
+            public function __construct(array|object|null $data = null, array $types = [])
+            {
+                $this->_types = $types;
+
+                if (Val::isNotNull($data)) {
+                    $this->_data = new Arr(is_object($data) ? get_object_vars($data) : $data);
+                }
+
+                parent::__construct();
+            }
+        };
     }
 }
 
@@ -84,8 +95,8 @@ if (!function_exists('filesystem')) {
     }
 }
 
-if (!function_exists('bf_file')) {
-    function bf_file(): File
+if (!function_exists('doc')) {
+    function doc(): File
     {
         return new File();
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -57,15 +57,9 @@ if (!function_exists('func')) {
 }
 
 if (!function_exists('obj')) {
-    function obj(array|object|null $data = null): Obj
+    function obj(): Obj
     {
-        $object = new Obj();
-
-        if ($data !== null) {
-            $object->assign($data);
-        }
-
-        return $object;
+        return new Obj();
     }
 }
 
@@ -76,8 +70,8 @@ if (!function_exists('collect')) {
     }
 }
 
-if (!function_exists('bf_date')) {
-    function bf_date(mixed $value = null): Date
+if (!function_exists('datetime')) {
+    function datetime(mixed $value = null): Date
     {
         return Date::make($value);
     }
@@ -91,35 +85,15 @@ if (!function_exists('filesystem')) {
 }
 
 if (!function_exists('bf_file')) {
-    function bf_file(?string $path = null, mixed $contents = null): File
+    function bf_file(): File
     {
-        $file = new File();
-
-        if ($path !== null) {
-            $file->label($path);
-        }
-
-        if ($contents !== null) {
-            $file->contents($contents);
-        }
-
-        return $file;
+        return new File();
     }
 }
 
 if (!function_exists('directory')) {
-    function directory(mixed $pathOrStorage = null): Directory
+    function directory(?IData $storage = null): Directory
     {
-        $storage = $pathOrStorage instanceof IData
-            ? $pathOrStorage
-            : new FileSystem(Arr::is($pathOrStorage) ? $pathOrStorage : ['root' => (string)($pathOrStorage ?? ''), 'filter' => []]);
-
-        $directory = new class($storage) extends Directory {};
-
-        if (Str::is($pathOrStorage) && $pathOrStorage !== '') {
-            $directory->label($pathOrStorage);
-        }
-
-        return $directory;
+        return new class($storage ?? new FileSystem()) extends Directory {};
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -6,6 +6,7 @@ use BlueFission\Collections\Collection;
 use BlueFission\Data\Directory;
 use BlueFission\Data\File;
 use BlueFission\Data\FileSystem;
+use BlueFission\Date;
 use BlueFission\Flag;
 use BlueFission\Func;
 use BlueFission\Num;
@@ -35,12 +36,15 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
         $callable = fn () => 'done';
         $this->assertInstanceOf(Func::class, func($callable));
         $this->assertSame('done', func($callable)->call());
+
+        $this->assertInstanceOf(Date::class, datetime('2026-07-04'));
     }
 
     public function testObjectAndCollectionHelpers()
     {
-        $object = obj(['name' => 'Ada']);
+        $object = obj();
         $this->assertInstanceOf(Obj::class, $object);
+        $object->assign(['name' => 'Ada']);
         $this->assertSame('Ada', $object->field('name'));
 
         $collection = collect(['first' => 'alpha']);
@@ -53,20 +57,25 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
         $filesystem = filesystem(['root' => __DIR__]);
         $this->assertInstanceOf(FileSystem::class, $filesystem);
 
-        $file = bf_file(__FILE__, 'contents');
+        $file = bf_file();
         $this->assertInstanceOf(File::class, $file);
-        $this->assertTrue($file->exists());
+        $this->assertTrue($file->exists(__FILE__));
+        $this->assertSame($file, $file->contents('contents'));
         $this->assertSame('contents', $file->contents());
 
-        $directory = directory(__DIR__);
+        $directory = directory();
         $this->assertInstanceOf(Directory::class, $directory);
-        $this->assertTrue($directory->exists());
+        $this->assertTrue($directory->exists(__DIR__));
     }
 
-    public function testGlobalHelpersAvoidPhpFileCollision()
+    public function testGlobalHelpersAvoidPhpBuiltInCollisions()
     {
         $this->assertTrue(function_exists('file'));
         $this->assertTrue(function_exists('bf_file'));
         $this->assertNotSame('bf_file', 'file');
+
+        $this->assertTrue(function_exists('date'));
+        $this->assertTrue(function_exists('datetime'));
+        $this->assertFalse(function_exists('bf_date'));
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -6,6 +6,7 @@ use BlueFission\Collections\Collection;
 use BlueFission\Data\Directory;
 use BlueFission\Data\File;
 use BlueFission\Data\FileSystem;
+use BlueFission\DataTypes;
 use BlueFission\Date;
 use BlueFission\Flag;
 use BlueFission\Func;
@@ -42,10 +43,14 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
 
     public function testObjectAndCollectionHelpers()
     {
-        $object = obj();
+        $object = obj(['name' => 'Ada']);
         $this->assertInstanceOf(Obj::class, $object);
-        $object->assign(['name' => 'Ada']);
         $this->assertSame('Ada', $object->field('name'));
+
+        $typedObject = obj(['count' => 3], ['count' => DataTypes::NUMBER]);
+        $typedObject->exposeValueObject();
+        $this->assertInstanceOf(Num::class, $typedObject->field('count'));
+        $this->assertSame(5, $typedObject->field('count')->plus(2)->val());
 
         $collection = collect(['first' => 'alpha']);
         $this->assertInstanceOf(Collection::class, $collection);
@@ -57,7 +62,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
         $filesystem = filesystem(['root' => __DIR__]);
         $this->assertInstanceOf(FileSystem::class, $filesystem);
 
-        $file = bf_file();
+        $file = doc();
         $this->assertInstanceOf(File::class, $file);
         $this->assertTrue($file->exists(__FILE__));
         $this->assertSame($file, $file->contents('contents'));
@@ -71,8 +76,8 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function testGlobalHelpersAvoidPhpBuiltInCollisions()
     {
         $this->assertTrue(function_exists('file'));
-        $this->assertTrue(function_exists('bf_file'));
-        $this->assertNotSame('bf_file', 'file');
+        $this->assertTrue(function_exists('doc'));
+        $this->assertFalse(function_exists('bf_file'));
 
         $this->assertTrue(function_exists('date'));
         $this->assertTrue(function_exists('datetime'));

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace BlueFission\Tests;
+
+use BlueFission\Arr;
+use BlueFission\Collections\Collection;
+use BlueFission\Data\Directory;
+use BlueFission\Data\File;
+use BlueFission\Data\FileSystem;
+use BlueFission\Flag;
+use BlueFission\Func;
+use BlueFission\Num;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+
+class FunctionsTest extends \PHPUnit\Framework\TestCase
+{
+    public function testPrimitiveHelpersReturnValueObjects()
+    {
+        $this->assertInstanceOf(Val::class, val('alpha'));
+        $this->assertSame('alpha', val('alpha')->val());
+
+        $this->assertInstanceOf(Str::class, str('alpha'));
+        $this->assertSame('ALPHA', str('alpha')->upper()->val());
+
+        $this->assertInstanceOf(Arr::class, arr(['one']));
+        $this->assertSame(['one'], arr(['one'])->val());
+
+        $this->assertInstanceOf(Num::class, num(2));
+        $this->assertSame(5, num(2)->plus(3)->val());
+
+        $this->assertInstanceOf(Flag::class, flag('yes'));
+        $this->assertTrue(flag('yes')->parseBool());
+
+        $callable = fn () => 'done';
+        $this->assertInstanceOf(Func::class, func($callable));
+        $this->assertSame('done', func($callable)->call());
+    }
+
+    public function testObjectAndCollectionHelpers()
+    {
+        $object = obj(['name' => 'Ada']);
+        $this->assertInstanceOf(Obj::class, $object);
+        $this->assertSame('Ada', $object->field('name'));
+
+        $collection = collect(['first' => 'alpha']);
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertSame('alpha', $collection->get('first'));
+    }
+
+    public function testFilesystemHelpers()
+    {
+        $filesystem = filesystem(['root' => __DIR__]);
+        $this->assertInstanceOf(FileSystem::class, $filesystem);
+
+        $file = bf_file(__FILE__, 'contents');
+        $this->assertInstanceOf(File::class, $file);
+        $this->assertTrue($file->exists());
+        $this->assertSame('contents', $file->contents());
+
+        $directory = directory(__DIR__);
+        $this->assertInstanceOf(Directory::class, $directory);
+        $this->assertTrue($directory->exists());
+    }
+
+    public function testGlobalHelpersAvoidPhpFileCollision()
+    {
+        $this->assertTrue(function_exists('file'));
+        $this->assertTrue(function_exists('bf_file'));
+        $this->assertNotSame('bf_file', 'file');
+    }
+}


### PR DESCRIPTION
## Intent
Add Composer-loaded global helper functions for high-use DevElation value objects and filesystem utilities, scoped to instantiation and first-class object lifecycles.

## User stories / acceptance criteria
- As a consumer, I can call `arr($value)`, `str($value)`, `num($value)`, `val($value)`, `flag($value)`, `func($value)`, and `datetime($value)` to get first-class DevElation value objects.
- As a consumer, I can call `obj($data = null, $types = [])` to instantiate an `Obj` with optional initial data and optional field type declarations.
- As a consumer, I can call `collect($value)`, `filesystem($config)`, `doc()`, and `directory($storage)` for common object lifecycles without helper-level feature shortcuts.
- As a maintainer, helpers are loaded through Composer autoload files and guarded with `function_exists`.
- As a maintainer, helper names avoid overriding PHP built-ins such as `file()` and `date()`.
- As a maintainer, the roadmap captures future helper candidates with strength ratings and naming/side-effect boundaries.
- As a reader, README and example docs describe the current object-first philosophy, helper signatures, and fluent patterns.

## Key files changed
- `composer.json`
- `src/functions.php`
- `tests/FunctionsTest.php`
- `roadmap.md`
- `README.md`
- `examples/README.md`
- `examples/helpers/workflow.php`

## How to test
- `composer dump-autoload`
- `php -l src/functions.php`
- `php -l tests/FunctionsTest.php`
- `php -l examples/helpers/workflow.php`
- `php examples/helpers/workflow.php`
- `vendor/bin/phpunit --do-not-cache-result tests/FunctionsTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Examples/ExamplesSmokeTest.php`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit --do-not-cache-result`

## QA checklist
- Helper functions load from Composer autoload.
- Helpers return object instances rather than scalar shortcuts.
- `obj()` supports optional initial data and type declarations through the existing `Obj` lifecycle.
- Feature behavior remains on the returned objects through normal methods/chaining.
- File and datetime helper names avoid PHP built-in collisions.
- Roadmap guidance distinguishes strong, moderate, weak, and avoided future helpers.
- Root README and examples README use current helper names and package-owned language.
- Helper workflow example runs with global helper entrypoints.
- Full PHPUnit suite passes.

## Approval conditions
Approve when the helper names, instantiation boundary, roadmap candidate ratings, and refreshed README/example guidance are acceptable and the functions preserve first-class object lifecycles.

Closes #181
