### PR TITLE
Align parsing rendering lifecycle patterns

### DIFF
--- a/src/Parsing/Element.php
+++ b/src/Parsing/Element.php
@@ -269,14 +269,13 @@ class Element extends Obj {
 
     public function hasPathValue(string $path): bool
     {
-        $segments = Str::make($this->normalizeScopedPath($path))->split('.')->val();
-        $segments = array_values(array_filter($segments, fn ($segment) => $segment !== ''));
+        $segments = $this->pathSegments($path);
 
-        if (empty($segments)) {
+        if ($segments->isEmpty()) {
             return false;
         }
 
-        $value = $this->block->getVar(array_shift($segments));
+        $value = $this->block->getVar($segments->shift());
         if ($value === null) {
             return false;
         }
@@ -308,10 +307,9 @@ class Element extends Obj {
 
     public function getPathValue(string $path, bool $throw = false): mixed
     {
-        $segments = Str::make($this->normalizeScopedPath($path))->split('.')->val();
-        $segments = array_values(array_filter($segments, fn ($segment) => $segment !== ''));
+        $segments = $this->pathSegments($path);
 
-        if (empty($segments)) {
+        if ($segments->isEmpty()) {
             if ($throw) {
                 throw new \RuntimeException("Undefined value path '{$path}'.");
             }
@@ -319,7 +317,7 @@ class Element extends Obj {
             return null;
         }
 
-        $value = $this->block->getVar(array_shift($segments));
+        $value = $this->block->getVar($segments->shift());
 
         foreach ($segments as $segment) {
             if (is_array($value) && array_key_exists($segment, $value)) {
@@ -352,16 +350,15 @@ class Element extends Obj {
 
     public function setPathValue(string $path, mixed $value): void
     {
-        $segments = Str::make($this->normalizeScopedPath($path))->split('.')->val();
-        $segments = array_values(array_filter($segments, fn ($segment) => $segment !== ''));
+        $segments = $this->pathSegments($path);
 
-        if (empty($segments)) {
+        if ($segments->isEmpty()) {
             return;
         }
 
-        $root = array_shift($segments);
+        $root = $segments->shift();
 
-        if (empty($segments)) {
+        if ($segments->isEmpty()) {
             $this->setScopeVariable($root, $value);
             return;
         }
@@ -371,7 +368,7 @@ class Element extends Obj {
             throw new \RuntimeException("Undefined value path '{$path}'.");
         }
 
-        $container = $this->setNestedPathValue($container, $segments, $value, $path);
+        $container = $this->setNestedPathValue($container, $segments->val(), $value, $path);
         $this->setScopeVariable($root, $container);
     }
 
@@ -456,6 +453,14 @@ class Element extends Obj {
         return Str::sub($path, 1);
     }
 
+    protected function pathSegments(string $path): Arr
+    {
+        return Str::make($this->normalizeScopedPath($path))
+            ->split('.')
+            ->filter(fn ($segment) => $segment !== '')
+            ->values();
+    }
+
     protected function shouldInterpolateAttribute(mixed $raw, mixed $value): bool
     {
         if (!Str::is($raw) || !Str::is($value)) {
@@ -506,8 +511,8 @@ class Element extends Obj {
 
     protected function resolveInterpolationExpression(string $expression): string
     {
-        $segments = Str::make($expression)->split('|')->val();
-        $base = Str::trim((string)array_shift($segments));
+        $segments = Str::make($expression)->split('|');
+        $base = Str::trim((string)$segments->shift());
         $value = $this->resolveInterpolationValue($base);
 
         foreach ($segments as $segment) {
@@ -539,11 +544,11 @@ class Element extends Obj {
 
     protected function parseInterpolationFilter(string $segment): array
     {
-        $parts = Str::make($segment)->split(':')->val();
-        $filter = Str::lower(Str::trim((string)array_shift($parts)));
+        $parts = Str::make($segment)->split(':');
+        $filter = Str::lower(Str::trim((string)$parts->shift()));
 
-        if ($filter === 'default' && count($parts) > 1) {
-            $parts = [implode(':', $parts)];
+        if ($filter === 'default' && $parts->count() > 1) {
+            $parts = Arr::make([$parts->join(':')->val()]);
         }
 
         $arguments = [];
@@ -627,12 +632,10 @@ class Element extends Obj {
         }
 
         if (is_array($value)) {
-            $stringified = [];
-            foreach ($value as $item) {
-                $stringified[] = $this->stringifyInterpolatedValue($item);
-            }
-
-            return implode(',', $stringified);
+            return Arr::make($value)
+                ->map(fn ($item) => $this->stringifyInterpolatedValue($item))
+                ->join(',')
+                ->val();
         }
 
         if (is_object($value) && method_exists($value, '__toString')) {
@@ -674,7 +677,9 @@ class Element extends Obj {
 
     protected function setNestedPathValue(mixed $target, array $segments, mixed $value, string $path): mixed
     {
-        $segment = array_shift($segments);
+        $pathSegments = Arr::make($segments);
+        $segment = $pathSegments->shift();
+        $segments = $pathSegments->val();
 
         if ($segment === null) {
             return $value;

--- a/src/Parsing/Elements/EachElement.php
+++ b/src/Parsing/Elements/EachElement.php
@@ -4,6 +4,7 @@ namespace BlueFission\Parsing\Elements;
 
 use BlueFission\Parsing\Element;
 use BlueFission\Parsing\Contracts\ILoopElement;
+use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\DevElation as Dev;
 
@@ -56,7 +57,7 @@ class EachElement extends Element implements ILoopElement
         $this->setScopeVariable('current_path', $previousCurrentPath);
         $this->setScopeVariable('index', $previousIndex);
 
-        $output = implode($glue, $results);
+        $output = Arr::make($results)->join($glue)->val();
         $output = Dev::apply('_out', $output);
         Dev::do('_after', [$output, $this]);
         return $output;
@@ -83,11 +84,11 @@ class EachElement extends Element implements ILoopElement
 
     protected function decodeGlue(string $glue): string
     {
-        $glue = Str::replace($glue, '\r\n', "\r\n");
-        $glue = Str::replace($glue, '\n', "\n");
-        $glue = Str::replace($glue, '\t', "\t");
-        $glue = Str::replace($glue, '\r', "\r");
-
-        return $glue;
+        return Str::make($glue)
+            ->replace('\r\n', "\r\n")
+            ->replace('\n', "\n")
+            ->replace('\t', "\t")
+            ->replace('\r', "\r")
+            ->val();
     }
 }

--- a/src/Parsing/Elements/FunctionElement.php
+++ b/src/Parsing/Elements/FunctionElement.php
@@ -8,6 +8,9 @@ use BlueFission\Parsing\Contracts\IToolFunction;
 use BlueFission\Parsing\Registry\FunctionRegistry;
 use BlueFission\Parsing\Registry\GeneratorRegistry;
 use BlueFission\Parsing\Element;
+use BlueFission\Arr;
+use BlueFission\Flag;
+use BlueFission\Str;
 use BlueFission\DevElation as Dev;
 
 class FunctionElement extends Element implements IExecutableElement, IRenderableElement
@@ -19,8 +22,8 @@ class FunctionElement extends Element implements IExecutableElement, IRenderable
         $result = Dev::apply('_out', $result);
 
         // Check for silent attribute
-        $silent = $this->getAttribute('silent') ?? 'false';
-        if (filter_var($silent, FILTER_VALIDATE_BOOLEAN)) {
+        $silent = Flag::make($this->getAttribute('silent') ?? 'false')->parseBool();
+        if ($silent) {
             Dev::do('_after', ['', $this]);
             return '';
         }
@@ -32,20 +35,26 @@ class FunctionElement extends Element implements IExecutableElement, IRenderable
     public function execute(): mixed
     {
         Dev::do('_before', [$this]);
-        $rawExpr = array_keys($this->attributes)[0] ?? '';
+        $rawExpr = Arr::make($this->attributes)->keys()->shift() ?? '';
         $rawExpr = Dev::apply('_in', $rawExpr);
 
         // Check for assignment syntax -> varName
         $assignTo = null;
-        if (preg_match('/->\s*(\w+)/', $rawExpr, $match)) {
+        if ($match = Str::make($rawExpr)->matchPattern('/->\s*(\w+)/')) {
             $assignTo = $match[1];
-            $rawExpr = trim(str_replace($match[0], '', $rawExpr));
+            $rawExpr = Str::make($rawExpr)
+                ->replace($match[0], '')
+                ->trim()
+                ->val();
         }
 
         // Check if function-style (contains parens)
-        if (preg_match('/^(\w+)\((.*?)\)$/', $rawExpr, $parts)) {
+        if ($parts = Str::make($rawExpr)->matchPattern('/^(\w+)\((.*?)\)$/')) {
             $funcName = $parts[1];
-            $args = array_map('trim', explode(',', $parts[2]));
+            $args = Str::make($parts[2])
+                ->split(',')
+                ->map(fn ($arg) => Str::trim((string)$arg))
+                ->val();
 
             $function = FunctionRegistry::get($funcName);
             $result = $function
@@ -67,9 +76,9 @@ class FunctionElement extends Element implements IExecutableElement, IRenderable
     public function getDescription(): string
     {
         $name = 'undefined';
-        if (preg_match('/->\s*(\w+)/', $rawExpr, $match)) {
+        $rawExpr = Arr::make($this->attributes)->keys()->shift() ?? '';
+        if ($match = Str::make($rawExpr)->matchPattern('/->\s*(\w+)/')) {
             $name = $match[1];
-            // $rawExpr = trim(str_replace($match[0], '', $rawExpr));
         }
 
         $descriptionString = sprintf('Define a function named `%s`', $name);

--- a/src/Parsing/Elements/InvokeElement.php
+++ b/src/Parsing/Elements/InvokeElement.php
@@ -4,6 +4,8 @@ namespace BlueFission\Parsing\Elements;
 
 use BlueFission\Parsing\Contracts\IRenderableElement;
 use BlueFission\Parsing\Element;
+use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\DevElation as Dev;
 
 class InvokeElement extends Element implements IRenderableElement
@@ -17,7 +19,7 @@ class InvokeElement extends Element implements IRenderableElement
         $match = $this->getMatch();
         $argString = '';
         if (preg_match('/@invoke\\((.*)\\)/s', $match, $m)) {
-            $argString = trim($m[1]);
+            $argString = Str::trim($m[1]);
         }
 
         $macroName = null;
@@ -48,7 +50,7 @@ class InvokeElement extends Element implements IRenderableElement
         }
 
         // Parse remaining key=value pairs as arguments.
-        $args = [];
+        $args = Arr::make([]);
         if ($argString !== '') {
             if (preg_match_all('/([a-zA-Z_][a-zA-Z0-9_-]*)\\s*=\\s*(\"[^\"]*\"|\\\'[^\\\']*\\\'|\\[[^\\]]*\\]|[^\\s]+)/', $argString, $matches, PREG_SET_ORDER)) {
                 foreach ($matches as $m) {
@@ -56,13 +58,13 @@ class InvokeElement extends Element implements IRenderableElement
                     $rawVal = $m[2];
                     // Treat macro arguments as literal values by default:
                     // strip quotes/brackets but do not resolve as scoped vars.
-                    $val = trim($rawVal, "\"'");
-                    $args[$key] = $val;
+                    $val = Str::trim($rawVal, "\"'");
+                    $args->set($key, $val);
                 }
             }
         }
 
-        $output = $macroElement->invoke($args);
+        $output = $macroElement->invoke($args->val());
         $output = Dev::apply('_out', $output);
         Dev::do('_after', [$output, $this]);
         return $output;

--- a/src/Parsing/Evaluator.php
+++ b/src/Parsing/Evaluator.php
@@ -14,6 +14,7 @@ use BlueFission\Parsing\Registry\TagRegistry;
 use BlueFission\Parsing\Contracts\IRenderableElement;
 use BlueFission\Parsing\Contracts\IExecutableElement;
 use BlueFission\Data\FileSystem;
+use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Obj;
@@ -96,13 +97,7 @@ class Evaluator implements IDispatcher
             }
 
             $originalValue = $this->element->getScopeVariable($this->var);
-            if (is_array($originalValue)) {
-                $value = array_merge($originalValue, [$value]);
-            } elseif (is_string($originalValue)) {
-                $value = $originalValue . $value;
-            } else {
-                throw new \Exception("Cannot append to non-array/string variable '{$this->var}'.");
-            }
+            $value = $this->appendAssignmentValue($originalValue, $value, $this->var);
         }
 
         if ($push) {
@@ -111,11 +106,7 @@ class Evaluator implements IDispatcher
             }
 
             $originalValue = $this->element->getScopeVariable($this->var);
-            if (is_array($originalValue)) {
-                $value = array_merge($originalValue, [$value]);
-            } else {
-                throw new \Exception("Cannot push to non-array variable '{$this->var}'.");
-            }
+            $value = $this->pushAssignmentValue($originalValue, $value, $this->var);
         }
 
         $this->element->setScopeVariable($this->var, $value);
@@ -362,13 +353,7 @@ class Evaluator implements IDispatcher
                     }
 
                     $originalValue = $this->element->getScopeVariable($this->var);
-                    if (is_array($originalValue)) {
-                        $value = array_merge($originalValue, [$value]);
-                    } elseif (is_string($originalValue)) {
-                        $value = $originalValue . $value;
-                    } else {
-                        throw new \Exception("Cannot append to non-array/string variable '{$this->var}'.");
-                    }
+                    $value = $this->appendAssignmentValue($originalValue, $value, $this->var);
                 }
 
                 if ($push) {
@@ -377,11 +362,7 @@ class Evaluator implements IDispatcher
                     }
 
                     $originalValue = $this->element->getScopeVariable($this->var);
-                    if (is_array($originalValue)) {
-                        $value = array_merge($originalValue, [$value]);
-                    } else {
-                        throw new \Exception("Cannot push to non-array variable '{$this->var}'.");
-                    }
+                    $value = $this->pushAssignmentValue($originalValue, $value, $this->var);
                 }
 
                 $this->element->setScopeVariable($this->var, $value);
@@ -556,7 +537,7 @@ class Evaluator implements IDispatcher
     protected function invokeTool( $name = null ): mixed
     {
         // Allow tag or attribute-based tool invocation with optional assignment.
-        [$function, $params, $assign] = array_values($this->parseAdditional());
+        [$function, $params, $assign] = Arr::make($this->parseAdditional())->values()->val();
 
         $function = $name ?? $this->element->resolveValue($function);
 
@@ -570,6 +551,28 @@ class Evaluator implements IDispatcher
         }
 
         return "[Unknown tool: $function]";
+    }
+
+    protected function appendAssignmentValue(mixed $originalValue, mixed $value, string $variable): mixed
+    {
+        if (is_array($originalValue)) {
+            return Arr::make($originalValue)->push($value)->val();
+        }
+
+        if (is_string($originalValue)) {
+            return Str::make($originalValue)->append($value)->val();
+        }
+
+        throw new \Exception("Cannot append to non-array/string variable '{$variable}'.");
+    }
+
+    protected function pushAssignmentValue(mixed $originalValue, mixed $value, string $variable): array
+    {
+        if (is_array($originalValue)) {
+            return Arr::make($originalValue)->push($value)->val();
+        }
+
+        throw new \Exception("Cannot push to non-array variable '{$variable}'.");
     }
 
     protected function useGenerator(string $expression): mixed

--- a/src/Parsing/Evaluator.php
+++ b/src/Parsing/Evaluator.php
@@ -296,7 +296,7 @@ class Evaluator implements IDispatcher
                 $path = $m[1];
                 $segments = explode('.', $path);
                 foreach ($segments as $seg) {
-                    if (is_array($value) && isset($value[$seg])) {
+                    if (Arr::is($value) && Val::is($value[$seg])) {
                         $value = $value[$seg];
                     } elseif (is_object($value) && isset($value->$seg)) {
                         $value = $value->$seg;
@@ -386,7 +386,7 @@ class Evaluator implements IDispatcher
         $filesystem->open($file)->read();
         $contents = $filesystem->contents();
 
-        if (!is_string($contents)) {
+        if (!Str::is($contents)) {
             return $contents;
         }
 
@@ -404,13 +404,13 @@ class Evaluator implements IDispatcher
             $paths = $this->element->getIncludePaths();
 
             foreach (['includes', 'modules', 'templates'] as $key) {
-                if (isset($paths[$key]) && is_string($paths[$key]) && $paths[$key] !== '') {
+                if (isset($paths[$key]) && Str::is($paths[$key]) && $paths[$key] !== '') {
                     $candidates[] = rtrim($paths[$key], '\\/') . DIRECTORY_SEPARATOR . $source;
                 }
             }
 
             foreach ($paths as $path) {
-                if (is_string($path) && $path !== '') {
+                if (Str::is($path) && $path !== '') {
                     $candidates[] = rtrim($path, '\\/') . DIRECTORY_SEPARATOR . $source;
                 }
             }
@@ -517,13 +517,13 @@ class Evaluator implements IDispatcher
 
         foreach ($matches as $match) {
             $param = $match['param'] ?? null;
-            if (!is_string($param) || Str::trim($param) === '') {
+            if (!Str::is($param) || Str::trim($param) === '') {
                 continue;
             }
 
             $arg = $this->element->resolveValue($param);
 
-            if (is_string($arg)) {
+            if (Str::is($arg)) {
                 $arg = Str::trim($arg);
                 $arg = $arg === '' ? null : $arg;
             }
@@ -555,11 +555,11 @@ class Evaluator implements IDispatcher
 
     protected function appendAssignmentValue(mixed $originalValue, mixed $value, string $variable): mixed
     {
-        if (is_array($originalValue)) {
+        if (Arr::is($originalValue)) {
             return Arr::make($originalValue)->push($value)->val();
         }
 
-        if (is_string($originalValue)) {
+        if (Str::is($originalValue)) {
             return Str::make($originalValue)->append($value)->val();
         }
 
@@ -568,7 +568,7 @@ class Evaluator implements IDispatcher
 
     protected function pushAssignmentValue(mixed $originalValue, mixed $value, string $variable): array
     {
-        if (is_array($originalValue)) {
+        if (Arr::is($originalValue)) {
             return Arr::make($originalValue)->push($value)->val();
         }
 
@@ -597,7 +597,7 @@ class Evaluator implements IDispatcher
     protected function call($classOrObject, $method, $args = []): mixed
     {
         // Handle both class static calls and instance method calls.
-        if (is_string($classOrObject)) {
+        if (Str::is($classOrObject)) {
             if (!class_exists($classOrObject)) {
                 throw new \Exception("Class '{$classOrObject}' does not exist.");
             }

--- a/tests/Parsing/AdditionalTagsTest.php
+++ b/tests/Parsing/AdditionalTagsTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace BlueFission\Tests\Parsing;
 
+use BlueFission\Parsing\Elements\FunctionElement;
 use BlueFission\Parsing\Parser;
 use BlueFission\Parsing\Registry\TagRegistry;
 
@@ -52,5 +53,14 @@ class AdditionalTagsTest extends ParsingTestCase
         $output = $parser->render();
 
         $this->assertStringContainsString('Hello World!', $output);
+    }
+
+    public function testFunctionDescriptionUsesAssignedName()
+    {
+        $element = new FunctionElement('function', '', '', [
+            'buildSummary() -> summary' => '',
+        ]);
+
+        $this->assertSame('Define a function named `summary`', $element->getDescription());
     }
 }


### PR DESCRIPTION
## Intent

Continue issue #154 by aligning parsing and rendering lifecycle code with DevElation helper patterns while preserving template behavior.

## User stories / acceptance criteria

- As a maintainer, dotted path resolution should carry segment lists through `Arr` helpers instead of repeating raw split/filter/shift logic.
- As a maintainer, interpolation filters, loop glue, macro arguments, and evaluator assignment flows should use first-class primitive helpers where they carry values through multiple operations.
- As a consumer, existing parsing, scoped variables, transforms, macro invocation, and eval assignment behavior should remain compatible.

## Key files changed

- `src/Parsing/Element.php`
- `src/Parsing/Evaluator.php`
- `src/Parsing/Elements/EachElement.php`
- `src/Parsing/Elements/FunctionElement.php`
- `src/Parsing/Elements/InvokeElement.php`
- `tests/Parsing/AdditionalTagsTest.php`

## How to test

- `php -l src/Parsing/Element.php`
- `php -l src/Parsing/Evaluator.php`
- `php -l src/Parsing/Elements/EachElement.php`
- `php -l src/Parsing/Elements/FunctionElement.php`
- `php -l src/Parsing/Elements/InvokeElement.php`
- `php -l tests/Parsing/AdditionalTagsTest.php`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Parsing`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit.bat --do-not-cache-result`

## QA checklist

- [x] Path segment parsing is centralized through `Element::pathSegments()`.
- [x] Rendering loop glue and interpolation list handling use `Arr` and `Str` primitives fluently.
- [x] Eval append/push assignment uses shared helper methods.
- [x] Function element description assignment parsing is covered by a focused test.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Existing parsing output remains stable.
- Review confirms helper usage improves lifecycle clarity without hiding parser grammar behavior.
