### PR TITLE
Align Disk storage lifecycle patterns

### DIFF
--- a/src/Data/Storage/Disk.php
+++ b/src/Data/Storage/Disk.php
@@ -40,21 +40,20 @@ class Disk extends Storage implements IData
 	 */
 	public function activate( ): IObj
 	{
-		$path = $this->config('location') ?? sys_get_temp_dir();
-		
-		$name = $this->config('name') ?? '';
-			
-		if (!$name)	{
-			$name = basename(tempnam($path, 'store_'));
+		$path = Str::make((string)($this->config('location') ?? sys_get_temp_dir()));
+		$name = Str::make((string)($this->config('name') ?? ''));
+
+		if ($name->isEmpty())	{
+			$name->val(basename(tempnam($path->val(), 'store_')));
 		}
 
 		$filesystem = new FileSystem( [
 			'mode'=>'c+',
 			'filter'=>'file',
-			'root'=>$path
+			'root'=>$path->val()
 		] );
 
-		$filesystem->filename = $name;
+		$filesystem->filename = $name->val();
 		$filesystem
 		->when(Event::CONNECTED, (function ($b, $m) use ($filesystem) {
 			$this->_source = $filesystem;
@@ -125,15 +124,14 @@ class Disk extends Storage implements IData
 
 		$value = Dev::apply(null, $value);
 
-		if ( function_exists('json_decode'))
-		{
-			$decoded = json_decode($value, true);
-			if (json_last_error() === JSON_ERROR_NONE) {
-				$this->contents($decoded);
-				$this->assign((array)$decoded);
-			} else {
-				$this->contents($value);
-			}
+		$invalidJson = new \stdClass();
+		$decoded = HTTP::jsonDecode((string)$value, true, $invalidJson);
+
+		if ($decoded !== $invalidJson) {
+			$this->contents($decoded);
+			$this->assign(Arr::make((array)$decoded)->val());
+		} else {
+			$this->contents($value);
 		}
 	}
 	


### PR DESCRIPTION
## Intent summary

Align `Data\Storage\Disk` activation and read lifecycles with DevElation value helpers while preserving storage behavior.

## User stories / acceptance criteria

- As a package consumer, disk storage should still activate with configured location and name values.
- As a package consumer, field writes should still round-trip through JSON content.
- As a package consumer, raw non-JSON content should still be returned unchanged.
- As a maintainer, disk storage should route JSON decoding through the existing HTTP helper and use value objects for path/name lifecycle handling.

## Key files changed

- `src/Data/Storage/Disk.php`

## How to test

```bash
php -l src/Data/Storage/Disk.php
vendor/bin/phpunit --do-not-cache-result tests/Data/Storage/DiskTest.php
composer validate --strict
git diff --check
vendor/bin/phpunit --do-not-cache-result
```

## QA checklist

- [x] Disk storage activation remains covered.
- [x] JSON field write/read behavior remains covered.
- [x] Raw content write/read behavior remains covered.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm the sentinel-based `HTTP::jsonDecode()` invalid JSON boundary is acceptable for disk reads.
- Confirm the `Str` path/name lifecycle treatment is the right level of refactor for this storage slice.
