### PR TITLE
Align Loader lifecycle patterns

### DIFF
--- a/src/Utils/Loader.php
+++ b/src/Utils/Loader.php
@@ -5,6 +5,7 @@ namespace BlueFission\Utils;
 use BlueFission\Val;
 use BlueFission\Str;
 use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
 
 /**
  * Class to import all class files.
@@ -28,8 +29,9 @@ class Loader
      */
     private function __construct()
     {
-        $this->_paths = [];
-        $this->_paths[] = realpath(dirname(__FILE__));
+        $this->_paths = Arr::make([])
+            ->push(realpath(dirname(__FILE__)))
+            ->val();
     }
 
     /**
@@ -61,14 +63,14 @@ class Loader
             return $this->_config;
         } elseif (Str::is($config)) {
             if (!Val::is($value)) {
-                return Val::is($this->_config[$config]) ? $this->_config[$config] : null;
+                return Arr::hasKey($this->_config, $config) ? $this->_config[$config] : null;
             }
             if (Arr::hasKey($this->_config, $config)) {
                 $this->_config[$config] = $value;
             }
         } elseif (Arr::is($config)) {
-            foreach ($this->config as $a => $b) {
-                $this->_config[$a] = $config[$a];
+            foreach (Arr::make($config)->filter(fn ($value, $key) => Arr::hasKey($this->_config, $key)) as $key => $newValue) {
+                $this->_config[$key] = $newValue;
             }
         }
     }
@@ -82,7 +84,15 @@ class Loader
      */
     public function addPath($path)
     {
-        $this->_paths[] = $path;
+        $path = Str::trim((string)$path);
+
+        if ($path === '') {
+            return;
+        }
+
+        $this->_paths = Arr::make($this->_paths)
+            ->push($path)
+            ->val();
     }
 
     /**
@@ -118,23 +128,14 @@ class Loader
      */
     private function getClassDirectoryPath($fullyQualifiedClass)
     {
-        $pathParts = explode(".", $fullyQualifiedClass);
-        $numberOfPathParts = Arr::size($pathParts);
-        $filePath = "";
-        $isWildcardMatch = $pathParts[ $numberOfPathParts - 1 ] == "*";
-
-        // Build the file path
-        for ($index = 0; $index < $numberOfPathParts; $index++) {
-            if ($index < $numberOfPathParts - 1) {
-                $filePath .= $pathParts[$index] . DIRECTORY_SEPARATOR;
-            } elseif (!$isWildcardMatch) {
-                $filePath .=  $pathParts[$index] . "." . $this->config('default_extension');
-            }
-        }
+        $pathParts = Str::make($fullyQualifiedClass)->split($this->config('full_stop'));
+        $numberOfPathParts = $pathParts->size();
+        $isWildcardMatch = $pathParts->get($numberOfPathParts - 1) == "*";
+        $filePath = $this->classFilePath($pathParts, $isWildcardMatch);
 
         // Check if wildcard match
         if ($isWildcardMatch) {
-            $wildcardMatches = [];
+            $wildcardMatches = Arr::make([]);
             foreach ($this->_paths as $path) {
                 $testPath = $path . DIRECTORY_SEPARATOR . $filePath;
                 if (is_dir($testPath)) {
@@ -142,24 +143,39 @@ class Loader
                     while (false !== ($entry = $directory->read())) {
                         if ($entry != "." && $entry != ".." &&
                             Str::rpos($entry, ".".$this->_config['default_extension']) !== false) {
-                            $wildcardMatches[] = $testPath . $entry;
+                            $wildcardMatches->push($testPath . $entry);
                         }
                     }
                     $directory->close();
                 }
             }
-            return $wildcardMatches;
+            return $wildcardMatches->val();
         }
 
         // Check for file in the paths
         foreach ($this->_paths as $path) {
             $testPath = $path . DIRECTORY_SEPARATOR . $filePath;
-            if (file_exists($testPath)) {
+            if (FileSystem::fileExists($testPath)) {
                 return $testPath;
             }
         }
 
         // File not found
         return false;
+    }
+
+    private function classFilePath(Arr $pathParts, bool $isWildcardMatch): string
+    {
+        $segments = $isWildcardMatch ? $pathParts->slice(0, -1) : $pathParts->copy();
+
+        if (!$isWildcardMatch) {
+            $lastIndex = $segments->size() - 1;
+            $segments->set(
+                $lastIndex,
+                $segments->get($lastIndex) . "." . $this->config('default_extension')
+            );
+        }
+
+        return $segments->join(DIRECTORY_SEPARATOR)->val() . ($isWildcardMatch ? DIRECTORY_SEPARATOR : '');
     }
 }

--- a/tests/Utils/LoaderTest.php
+++ b/tests/Utils/LoaderTest.php
@@ -7,6 +7,13 @@ use PHPUnit\Framework\TestCase;
 
 class LoaderTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        $loader = Loader::instance();
+        $loader->config('default_extension', 'php');
+        $loader->config('full_stop', '.');
+    }
+
     public function testInstanceIsSingleton()
     {
         $loader1 = Loader::instance();
@@ -27,9 +34,48 @@ class LoaderTest extends TestCase
         $this->assertEquals('js', $loader->config('default_extension'));
     }
 
+    public function testConfigAcceptsArrayUpdatesForKnownKeys()
+    {
+        $loader = Loader::instance();
+        $loader->config([
+            'default_extension' => 'inc',
+            'full_stop' => ':',
+            'unknown' => 'ignored',
+        ]);
+
+        $this->assertEquals('inc', $loader->config('default_extension'));
+        $this->assertEquals(':', $loader->config('full_stop'));
+        $this->assertNull($loader->config('unknown'));
+    }
+
     public function testLoadClass()
     {
         $loader = Loader::instance();
         $this->assertFalse($loader->load('NotExistingClass'));
+    }
+
+    public function testLoadResolvesConfiguredPath()
+    {
+        $loader = Loader::instance();
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('loader-fixture-', true);
+        $class = 'LoaderFixture' . str_replace('.', '', uniqid('', true));
+
+        mkdir($dir);
+        $file = $dir . DIRECTORY_SEPARATOR . $class . '.php';
+        file_put_contents($file, "<?php class {$class} {}\n");
+
+        try {
+            $loader->addPath($dir);
+            $this->assertNull($loader->load($class));
+            $this->assertTrue(class_exists($class, false));
+        } finally {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+
+            if (is_dir($dir)) {
+                rmdir($dir);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Intent

Continue issue #154 by aligning `Utils\Loader` with DevElation helper lifecycles while fixing array-based configuration assignment.

## User stories / acceptance criteria

- As a maintainer, Loader config updates should accept arrays of known config keys without touching unknown keys.
- As a maintainer, Loader path assembly should use `Str`, `Arr`, and local file helpers where values are split, sliced, joined, stored, and resolved.
- As a consumer, singleton access, direct config lookup, missing-class handling, and class loading from configured paths should remain compatible.

## Key files changed

- `src/Utils/Loader.php`
- `tests/Utils/LoaderTest.php`

## How to test

- `php -l src/Utils/Loader.php`
- `php -l tests/Utils/LoaderTest.php`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Utils`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit.bat --do-not-cache-result`

## QA checklist

- [x] Array config assignment updates known keys and ignores unknown keys.
- [x] Loader path registration uses `Arr` for internal path storage.
- [x] Class path construction uses `Str` and `Arr` lifecycle helpers.
- [x] File existence checks use the local file-system helper.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Existing Loader usage remains compatible.
- Review confirms the helper usage clarifies Loader lifecycle behavior without broadening its public API.
