### PR TITLE
Align Email helper lifecycle patterns

### DIFF
--- a/src/Net/Email.php
+++ b/src/Net/Email.php
@@ -398,9 +398,9 @@ class Email extends Obj implements IConfigurable, IEmail
 	 * 
 	 * @return bool Returns true if all email addresses are valid, false otherwise
 	 */
-	static function validateAddress($address = null) 
+	static function validateAddress($address = null)
 	{
-		$address = Arr::toArray($address); //dev_value_to_array($address);
+		$addresses = Arr::make(Arr::toArray($address));
 		$p = '/^[a-z0-9!#$%&*+-=?^_`{|}~\.]+([\.\+][a-z0-9!#$%&*+-=?^_`{|}~\.]+)*';
 		$p .= '@[a-z0-9][-a-z0-9]*(\.[a-z0-9][-a-z0-9]*)*';
 		$p .= '(\.[a-z]{2,}';
@@ -412,22 +412,22 @@ class Email extends Obj implements IConfigurable, IEmail
 		// Regex to get email address from out of  User Name <email@address> format
 		$filter = '/(?<=<)?[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}(?=>)?/';
 
-		$passed = false;
-		$i = 0;
-		$count = Arr::count($address);
-		do
-		{
+		if ($addresses->isEmpty()) {
+			return false;
+		}
+
+		foreach ($addresses as $candidate) {
 			// get email from User Name <email@address> format
-			preg_match($filter, $address[$i] ?? '', $matches);
+			$matches = Str::make((string)$candidate)->matchPattern($filter) ?? [];
 			$email = $matches[0] ?? null;
 
 			$email = $email ?? '';
-			$match = preg_match($pattern, $email);
-			$passed = ($match > 0 && $match !== false) ? true : false;
-			$i++;
-		} while ($passed === true && $i < $count);
-		
-		return $passed;
+			if (!Str::matches($email, $pattern)) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -489,16 +489,19 @@ class Email extends Obj implements IConfigurable, IEmail
 	{
 		if (Val::isNull($field)) return null;
 		//Remove line feeds
-		$ret = str_replace("\r", "", $field);
+		$ret = Str::make((string)$field)->replace("\r", "");
 		// Remove injected headers
-		$find = array("/bcc\:/i",
+		$find = Arr::make(["/bcc\:/i",
 		        "/Content\-Type\:/i",
 		        "/Mime\-Type\:/i",
 		        "/cc\:/i",
-		        "/to\:/i");
-		$ret = preg_replace($find, "", $field);
-		
-		return $ret;
+		        "/to\:/i"]);
+
+		foreach ($find as $pattern) {
+			$ret->replacePattern($pattern, "");
+		}
+
+		return $ret->val();
 	}
 
 	/**

--- a/tests/Net/EmailTest.php
+++ b/tests/Net/EmailTest.php
@@ -98,6 +98,26 @@ class EmailTest extends TestCase
         $this->assertFileDoesNotExist($path);
     }
 
+    public function testValidateAddressAcceptsDisplayNamesAndRejectsInvalidBatches()
+    {
+        $this->assertTrue(Email::validateAddress([
+            'Test User <test@example.com>',
+            'second@example.com',
+        ]));
+
+        $this->assertFalse(Email::validateAddress([
+            'valid@example.com',
+            'not-an-address',
+        ]));
+    }
+
+    public function testSanitizeRemovesHeaderInjectionAndCarriageReturns()
+    {
+        $value = "Hello\r\nBcc: injected@example.com\r\nContent-Type: text/html";
+
+        $this->assertSame("Hello\n injected@example.com\n text/html", Email::sanitize($value));
+    }
+
     private function invokeEmailMethod(Email $email, string $method, array $arguments = [])
     {
         $reflection = new \ReflectionClass($email);


### PR DESCRIPTION
## Intent

Continue issue #154 by aligning focused email validation and sanitization lifecycles with DevElation primitives.

## User stories / acceptance criteria

- As a maintainer, email address validation should carry batches through `Arr` and matched strings through `Str`.
- As a maintainer, sanitization should preserve the line-feed cleanup step while removing injected header names through string helper methods.
- As a consumer, display-name validation, invalid batch rejection, and existing email object behavior should remain compatible.

## Key files changed

- `src/Net/Email.php`
- `tests/Net/EmailTest.php`

## How to test

- `php -l src/Net/Email.php`
- `php -l tests/Net/EmailTest.php`
- `vendor/bin/phpunit.bat --do-not-cache-result tests/Net`
- `composer validate --strict`
- `git diff --check`
- `vendor/bin/phpunit.bat --do-not-cache-result`

## QA checklist

- [x] Email validation uses `Arr` for address batches.
- [x] Display-name extraction uses `Str::matchPattern()`.
- [x] Final address validation uses `Str::matches()`.
- [x] Sanitization keeps carriage-return stripping and removes injected header labels through helper methods.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Existing email construction and attachment tests remain green.
- Review confirms this stays inside validation/sanitization behavior and does not alter mail transport semantics.
