### PR TITLE
Align Net and System lifecycle patterns

### DIFF
--- a/src/Net/HTTP.php
+++ b/src/Net/HTTP.php
@@ -182,16 +182,16 @@ class HTTP {
 		{
 			return http_build_query($formdata, $numeric_prefix);
 		}
-	     $res = array();
-	     foreach ((array)$formdata as $k=>$v) 
+	     $res = Arr::make([]);
+	     foreach ((array)$formdata as $k=>$v)
 	     {
 	         $tmp_key = urlencode((is_int($k) && $numeric_prefix) ? $numeric_prefix.$k : $k);
 	         if ($key) $tmp_key = $key.'['.$tmp_key.']';
-	         if ( is_array($v) || is_object($v) ) 
+	         if ( is_array($v) || is_object($v) )
 	         {
-	             $res[] = HTTP::query($v, null /* or $numeric_prefix if you want to add numeric_prefix to all indexes in array*/, $tmp_key);
+	             $res->push(HTTP::query($v, null /* or $numeric_prefix if you want to add numeric_prefix to all indexes in array*/, $tmp_key));
 	         } else {
-	             $res[] = $tmp_key."=".str_replace('%2F', '/', urlencode($v));
+	             $res->push($tmp_key."=".Str::replace(urlencode($v), '%2F', '/'));
 	         }
 	         /*
 	         If you want, you can write this as one string:
@@ -199,7 +199,7 @@ class HTTP {
 	         */
 	     }
 	     $separator = ini_get('arg_separator.output');
-	     return implode($separator, $res);
+	     return $res->join($separator)->val();
 	}
 
 	/**

--- a/src/System/Machine.php
+++ b/src/System/Machine.php
@@ -83,12 +83,11 @@ class Machine {
                     $bootString = Str::trim($matches[1]);
                 } else {
                     // Fallback to the original colon-based parsing but guard array access
-                    $boottimeParts = explode(':', $boottime, 4);
-                    if (count($boottimeParts) < 2) {
+                    $boottimeParts = Str::make($boottime)->split(':');
+                    if ($boottimeParts->count() < 2) {
                         return 0.0;
                     }
-                    $tail = array_slice($boottimeParts, 1);
-                    $bootString = Str::trim(implode(':', $tail));
+                    $bootString = Str::trim($boottimeParts->slice(1)->join(':')->val());
                 }
 
                 $uptime = Date::diff($bootString, Date::now()->val(), 'seconds');
@@ -106,12 +105,13 @@ class Machine {
             return 0.0;
         }
 
-        $parts = explode(' ', trim($contents));
-        if (!isset($parts[0]) || !is_numeric($parts[0])) {
+        $parts = Str::make($contents)->trim()->split(' ');
+        $uptime = $parts->get(0);
+        if (!is_numeric($uptime)) {
             return 0.0;
         }
 
-        return (float)$parts[0];
+        return (float)$uptime;
     }
 
     /**

--- a/src/System/Machine.php
+++ b/src/System/Machine.php
@@ -3,6 +3,7 @@ namespace BlueFission\System;
 
 use BlueFission\Val;
 use BlueFission\Str;
+use BlueFission\Num;
 use BlueFission\Date;
 use BlueFission\DevElation as Dev;
 
@@ -107,7 +108,7 @@ class Machine {
 
         $parts = Str::make($contents)->trim()->split(' ');
         $uptime = $parts->get(0);
-        if (!is_numeric($uptime)) {
+        if (!Num::is($uptime)) {
             return 0.0;
         }
 
@@ -131,7 +132,7 @@ class Machine {
             $response = (string)$this->_system->response();
 
             //extract the numerical value from the response
-            $cpuUsage = preg_replace("/[^0-9]/", "", $response);
+            $cpuUsage = Str::replacePattern("/[^0-9]/", "", $response);
 
             if ($cpuUsage === null || $cpuUsage === '') {
                 return 0.0;
@@ -141,7 +142,7 @@ class Machine {
         }
 
         $load = @\sys_getloadavg();
-        if ($load === false || !isset($load[0]) || !is_numeric($load[0])) {
+        if ($load === false || !isset($load[0]) || !Num::is($load[0])) {
             return 0.0;
         }
 

--- a/tests/Net/HTTPTest.php
+++ b/tests/Net/HTTPTest.php
@@ -79,6 +79,16 @@ class HTTPTest extends TestCase {
         $this->assertEquals($expected, $actual);
     }
 
+    public function testQueryPreservesEncodedSlashesInNestedValues() {
+        $formdata = [
+            'asset' => [
+                'path' => 'images/logo.png',
+            ],
+        ];
+
+        $this->assertSame('data[asset][path]=images/logo.png', HTTP::query($formdata, '', 'data'));
+    }
+
     public function testUrlExists() {
         if (!TestEnvironment::isNetworkEnabled()) {
             $this->assertFalse(HTTP::urlExists('ftp://example.com'));


### PR DESCRIPTION
## Intent

Continue issue #154 by aligning focused Net and System helper lifecycles with DevElation primitives.

## User stories / acceptance criteria

- As a maintainer, recursive query-string assembly should collect and join fragments through `Arr` and string helpers.
- As a maintainer, machine uptime parsing should use `Str`/`Arr` lifecycles for split, slice, and value access.
- As a consumer, existing HTTP query output and system information behavior should remain compatible.

## Key files changed

- `src/Net/HTTP.php`
- `src/System/Machine.php`
- `tests/Net/HTTPTest.php`

## How to test

- `php -l src/Net/HTTP.php`
- `php -l src/System/Machine.php`
- `php -l tests/Net/HTTPTest.php`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Net tests/System`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit.bat --do-not-cache-result`

## QA checklist

- [x] Recursive query fallback uses `Arr` to collect and join fragments.
- [x] Nested query slash-preservation behavior is covered.
- [x] Uptime parsing uses fluent string/list helpers.
- [x] Focused Net/System tests pass.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Existing public HTTP query behavior remains compatible.
- Review confirms the System parsing helper usage improves clarity without adding OS-specific behavior.
