### PR TITLE
Align storage query lifecycle patterns

### DIFF
--- a/src/Data/Storage/MySQL.php
+++ b/src/Data/Storage/MySQL.php
@@ -9,6 +9,7 @@ use BlueFission\Date;
 use BlueFission\IObj;
 use BlueFission\Data\IData;
 use BlueFission\Connections\Database\MySQLLink;
+use BlueFission\Data\Storage\Support\BuildsQueryFragments;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\State;
 use BlueFission\Data\Storage\Behaviors\StorageAction;
@@ -36,6 +37,8 @@ use BlueFission\Data\Storage\Behaviors\StorageAction;
  */
 class MySQL extends Storage implements IData
 {
+    use BuildsQueryFragments;
+
     protected $_config = [
         'location' => null,
         'name' => '',
@@ -242,7 +245,7 @@ class MySQL extends Storage implements IData
     public function read(): IObj
     {
         $tables = $this->tables();
-        if (count($tables) < 1) {
+        if (Arr::isEmpty($tables)) {
             $this->status(self::STATUS_FAILED);
             return $this;
         }
@@ -291,12 +294,12 @@ class MySQL extends Storage implements IData
                     if ($this->config('auto_join')) {
                         $field = $this->arrayKeyIntersect($this->table($table), $join);
                         foreach ($field as $b => $c) {
-                            if (in_array($b, $active_fields) || Val::isEmpty($active_fields)) {
+                            if (Arr::has($active_fields, $b) || Val::isEmpty($active_fields)) {
                                 $on[] = $table . ".$b  = $a.$b";
                             }
                         }
                     }
-                    if (count($relations) > 0) {
+                    if (Arr::isNotEmpty($relations)) {
                         $fields = $this->arrayKeyIntersect($relations, $join);
                         foreach ($fields as $b => $c) {
                             $on[] = $table . "." . $relations[$b] . "  = $a.$b";
@@ -305,7 +308,7 @@ class MySQL extends Storage implements IData
 
                     if ($this->config('auto_join')) {
 
-                        for ($i = $count; $i < count($tables); $i++) {
+                        for ($i = $count; $i < Arr::count($tables); $i++) {
                             $b = $tables[$i];
                             if ($a != $b) {
                                 $join_2 = $this->table($b);
@@ -345,10 +348,7 @@ class MySQL extends Storage implements IData
             }
         }
 
-        $left_join = '';
-        if (count($this->tables()) > 1) {
-            $left_join .= "INNER JOIN (" . implode(', ', array_slice($tables, 1)) . ") ON (" . implode(' AND ', $on) . ")";
-        }
+        $left_join = $this->innerJoinClause($tables, $on);
 
         $select = [];
         foreach ($active_fields as $a) {
@@ -356,7 +356,7 @@ class MySQL extends Storage implements IData
                 $select[] = ($this->aggregateCase($table, $a)) ? $this->aggregateCase($table, $a) : $this->fieldTable($a).'.'.$a;
             }
         }
-        if (count($select) <= 0) {
+        if (Arr::isEmpty($select)) {
             $select[] = '*';
             foreach ($this->_aggregate as $a => $b) {
                 if ($this->exists($a)) {
@@ -366,14 +366,10 @@ class MySQL extends Storage implements IData
         }
 
         // Build query
-        $query = "SELECT " . implode(', ', $select) . " FROM `$table` $left_join WHERE " . implode(' AND ', $where);
+        $query = "SELECT " . Arr::join($select, ', ') . " FROM `$table` $left_join WHERE " . Arr::join($where, ' AND ');
 
-        if (count($distinct) > 0) {
-            $query .= " GROUP BY " . implode(', ', $distinct);
-        }
-        if (count($sort) > 0) {
-            $query .= " ORDER BY " . implode(', ', $sort);
-        }
+        $query = $this->appendListClause($query, 'GROUP BY', $distinct);
+        $query = $this->appendListClause($query, 'ORDER BY', $sort);
 
         $start = $this->start();
         $end = $this->end();
@@ -476,14 +472,14 @@ class MySQL extends Storage implements IData
                         }
                     }
 
-                    if (count($relations) > 0) {
+                    if (Arr::isNotEmpty($relations)) {
                         $fields = $this->arrayKeyIntersect($relations, $join);
                         foreach ($fields as $b => $c) {
                             $on[] = $table . "." . $relations[$b] . "  = $a.$b";
                         }
                     }
 
-                    for ($i = $count; $i < count($tables); $i++) {
+                    for ($i = $count; $i < Arr::count($tables); $i++) {
                         $b = $tables[$i];
                         if ($a != $b) {
                             $join_2 = $this->table($b);
@@ -505,7 +501,7 @@ class MySQL extends Storage implements IData
                     }
                     $count++;
 
-                    $members = $this->arrayKeyIntersect(array_keys($data), $join);
+                    $members = $this->arrayKeyIntersect(Arr::keys($data), $join);
 
                     foreach ($members as $b => $c) {
                         $where[] = $this->whereCase($a, $b, $c);
@@ -515,10 +511,7 @@ class MySQL extends Storage implements IData
             }
         }
 
-        $left_join = '';
-        if (count($this->tables()) > 1) {
-            $left_join = "INNER JOIN (" . implode(', ', array_slice($tables, 1)) . ") ON (" . implode(' AND ', $on) . ")";
-        }
+        $left_join = $this->innerJoinClause($tables, $on);
 
         // $select = []
         // foreach($active_fields as $a) if ($this->exists($a)) $select[] = $field_info[$a]['Table'].'.'.$a;
@@ -526,7 +519,7 @@ class MySQL extends Storage implements IData
 
         // Build query
         //$query = "SELECT " . implode(', ', $select) . " FROM `$table` $left_join WHERE " . implode(' AND ', $where);
-        $query = "DELETE FROM `$table` $left_join WHERE " . implode(' AND ', $where);
+        $query = "DELETE FROM `$table` $left_join WHERE " . Arr::join($where, ' AND ');
 
         //if (count($distinct) > 0) $query .= " GROUP BY " . implode(', ', $distinct);
         //if (count($sort) > 0) $query .= " ORDER BY " . implode(', ', $sort);

--- a/src/Data/Storage/SQLite.php
+++ b/src/Data/Storage/SQLite.php
@@ -9,6 +9,7 @@ use BlueFission\Date;
 use BlueFission\IObj;
 use BlueFission\Data\IData;
 use BlueFission\Connections\Database\SQLiteLink;
+use BlueFission\Data\Storage\Support\BuildsQueryFragments;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\State;
 use BlueFission\Data\Storage\Behaviors\StorageAction;
@@ -36,6 +37,8 @@ use BlueFission\Data\Storage\Behaviors\StorageAction;
  */
 class SQLite extends Storage implements IData
 {
+    use BuildsQueryFragments;
+
     protected $_config = [
         'location' => null,
         'name' => '',
@@ -240,7 +243,7 @@ class SQLite extends Storage implements IData
     public function read(): IObj
     {
         $tables = $this->tables();
-        if (count($tables) < 1) {
+        if (Arr::isEmpty($tables)) {
             $this->status(self::STATUS_FAILED);
             return $this;
         }
@@ -288,12 +291,12 @@ class SQLite extends Storage implements IData
                     if ($this->config('auto_join')) {
                         $field = $this->arrayKeyIntersect($this->table($table), $join);
                         foreach ($field as $b => $c) {
-                            if (in_array($b, $active_fields) || Val::isEmpty($active_fields)) {
+                            if (Arr::has($active_fields, $b) || Val::isEmpty($active_fields)) {
                                 $on[] = $table . ".$b  = $a.$b";
                             }
                         }
                     }
-                    if (count($relations) > 0) {
+                    if (Arr::isNotEmpty($relations)) {
                         $fields = $this->arrayKeyIntersect($relations, $join);
                         foreach ($fields as $b => $c) {
                             $on[] = $table . "." . $relations[$b] . "  = $a.$b";
@@ -302,7 +305,7 @@ class SQLite extends Storage implements IData
 
                     if ($this->config('auto_join')) {
 
-                        for ($i = $count; $i < count($tables); $i++) {
+                        for ($i = $count; $i < Arr::count($tables); $i++) {
                             $b = $tables[$i];
                             if ($a != $b) {
                                 $join_2 = $this->table($b);
@@ -342,10 +345,7 @@ class SQLite extends Storage implements IData
             }
         }
 
-        $left_join = '';
-        if (count($this->tables()) > 1) {
-            $left_join .= "INNER JOIN (" . implode(', ', array_slice($tables, 1)) . ") ON (" . implode(' AND ', $on) . ")";
-        }
+        $left_join = $this->innerJoinClause($tables, $on);
 
         $select = [];
         foreach ($active_fields as $a) {
@@ -353,7 +353,7 @@ class SQLite extends Storage implements IData
                 $select[] = ($this->aggregateCase($table, $a)) ? $this->aggregateCase($table, $a) : $this->fieldTable($a).'.'.$a;
             }
         }
-        if (count($select) <= 0) {
+        if (Arr::isEmpty($select)) {
             $select[] = '*';
             foreach ($this->_aggregate as $a => $b) {
                 if ($this->exists($a)) {
@@ -363,14 +363,10 @@ class SQLite extends Storage implements IData
         }
 
         // Build query
-        $query = "SELECT " . implode(', ', $select) . " FROM `$table` $left_join WHERE " . implode(' AND ', $where);
+        $query = "SELECT " . Arr::join($select, ', ') . " FROM `$table` $left_join WHERE " . Arr::join($where, ' AND ');
 
-        if (count($distinct) > 0) {
-            $query .= " GROUP BY " . implode(', ', $distinct);
-        }
-        if (count($sort) > 0) {
-            $query .= " ORDER BY " . implode(', ', $sort);
-        }
+        $query = $this->appendListClause($query, 'GROUP BY', $distinct);
+        $query = $this->appendListClause($query, 'ORDER BY', $sort);
 
         $start = $this->start();
         $end = $this->end();
@@ -530,14 +526,14 @@ class SQLite extends Storage implements IData
                         }
                     }
 
-                    if (count($relations) > 0) {
+                    if (Arr::isNotEmpty($relations)) {
                         $fields = $this->arrayKeyIntersect($relations, $join);
                         foreach ($fields as $b => $c) {
                             $on[] = $table . "." . $relations[$b] . "  = $a.$b";
                         }
                     }
 
-                    for ($i = $count; $i < count($tables); $i++) {
+                    for ($i = $count; $i < Arr::count($tables); $i++) {
                         $b = $tables[$i];
                         if ($a != $b) {
                             $join_2 = $this->table($b);
@@ -559,7 +555,7 @@ class SQLite extends Storage implements IData
                     }
                     $count++;
 
-                    $members = $this->arrayKeyIntersect(array_keys($data), $join);
+                    $members = $this->arrayKeyIntersect(Arr::keys($data), $join);
 
                     foreach ($members as $b => $c) {
                         $where[] = $this->whereCase($a, $b, $c);
@@ -569,12 +565,9 @@ class SQLite extends Storage implements IData
             }
         }
 
-        $left_join = '';
-        if (count($this->tables()) > 1) {
-            $left_join = "INNER JOIN (" . implode(', ', array_slice($tables, 1)) . ") ON (" . implode(' AND ', $on) . ")";
-        }
+        $left_join = $this->innerJoinClause($tables, $on);
 
-        $query = "DELETE FROM `$table` $left_join WHERE " . implode(' AND ', $where);
+        $query = "DELETE FROM `$table` $left_join WHERE " . Arr::join($where, ' AND ');
 
         $db->query($query);
         $this->_query = $db->stats()['query'];

--- a/src/Data/Storage/Support/BuildsQueryFragments.php
+++ b/src/Data/Storage/Support/BuildsQueryFragments.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BlueFission\Data\Storage\Support;
+
+use BlueFission\Arr;
+
+/**
+ * Shared SQL query-fragment helpers for storage builders.
+ */
+trait BuildsQueryFragments
+{
+    /**
+     * Build an INNER JOIN fragment for related table reads/deletes.
+     *
+     * @param array $tables
+     * @param array $conditions
+     * @return string
+     */
+    protected function innerJoinClause(array $tables, array $conditions): string
+    {
+        if (Arr::count($tables) <= 1) {
+            return '';
+        }
+
+        return 'INNER JOIN (' . Arr::join(Arr::slice($tables, 1), ', ') . ') ON (' . Arr::join($conditions, ' AND ') . ')';
+    }
+
+    /**
+     * Append a list-backed SQL clause when values are present.
+     *
+     * @param string $query
+     * @param string $clause
+     * @param array $values
+     * @param string $separator
+     * @return string
+     */
+    protected function appendListClause(string $query, string $clause, array $values, string $separator = ', '): string
+    {
+        if (Arr::isEmpty($values)) {
+            return $query;
+        }
+
+        return $query . ' ' . $clause . ' ' . Arr::join($values, $separator);
+    }
+}


### PR DESCRIPTION
## Intent

Continue issue #154 by aligning SQL storage query-fragment assembly with DevElation helper patterns while preserving generated SQL behavior.

## User stories / acceptance criteria

- As a maintainer, repeated SELECT/DELETE fragment assembly should use shared storage-local helpers instead of duplicated raw list operations.
- As a maintainer, table, join, select, where, group, and sort fragments should flow through `Arr` helper APIs where they improve consistency.
- As a consumer, SQLite and MySQL storage behavior should remain compatible.

## Key files changed

- `src/Data/Storage/Support/BuildsQueryFragments.php`
- `src/Data/Storage/SQLite.php`
- `src/Data/Storage/MySQL.php`

## How to test

- `php -l src/Data/Storage/Support/BuildsQueryFragments.php`
- `php -l src/Data/Storage/SQLite.php`
- `php -l src/Data/Storage/MySQL.php`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Data/Storage/SQLiteTest.php tests/Data/Storage/SQLiteAutoCreateTest.php tests/Data/Storage/StorageTest.php`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Data/Storage`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Data`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit.bat --do-not-cache-result`

## QA checklist

- [x] SQLite and MySQL share query-fragment list assembly helpers.
- [x] SELECT and DELETE builders use `Arr` for list checks, slicing, keys, and joining.
- [x] External database connection behavior is unchanged.
- [x] Focused storage tests pass.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Existing SQLite and MySQL generated query behavior remains compatible.
- Review confirms the helper usage improves storage lifecycle clarity without over-abstracting database behavior.
