### PR TITLE
Align queue lifecycle patterns

### DIFF
--- a/src/Data/Queues/DiskQueue.php
+++ b/src/Data/Queues/DiskQueue.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Data\Queues;
 
 use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\Data\FileSystem;
 use BlueFission\Collections\Collection;
 use BlueFission\Behavioral\Behaviors\Event;
@@ -61,15 +62,15 @@ class DiskQueue extends Queue implements IQueue
         if (!self::$initialized) {
             $tempfile = sys_get_temp_dir();
 
-            $stack = $tempfile.DIRECTORY_SEPARATOR.self::DIRNAME;
+            $stack = Str::make($tempfile)->append(DIRECTORY_SEPARATOR)->append(self::DIRNAME)->val();
 
             $fs = new FileSystem(array('root' => $tempfile, 'mode' => 'a+', 'filter' => 'file', 'doNotConfirm' => true));
 
-            if (file_exists($stack) && !is_dir($stack)) {
+            if (FileSystem::fileExists($stack) && !FileSystem::directoryExists($stack)) {
                 unlink($stack);
             }
 
-            if (!is_dir($stack)) {
+            if (!FileSystem::directoryExists($stack)) {
                 $fs->mkdir(self::DIRNAME);
             }
 
@@ -97,7 +98,7 @@ class DiskQueue extends Queue implements IQueue
             return true;
         }
 
-        return Arr::count($array) ? false : true;
+        return Arr::make($array)->isEmpty();
     }
 
     /**
@@ -145,7 +146,7 @@ class DiskQueue extends Queue implements IQueue
 
         $items = [];
         for ($i = $after + 1; $i <= $until; $i++) {
-            $file = self::FILENAME . str_pad($i, 11, '0', STR_PAD_LEFT);
+            $file = Str::make(self::FILENAME)->append(str_pad($i, 11, '0', STR_PAD_LEFT))->val();
             $fs->filename = $file;
 
             if ($fs->exists()) {
@@ -198,7 +199,7 @@ class DiskQueue extends Queue implements IQueue
 
         $tail = self::tail($queue);
         do {
-            $fs->basename = self::FILENAME . str_pad($tail, 11, '0', STR_PAD_LEFT);
+            $fs->basename = Str::make(self::FILENAME)->append(str_pad($tail, 11, '0', STR_PAD_LEFT))->val();
 
             $tail++;
             if ($tail > 99999999999) {
@@ -229,13 +230,18 @@ class DiskQueue extends Queue implements IQueue
         $fs->dirname = $queue;
         $array = $fs->listDir();
 
-        if (!Arr::is($array) || Arr::count($array) < 1) {
+        if (!Arr::is($array) || Arr::isEmpty($array)) {
             return 1;
         }
         // rsort($array);
-        $last = end($array);
+        $last = Arr::pop($array);
 
-        $tail = str_replace([$stack, self::FILENAME, $queue,DIRECTORY_SEPARATOR], ['','','',''], $last);
+        $tail = Str::make($last)
+            ->replace($stack, '')
+            ->replace(self::FILENAME, '')
+            ->replace($queue, '')
+            ->replace(DIRECTORY_SEPARATOR, '')
+            ->val();
 
         return (int)$tail;
     }

--- a/src/Data/Queues/FileQueue.php
+++ b/src/Data/Queues/FileQueue.php
@@ -4,7 +4,6 @@ namespace BlueFission\Data\Queues;
 
 use RuntimeException;
 use BlueFission\Arr;
-use BlueFission\Val;
 use BlueFission\Collections\Collection;
 
 /**
@@ -63,13 +62,8 @@ class FileQueue extends Queue implements IQueue
     public static function isEmpty($queue)
     {
         self::ensureFileHandle();
-        $items = self::$cache[$queue] ?? null;
 
-        if (!Val::is($items)) {
-            return true;
-        }
-
-        return Arr::count($items) === 0;
+        return Arr::make(self::$cache[$queue] ?? [])->isEmpty();
     }
 
     public static function dequeue($queue, $after_id = false, $till_id = false)
@@ -82,10 +76,12 @@ class FileQueue extends Queue implements IQueue
         }
 
         if ($after_id === false && $till_id === false) {
-            $item = array_shift(self::$cache[$queue]);
+            $queueItems = Arr::make(self::$cache[$queue] ?? []);
+            $item = $queueItems->shift();
+            self::$cache[$queue] = $queueItems->val();
         } else {
             $after_id = $after_id ?? 0;
-            $queueItems = Arr::make(self::$cache[$queue]);
+            $queueItems = Arr::make(self::$cache[$queue] ?? []);
             $length = $till_id === false ? $queueItems->count() : $till_id;
             $item = new Collection($queueItems->slice($after_id, $length)->val());
             self::$cache[$queue] = $queueItems->splice([], $after_id, $length)->val();

--- a/src/Data/Queues/MemQueue.php
+++ b/src/Data/Queues/MemQueue.php
@@ -3,6 +3,8 @@
 namespace BlueFission\Data\Queues;
 
 use Memcached;
+use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\Collections\Collection;
 
 /**
@@ -76,11 +78,11 @@ class MemQueue extends Queue implements IQueue
     private static function init()
     {
         $_stack = new Memcached();
-        $servers = explode(",", static::$_memq_pool);
-        foreach ($servers as $server) {
-            list($host, $port) = explode(":", $server);
+        $servers = Str::make(static::$_memq_pool)->split(',');
+        $servers->each(function ($server) use ($_stack) {
+            [$host, $port] = Str::make($server)->split(':')->val();
             $_stack->addServer($host, $port);
-        }
+        });
         self::$_stack = $_stack;
     }
 
@@ -151,20 +153,19 @@ class MemQueue extends Queue implements IQueue
             $until = $stack->get($queue . "_tail");
         }
 
-        $item_keys = [];
-        for ($i = $after + 1; $i <= $until; $i++) {
-            $item_keys[] = $queue . "_" . $i;
-        }
+        $item_keys = ($after + 1 <= $until)
+            ? Arr::make(range($after + 1, $until))
+                ->map(fn ($i) => Str::make($queue)->append('_')->append($i)->val())
+                ->val()
+            : [];
 
         $items = $stack->getMulti($item_keys, Memcached::GET_PRESERVE_ORDER);
 
-        if ($items === false || empty($items)) {
+        if ($items === false || Arr::isEmpty($items)) {
             return false;
         }
 
-        foreach ($item_keys as $key) {
-            $stack->delete($key);
-        }
+        Arr::make($item_keys)->each(fn ($key) => $stack->delete($key));
 
         return new Collection($items);
     }

--- a/src/Data/Queues/Queue.php
+++ b/src/Data/Queues/Queue.php
@@ -3,7 +3,6 @@
 namespace BlueFission\Data\Queues;
 
 use BlueFission\Arr;
-use BlueFission\Val;
 use BlueFission\Collections\Collection;
 
 /**
@@ -68,6 +67,18 @@ class Queue implements IQueue
     }
 
     /**
+     * Return the queue items as a DevElation array primitive.
+     *
+     * @param \ArrayObject $stack
+     * @param string $queue
+     * @return Arr
+     */
+    private static function itemsFor(\ArrayObject $stack, string $queue): Arr
+    {
+        return Arr::make($stack[$queue] ?? []);
+    }
+
+    /**
      * Determines if the queue is empty.
      *
      * @param string $queue the name of the queue.
@@ -77,13 +88,7 @@ class Queue implements IQueue
     public static function isEmpty($queue)
     {
         $stack = self::instance();
-        $items = $stack[$queue] ?? null;
-
-        if (!Val::is($items)) {
-            return true;
-        }
-
-        return Arr::count($items) === 0;
+        return self::itemsFor($stack, $queue)->isEmpty();
     }
 
     /**
@@ -98,18 +103,21 @@ class Queue implements IQueue
     public static function dequeue($queue, $after_id = false, $till_id = false)
     {
         $stack = self::instance();
+        $items = self::itemsFor($stack, $queue);
+
         if ($after_id === false && $till_id === false) {
             if (self::$_mode == static::FIFO) {
-                $item = array_shift($stack[$queue]);
+                $item = $items->shift();
             } elseif (self::$_mode == static::FILO) {
-                $item = array_pop($stack[$queue]);
+                $item = $items->pop();
             }
+            $stack[$queue] = $items->val();
             return $item;
         } elseif ($after_id !== false && $till_id === false) {
-            $till_id = Arr::count($stack[$queue]) - 1;
+            $till_id = $items->count() - 1;
         }
-        $items = new Collection(Arr::slice($stack[$queue], $after_id, $till_id));
-        return $items;
+
+        return new Collection($items->slice($after_id, $till_id)->val());
     }
 
     /**


### PR DESCRIPTION
## Intent

Continue issue #154 by aligning queue internals with DevElation's first-class helper patterns while preserving queue ordering and backend behavior.

## User stories / acceptance criteria

- As a maintainer, in-memory queue item lists should be handled through `Arr` during count, shift, pop, slice, and splice lifecycle operations.
- As a maintainer, queue key and path token assembly should use `Str` where it improves consistency.
- As a consumer, FIFO/FILO behavior, range dequeue behavior, and backend-specific locking/storage behavior should remain compatible.

## Key files changed

- `src/Data/Queues/Queue.php`
- `src/Data/Queues/FileQueue.php`
- `src/Data/Queues/DiskQueue.php`
- `src/Data/Queues/MemQueue.php`

## How to test

- `php -l src/Data/Queues/Queue.php`
- `php -l src/Data/Queues/FileQueue.php`
- `php -l src/Data/Queues/DiskQueue.php`
- `php -l src/Data/Queues/MemQueue.php`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Data/Queues`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Data`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit.bat --do-not-cache-result`

## QA checklist

- [x] Queue and FileQueue wrap queue item arrays with `Arr` during mutation.
- [x] DiskQueue uses FileSystem probes and `Str` token assembly where practical.
- [x] MemQueue uses `Str`/`Arr` for server parsing and queue-key ranges.
- [x] Loops remain where they manage backend state, locks, or deletion side effects.
- [x] Queue tests pass.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Existing queue public behavior remains compatible.
- Review confirms helper use improves lifecycle clarity without hiding backend semantics.
