### PR TITLE
Align Util lifecycle patterns

### DIFF
--- a/src/Utils/Util.php
+++ b/src/Utils/Util.php
@@ -1,10 +1,13 @@
 <?php
 namespace BlueFission\Utils;
 
+use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Net\Email;
 use BlueFission\Net\HTTP;
 use BlueFission\Data\Storage\Disk;
+use BlueFission\Security\Hash;
 
 class Util {
     /**
@@ -171,9 +174,7 @@ class Util {
      */
     static function csrfToken()
     {
-        $token = bin2hex(random_bytes(32));
-
-        return $token;
+        return Hash::value(random_bytes(32), 'sha256');
     }
 
     /**
@@ -184,21 +185,36 @@ class Util {
      * @return mixed
      */
     static function value($var, $filter = FILTER_DEFAULT ) {
+        $var = Str::make((string)$var)->val();
+        $values = Arr::make([
+            self::inputValue(INPUT_COOKIE, $var, $filter, $_COOKIE),
+            self::inputValue(INPUT_POST, $var, $filter, $_POST),
+            self::inputValue(INPUT_GET, $var, $filter, $_GET),
+        ])
+            ->filter(fn ($value) => Val::isNotNull($value))
+            ->values();
 
-        $cookie = filter_input(INPUT_COOKIE, $var);
-		$get = filter_input(INPUT_GET, $var);
-		$post = filter_input(INPUT_POST, $var);
-
-        if ($cookie === null) {
-            $cookie = $_COOKIE[$var] ?? null;
-        }
-        if ($post === null) {
-            $post = $_POST[$var] ?? null;
-        }
-        if ($get === null) {
-            $get = $_GET[$var] ?? null;
-        }
-
-		return ( Val::isNotNull($cookie) ) ? $cookie : ( ( Val::isNotNull($post) ) ? $post : $get);
+		return $values->shift();
 	}
+
+    /**
+     * Read a filtered request value, falling back to superglobals for CLI tests.
+     *
+     * @param int $type
+     * @param string $var
+     * @param int $filter
+     * @param array $fallback
+     * @return mixed
+     */
+    private static function inputValue(int $type, string $var, int $filter, array $fallback): mixed
+    {
+        $value = filter_input($type, $var, $filter);
+        $fallback = Arr::make($fallback);
+
+        if (Val::isNull($value) && $fallback->hasKey($var)) {
+            $value = filter_var($fallback->get($var), $filter);
+        }
+
+        return $value;
+    }
 }

--- a/tests/Utils/UtilTest.php
+++ b/tests/Utils/UtilTest.php
@@ -3,6 +3,7 @@ namespace BlueFission\Tests;
 
 use BlueFission\Utils\Util;
 use BlueFission\Val;
+use BlueFission\Str;
 use BlueFission\Net\HTTP;
 use BlueFission\Net\Email;
 
@@ -41,8 +42,9 @@ class UtilTest extends \PHPUnit\Framework\TestCase {
     public function testCsrfToken() {
         //Test generating csrf token
         $token = Util::csrfToken();
-        $this->assertTrue(is_string($token));
-        $this->assertEquals(64, strlen($token));
+        $this->assertTrue(Str::is($token));
+        $this->assertSame(64, Str::len($token));
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $token);
     }
 
     public function testValue() {
@@ -65,5 +67,18 @@ class UtilTest extends \PHPUnit\Framework\TestCase {
 
         $value = Util::value('test');
         $this->assertEquals('get_value', $value);
+    }
+
+    public function testValueAppliesRequestedFilter() {
+        unset($_COOKIE['age'], $_GET['age']);
+        $_POST['age'] = '42';
+
+        $value = Util::value('age', FILTER_VALIDATE_INT);
+        $this->assertSame(42, $value);
+
+        $_POST['age'] = 'forty-two';
+
+        $value = Util::value('age', FILTER_VALIDATE_INT);
+        $this->assertFalse($value);
     }
 }


### PR DESCRIPTION
## Intent summary

Align `Utils\Util` token and request-value helpers with current DevElation lifecycle patterns while preserving their public signatures.

## User stories / acceptance criteria

- As a package consumer, `Util::csrfToken()` should continue returning a 64-character token string.
- As a maintainer, token generation should use the package hashing helper for the final digest representation.
- As a package consumer, `Util::value()` should preserve cookie, post, then get precedence.
- As a package consumer, the `$filter` argument should be applied consistently when reading request values and test superglobals.

## Key files changed

- `src/Utils/Util.php`
- `tests/Utils/UtilTest.php`

## How to test

```bash
php -l src/Utils/Util.php
php -l tests/Utils/UtilTest.php
vendor/bin/phpunit --do-not-cache-result tests/Utils/UtilTest.php
composer validate --strict
git diff --check
vendor/bin/phpunit --do-not-cache-result
```

## QA checklist

- [x] Existing token length behavior is preserved.
- [x] Token output is asserted as lowercase hex.
- [x] Request value precedence remains cookie, post, get.
- [x] Request filter behavior is covered.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm that SHA-256 over random bytes is the preferred token representation for this helper.
- Confirm the private request-input helper boundary is appropriate for keeping CLI test fallback behavior inside `Util`.
