### PR TITLE
Align HTTP JSON lifecycle patterns

### DIFF
--- a/src/Net/HTTP.php
+++ b/src/Net/HTTP.php
@@ -185,9 +185,9 @@ class HTTP {
 	     $res = array();
 	     foreach ((array)$formdata as $k=>$v) 
 	     {
-	         $tmp_key = urlencode((is_int($k) && $numeric_prefix) ? $numeric_prefix.$k : $k);
+	         $tmp_key = urlencode((Num::isIntStrict($k) && $numeric_prefix) ? $numeric_prefix.$k : $k);
 	         if ($key) $tmp_key = $key.'['.$tmp_key.']';
-	         if ( is_array($v) || is_object($v) ) 
+	         if ( Arr::is($v) || is_object($v) ) 
 	         {
 	             $res[] = HTTP::query($v, null /* or $numeric_prefix if you want to add numeric_prefix to all indexes in array*/, $tmp_key);
 	         } else {
@@ -397,11 +397,11 @@ class HTTP {
 		if ($value === false) return 'false';
 		if ($value === true) return 'true';
 
-		if (is_float($value)) {
+		if (isFloatStrict($value)) {
 			return Str::make((string)$value)->replace(',', '.')->val();
 		}
 
-		if (is_int($value)) {
+		if (Num::isIntStrict($value)) {
 			return (string)$value;
 		}
 

--- a/src/Net/HTTP.php
+++ b/src/Net/HTTP.php
@@ -381,45 +381,72 @@ class HTTP {
 		{
 			return json_encode($a);
 		}
-		if (is_null($a)) return 'null';
-		if ($a === false) return 'false';
-		if ($a === true) return 'true';
-		if (is_scalar($a))
-		{
-			if (is_float($a))
-			{
-				// Always use "." for floats.
-				return floatval(str_replace(",", ".", strval($a)));
-			}
 
-			if (is_string($a))
-			{
-				static $jsonReplaces = array(array("\\", "/", "\n", "\t", "\r", "\b", "\f", '"'), array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\b', '\\f', '\"'));
-				return '"' . str_replace($jsonReplaces[0], $jsonReplaces[1], $a) . '"';
-			}
-			else
-				return $a;
+		return self::jsonEncodeFallback($a);
+	}
+
+	/**
+	 * Encode values without relying on the native JSON extension.
+	 *
+	 * @param mixed $value
+	 * @return string
+	 */
+	private static function jsonEncodeFallback($value): string
+	{
+		if (Val::isNull($value)) return 'null';
+		if ($value === false) return 'false';
+		if ($value === true) return 'true';
+
+		if (is_float($value)) {
+			return Str::make((string)$value)->replace(',', '.')->val();
 		}
-		$isList = true;
-		for ($i = 0, reset($a); $i < count($a); $i++, next($a))
-		{
-		  if (key($a) !== $i)
-		  {
-		    $isList = false;
-		    break;
-		  }
+
+		if (is_int($value)) {
+			return (string)$value;
 		}
-		$result = array();
-		if ($isList)
-		{
-		  foreach ($a as $v) $result[] = json_encode($v);
-		  return '[' . join(',', $result) . ']';
+
+		if (Str::is($value)) {
+			return '"' . self::escapeJsonStringFallback($value) . '"';
 		}
-		else
-		{
-		  foreach ($a as $k => $v) $result[] = json_encode($k).':'.json_encode($v);
-		  return '{' . join(',', $result) . '}';
+
+		$values = Arr::make((array)$value);
+
+		if (array_is_list($values->val())) {
+			return '[' . $values
+				->map(fn ($item) => self::jsonEncodeFallback($item))
+				->join(',')
+				->val() . ']';
 		}
+
+		return '{' . $values
+			->map(fn ($item, $key) => self::jsonEncodeFallback((string)$key) . ':' . self::jsonEncodeFallback($item))
+			->join(',')
+			->val() . '}';
+	}
+
+	/**
+	 * Escape a string for the legacy JSON encoder.
+	 *
+	 * @param string $value
+	 * @return string
+	 */
+	private static function escapeJsonStringFallback(string $value): string
+	{
+		$escaped = Str::make($value);
+		$replacements = Arr::make([
+			"\\" => '\\\\',
+			'/' => '\\/',
+			"\n" => '\\n',
+			"\t" => '\\t',
+			"\r" => '\\r',
+			"\x08" => '\\b',
+			"\f" => '\\f',
+			'"' => '\"',
+		]);
+
+		$replacements->each(fn ($replace, $search) => $escaped->replace($search, $replace));
+
+		return $escaped->val();
 	}
 
 	/**

--- a/tests/Net/HTTPTest.php
+++ b/tests/Net/HTTPTest.php
@@ -54,6 +54,24 @@ class HTTPTest extends TestCase {
         $this->assertSame(['fallback' => true], HTTP::jsonDecode('{bad json', true, ['fallback' => true]));
     }
 
+    public function testJsonEncodeUsesNativeEncoderWhenAvailable() {
+        $payload = ['ok' => true, 'items' => [1, 'two']];
+
+        $this->assertSame(json_encode($payload), HTTP::jsonEncode($payload));
+    }
+
+    public function testJsonEncodeFallbackHandlesListsObjectsAndEscapes() {
+        $payload = [
+            'title' => "Hello\nWorld",
+            'items' => [1, true, null, 'path/file'],
+        ];
+
+        $this->assertSame(
+            '{"title":"Hello\\nWorld","items":[1,true,null,"path\\/file"]}',
+            $this->invokeStaticHttpMethod('jsonEncodeFallback', [$payload])
+        );
+    }
+
     public function testHeaderLineNormalizesNameAndValue() {
         $this->assertSame('Content-Type: application/json', HTTP::headerLine(' Content-Type ', ' application/json '));
     }
@@ -116,6 +134,14 @@ class HTTPTest extends TestCase {
         $expected = 'http://www.bluefission.com/test';
         $actual = HTTP::url();
         $this->assertEquals($expected, $actual);
+    }
+
+    private function invokeStaticHttpMethod(string $method, array $arguments = []): mixed {
+        $reflection = new \ReflectionClass(HTTP::class);
+        $method = $reflection->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs(null, $arguments);
     }
 
 }


### PR DESCRIPTION
## Intent summary

Align the legacy `HTTP::jsonEncode()` fallback with current DevElation helper patterns while preserving native `json_encode()` parity for normal PHP runtimes.

## User stories / acceptance criteria

- As a package consumer, `HTTP::jsonEncode()` should continue to use native JSON encoding when available.
- As a maintainer, the fallback path should be testable and should not recursively depend on the native encoder it replaces.
- As a contributor, the fallback implementation should use DevElation value helpers for array traversal and string mutation where practical.

## Key files changed

- `src/Net/HTTP.php`
- `tests/Net/HTTPTest.php`

## How to test

```bash
php -l src/Net/HTTP.php
php -l tests/Net/HTTPTest.php
vendor/bin/phpunit --do-not-cache-result tests/Net
composer validate --strict
git diff --check
vendor/bin/phpunit --do-not-cache-result
```

## QA checklist

- [x] Public native encoder behavior remains unchanged.
- [x] Legacy fallback handles associative arrays, lists, booleans, nulls, numbers, and escaped strings.
- [x] Focused Net suite passes.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm the private fallback boundary is acceptable for direct reflection coverage.
- Confirm the fallback should continue escaping slashes to match PHP's default JSON output.
