### PR TITLE
Align filesystem path lifecycle patterns

### DIFF
--- a/src/Data/Directory.php
+++ b/src/Data/Directory.php
@@ -4,10 +4,9 @@ namespace BlueFission\Data;
 
 use BlueFission\Collections\Hierarchical;
 use BlueFission\Collections\ICollection;
-use BlueFission\Collections\Collection;
 use BlueFission\Data\IData;
+use BlueFission\Data\Support\ResolvesFilesystemPath;
 use BlueFission\DevElation as Dev;
-use BlueFission\Val;
 
 /**
  * Class Directory
@@ -20,6 +19,8 @@ use BlueFission\Val;
  */
 abstract class Directory extends Hierarchical implements ICollection
 {
+    use ResolvesFilesystemPath;
+
     /**
      * The root storage object backing the directory.
      *
@@ -68,26 +69,4 @@ abstract class Directory extends Hierarchical implements ICollection
         return (bool)Dev::apply('_out', $isReachable);
     }
 
-    /**
-     * Resolve the explicit path or the hierarchical label path.
-     *
-     * @param string|null $path
-     * @return string|null
-     */
-    private function targetPath(?string $path = null): ?string
-    {
-        if (Val::isNotNull($path)) {
-            return Dev::apply('_in', $path);
-        }
-
-        $segments = (new Collection($this->path()))
-            ->filter(fn ($segment) => Val::isNotNull($segment) && $segment !== '')
-            ->contents();
-
-        if (empty($segments)) {
-            return null;
-        }
-
-        return Dev::apply('_in', implode(DIRECTORY_SEPARATOR, $segments));
-    }
 }

--- a/src/Data/File.php
+++ b/src/Data/File.php
@@ -6,8 +6,8 @@ use BlueFission;
 use BlueFission\Behavioral\Dispatches;
 use BlueFission\Behavioral\IDispatcher;
 use BlueFission\Collections\ICollection;
-use BlueFission\Collections\Collection;
 use BlueFission\Collections\Hierarchical;
+use BlueFission\Data\Support\ResolvesFilesystemPath;
 use BlueFission\DevElation as Dev;
 use BlueFission\Val;
 use ReflectionClass;
@@ -25,6 +25,7 @@ class File extends Hierarchical implements IDispatcher
     use Dispatches {
         Dispatches::__construct as private __dispatchesConstruct;
     }
+    use ResolvesFilesystemPath;
 
     /**
      * The contents of the file.
@@ -73,7 +74,7 @@ class File extends Hierarchical implements IDispatcher
      */
     public function exists(?string $path = null): bool
     {
-        $target = $this->targetPath($path);
+        $target = $this->targetPath($path, static::PATH_SEPARATOR);
         $exists = FileSystem::fileExists($target);
 
         return (bool)Dev::apply('_out', $exists);
@@ -87,33 +88,10 @@ class File extends Hierarchical implements IDispatcher
      */
     public function isReachable(?string $path = null): bool
     {
-        $target = $this->targetPath($path);
+        $target = $this->targetPath($path, static::PATH_SEPARATOR);
         $isReachable = FileSystem::fileExists($target) && FileSystem::isReadable($target);
 
         return (bool)Dev::apply('_out', $isReachable);
-    }
-
-    /**
-     * Resolve the explicit path or the hierarchical label path.
-     *
-     * @param string|null $path
-     * @return string|null
-     */
-    private function targetPath(?string $path = null): ?string
-    {
-        if (Val::isNotNull($path)) {
-            return Dev::apply('_in', $path);
-        }
-
-        $segments = (new Collection($this->path()))
-            ->filter(fn ($segment) => Val::isNotNull($segment) && $segment !== '')
-            ->contents();
-
-        if (empty($segments)) {
-            return null;
-        }
-
-        return Dev::apply('_in', implode(static::PATH_SEPARATOR, $segments));
     }
 
     /**

--- a/src/Data/FileSystem.php
+++ b/src/Data/FileSystem.php
@@ -278,7 +278,7 @@ class FileSystem extends Data implements IData {
 	private function file(): string|null
 	{
 		if ( !$this->basename && $this->extension ) {
-			$this->basename = Arr::make([$this->filename, $this->extension])->join('.')->val();
+			$this->basename = Arr::join([$this->filename, $this->extension], '.');
 		} elseif ( !$this->basename ) {
 			$this->basename = $this->filename;
 		}
@@ -303,7 +303,7 @@ class FileSystem extends Data implements IData {
 
 		}
 
-		$path = Arr::make($pathParts)->join(DIRECTORY_SEPARATOR)->val();
+		$path = Arr::join($pathParts, DIRECTORY_SEPARATOR);
 		$realpath = realpath($path);
 
 		return $realpath ? $realpath : $path;
@@ -392,7 +392,7 @@ class FileSystem extends Data implements IData {
 		if ($filepath && file_exists($filepath) && is_readable($filepath)) {
 			$mimeType = @finfo_file($finfo, $filepath);
 		}
-		$content = ($mimeType && Str::make($mimeType)->sub(0, 4) == 'text') ? stripslashes($content) : $content;
+		$content = ($mimeType && Str::sub($mimeType, 0, 4) == 'text') ? stripslashes($content) : $content;
 
 		$status = '';
 		$isNewFile = false;
@@ -576,7 +576,7 @@ class FileSystem extends Data implements IData {
 			return false;
 		}
 
-		$path = Arr::make([$directory, $file])->join(DIRECTORY_SEPARATOR)->val();
+		$path = Arr::join([$directory, $file], DIRECTORY_SEPARATOR);
 
 		if (!$this->allowedDir($path)) {
 			$this->status("Location is outside of allowed path.");
@@ -785,7 +785,7 @@ class FileSystem extends Data implements IData {
 		$type = $this->config('filter');
 		$pattern = '';
 		if ( Arr::is($type) ) {
-			$pattern = "/\\" . Arr::make($type)->join('$|\\')->val() . "$/i";
+			$pattern = "/\\" . Arr::join($type, '$|\\') . "$/i";
 		}
 		return $pattern;
 	}
@@ -812,7 +812,7 @@ class FileSystem extends Data implements IData {
 		$filters = $this->config('filter');
 
 		$filter = (Arr::is($filters) && Arr::isNotEmpty($filters))
-			? '{'.Arr::make($filters)->map(fn ($extension) => '*' . $extension)->join(',')->val().'}'
+			? '{'.Arr::join(Arr::map($filters, fn ($extension) => '*' . $extension), ',').'}'
 			: '*';
 
 		$files = glob($this->path().DIRECTORY_SEPARATOR.$filter, GLOB_BRACE);
@@ -852,7 +852,7 @@ class FileSystem extends Data implements IData {
 			return Dev::apply('_out', []);
 		}
 
-		$entries = Arr::make($entries)->sort()->val();
+		$entries = Arr::sort($entries);
 
 		return Dev::apply('_out', $entries);
 	}
@@ -894,7 +894,7 @@ class FileSystem extends Data implements IData {
 			return Dev::apply('_out', [$contents]);
 		}
 
-		return Dev::apply('_out', Str::make($contents)->split($eol)->val());
+		return Dev::apply('_out', Str::split($contents, $eol));
 	}
 
 	/**

--- a/src/Data/FileSystem.php
+++ b/src/Data/FileSystem.php
@@ -5,6 +5,7 @@ use BlueFission\Val;
 use BlueFission\Str;
 use BlueFission\Arr;
 use BlueFission\IObj;
+use BlueFission\Collections\Collection;
 use BlueFission\DataTypes;
 use BlueFission\HTML\HTML;
 use BlueFission\Net\HTTP;
@@ -277,7 +278,7 @@ class FileSystem extends Data implements IData {
 	private function file(): string|null
 	{
 		if ( !$this->basename && $this->extension ) {
-			$this->basename = implode( '.', [$this->filename, $this->extension] );
+			$this->basename = Arr::make([$this->filename, $this->extension])->join('.')->val();
 		} elseif ( !$this->basename ) {
 			$this->basename = $this->filename;
 		}
@@ -302,7 +303,7 @@ class FileSystem extends Data implements IData {
 
 		}
 
-		$path = implode( DIRECTORY_SEPARATOR, $pathParts ) ?? getcwd();
+		$path = Arr::make($pathParts)->join(DIRECTORY_SEPARATOR)->val();
 		$realpath = realpath($path);
 
 		return $realpath ? $realpath : $path;
@@ -391,7 +392,7 @@ class FileSystem extends Data implements IData {
 		if ($filepath && file_exists($filepath) && is_readable($filepath)) {
 			$mimeType = @finfo_file($finfo, $filepath);
 		}
-		$content = ($mimeType && substr($mimeType, 0, 4) == 'text') ? stripslashes($content) : $content;
+		$content = ($mimeType && Str::make($mimeType)->sub(0, 4) == 'text') ? stripslashes($content) : $content;
 
 		$status = '';
 		$isNewFile = false;
@@ -468,7 +469,7 @@ class FileSystem extends Data implements IData {
 
 		$filepath = $path.DIRECTORY_SEPARATOR.$file;
 
-		$content = (!empty($this->contents()) && Str::is($this->contents()) ) ? stripslashes($this->contents()) : $this->contents();
+		$content = (Val::isNotEmpty($this->contents()) && Str::is($this->contents()) ) ? stripslashes($this->contents()) : $this->contents();
 		$status = '';
 
 		if ($this->_handle) {
@@ -575,7 +576,7 @@ class FileSystem extends Data implements IData {
 			return false;
 		}
 
-		$path = join(DIRECTORY_SEPARATOR, [$directory, $file]);
+		$path = Arr::make([$directory, $file])->join(DIRECTORY_SEPARATOR)->val();
 
 		if (!$this->allowedDir($path)) {
 			$this->status("Location is outside of allowed path.");
@@ -784,7 +785,7 @@ class FileSystem extends Data implements IData {
 		$type = $this->config('filter');
 		$pattern = '';
 		if ( Arr::is($type) ) {
-			$pattern = "/\\" . implode('$|\\', $type) . "$/i";
+			$pattern = "/\\" . Arr::make($type)->join('$|\\')->val() . "$/i";
 		}
 		return $pattern;
 	}
@@ -810,14 +811,15 @@ class FileSystem extends Data implements IData {
 
 		$filters = $this->config('filter');
 
-		$filter = (Val::isNotNull($filters) && Arr::size($filters) > 0) 
-			? '{'.implode(',*', $filters ?? []).'}' : '*';
+		$filter = (Arr::is($filters) && Arr::isNotEmpty($filters))
+			? '{'.Arr::make($filters)->map(fn ($extension) => '*' . $extension)->join(',')->val().'}'
+			: '*';
 
 		$files = glob($this->path().DIRECTORY_SEPARATOR.$filter, GLOB_BRACE);
-		
-		foreach ($files as $key=>$file) {
-			$files[$key] = basename($file);
-		}
+
+		$files = (new Collection($files ?: []))
+			->map(fn ($file) => basename($file))
+			->contents();
 
 		// $files = scandir($this->path());
 		
@@ -892,7 +894,7 @@ class FileSystem extends Data implements IData {
 			return Dev::apply('_out', [$contents]);
 		}
 
-		return Dev::apply('_out', explode($eol, $contents));
+		return Dev::apply('_out', Str::make($contents)->split($eol)->val());
 	}
 
 	/**
@@ -1022,13 +1024,16 @@ class FileSystem extends Data implements IData {
 		}
 
 		if ( !$dir ) {
-			$dir = str_replace(['..'.DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR.'..'], ['',''], $path);
+			$dir = Str::make($path)
+				->replace('..'.DIRECTORY_SEPARATOR, '')
+				->replace(DIRECTORY_SEPARATOR.'..', '')
+				->val();
 		}
 
-		$len1 = strlen($root);
-		$len2 = strlen($dir);
+		$len1 = Str::len($root);
+		$len2 = Str::len($dir);
 
-		$position = ( $len2 > 0 ) ? strpos ( $dir, $root ) : 0;
+		$position = ( $len2 > 0 ) ? Str::pos($dir, $root) : 0;
 
 		$allowed = ( $len1 <= $len2 && $position === 0 ) ? true : false;
 

--- a/src/Data/Support/ResolvesFilesystemPath.php
+++ b/src/Data/Support/ResolvesFilesystemPath.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BlueFission\Data\Support;
+
+use BlueFission\Arr;
+use BlueFission\Collections\Collection;
+use BlueFission\DevElation as Dev;
+use BlueFission\Val;
+
+/**
+ * Resolves explicit filesystem paths or hierarchical label paths.
+ */
+trait ResolvesFilesystemPath
+{
+    /**
+     * Resolve an explicit path or the current hierarchical label path.
+     *
+     * @param string|null $path
+     * @param string $separator
+     * @return string|null
+     */
+    protected function targetPath(?string $path = null, string $separator = DIRECTORY_SEPARATOR): ?string
+    {
+        if (Val::isNotNull($path)) {
+            return Dev::apply('_in', $path);
+        }
+
+        $segments = (new Collection($this->path()))
+            ->filter(fn ($segment) => Val::isNotNull($segment) && $segment !== '')
+            ->contents();
+
+        if (Arr::isEmpty($segments)) {
+            return null;
+        }
+
+        return Dev::apply('_in', Arr::make($segments)->join($separator)->val());
+    }
+}

--- a/src/Data/Support/ResolvesFilesystemPath.php
+++ b/src/Data/Support/ResolvesFilesystemPath.php
@@ -33,6 +33,6 @@ trait ResolvesFilesystemPath
             return null;
         }
 
-        return Dev::apply('_in', Arr::make($segments)->join($separator)->val());
+        return Dev::apply('_in', Arr::join($segments, $separator));
     }
 }

--- a/tests/Data/FileSystemTest.php
+++ b/tests/Data/FileSystemTest.php
@@ -45,6 +45,17 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals('Success', $status);
 	}
 
+	public function testCanViewFolderWithConfiguredExtensionFilter()
+	{
+		touch($this->testdirectory.DIRECTORY_SEPARATOR.'keep.txt');
+		touch($this->testdirectory.DIRECTORY_SEPARATOR.'skip.log');
+
+		$this->object->filter(['.txt']);
+		$dir = $this->object->listDir();
+
+		$this->assertEquals(['keep.txt'], $dir);
+	}
+
 	public function testCanCreateDirectory()
 	{
 		$this->object->mkdir('filesystem');


### PR DESCRIPTION
## Intent

Continue issue #154 by aligning the file/path lifecycle classes with DevElation's first-class helper patterns without changing filesystem boundary behavior.

## User stories / acceptance criteria

- As a consumer, File and Directory existence checks should share one maintainable path-resolution path.
- As a maintainer, FileSystem path/list/string assembly should use DevElation primitives and collections where they improve consistency.
- As a reviewer, native filesystem probes should remain explicit at the actual IO boundary.
- Filtered directory listing behavior should remain covered by tests.

## Key files changed

- `src/Data/Support/ResolvesFilesystemPath.php`
- `src/Data/File.php`
- `src/Data/Directory.php`
- `src/Data/FileSystem.php`
- `tests/Data/FileSystemTest.php`

## How to test

- `php -l src/Data/FileSystem.php`
- `php -l src/Data/File.php`
- `php -l src/Data/Directory.php`
- `php -l src/Data/Support/ResolvesFilesystemPath.php`
- `php -l tests/Data/FileSystemTest.php`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Data/FileSystemTest.php tests/Data/FileDirectoryExistenceTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Data`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit.bat --do-not-cache-result`

## QA checklist

- [x] Shared path resolution is used by both File and Directory.
- [x] FileSystem list/path/string transformations use Arr, Str, Collection, and Val where practical.
- [x] Native filesystem calls remain at concrete filesystem boundaries.
- [x] Focused filesystem tests pass.
- [x] Broader Data tests pass.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Existing FileSystem, File, and Directory public behavior remains compatible.
- Review confirms the helper usage improves lifecycle consistency without obscuring IO checks.
