### PR TITLE
Refine connection helper lifecycles

### DIFF
--- a/src/Connections/Curl.php
+++ b/src/Connections/Curl.php
@@ -96,17 +96,86 @@ class Curl extends Connection implements IConfigurable
 
         $headers = Arr::grab();
         if (Arr::isAssoc($headers)) {
-            $normalized = [];
-            foreach ($headers as $name => $value) {
-                if (is_array($value)) {
-                    $value = implode(', ', $value);
-                }
-                $normalized[] = $name . ': ' . $value;
-            }
-            $headers = $normalized;
+            $headers = Arr::make($headers)
+                ->map(function ($value, $name) {
+                    if (Arr::is($value)) {
+                        $value = Arr::make($value)->join(', ')->val();
+                    }
+
+                    return Str::make($name)->append(': ')->append($value)->val();
+                })
+                ->values()
+                ->toArray();
         }
 
         return $headers;
+    }
+
+    /**
+     * Determine whether a normalized header list contains a header name.
+     *
+     * @param array $headers
+     * @param string $name
+     * @return bool
+     */
+    protected function hasHeader(array $headers, string $name): bool
+    {
+        $needle = Str::make($name)->lower()->append(':')->val();
+
+        foreach (Arr::make($headers) as $header) {
+            if (Str::is($header) && Str::make($header)->lower()->startsWith($needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Build a request payload from the current connection data.
+     *
+     * @param mixed $data
+     * @return string
+     */
+    protected function payloadFromData(mixed $data): string
+    {
+        if (Str::is($data)) {
+            return $data;
+        }
+
+        $payload = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (!Str::is($payload)) {
+            return '';
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Ensure JSON request headers are present for generated request payloads.
+     *
+     * @param array $headers
+     * @param string $payload
+     * @return array
+     */
+    protected function jsonPayloadHeaders(array $headers, string $payload): array
+    {
+        $headers = Arr::make($headers);
+
+        if (!$this->hasHeader($headers->toArray(), 'content-type')) {
+            $headers[] = 'Content-Type: application/json';
+        }
+
+        if (!$this->hasHeader($headers->toArray(), 'accept')) {
+            $headers[] = 'Accept: application/json';
+        }
+
+        if (!$this->hasHeader($headers->toArray(), 'content-length')) {
+            $headers[] = 'Content-Length: ' . Str::size($payload);
+        }
+
+        return $headers->toArray();
     }
 
     /**
@@ -216,32 +285,11 @@ class Curl extends Connection implements IConfigurable
             //set the url, number of POST vars, POST data
             if ($method == 'post') {
                 if (Arr::size($data) > 0 || Str::is($data)) {
-                    $payload = $data;
-                    if (!Str::is($payload)) {
-                        $payload = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-                    }
-                    if (!Str::is($payload)) {
-                        $payload = '';
-                    }
-                    $headers = $this->normalizeHeaders($this->config('headers'));
-                    $hasContentType = false;
-                    $hasAccept = false;
-                    $hasContentLength = false;
-                    foreach ($headers as $header) {
-                        $header = is_string($header) ? strtolower($header) : '';
-                        $hasContentType = $hasContentType || str_starts_with($header, 'content-type:');
-                        $hasAccept = $hasAccept || str_starts_with($header, 'accept:');
-                        $hasContentLength = $hasContentLength || str_starts_with($header, 'content-length:');
-                    }
-                    if (!$hasContentType) {
-                        $headers[] = 'Content-Type: application/json';
-                    }
-                    if (!$hasAccept) {
-                        $headers[] = 'Accept: application/json';
-                    }
-                    if (!$hasContentLength) {
-                        $headers[] = 'Content-Length: ' . strlen($payload);
-                    }
+                    $payload = $this->payloadFromData($data);
+                    $headers = $this->jsonPayloadHeaders(
+                        $this->normalizeHeaders($this->config('headers')),
+                        $payload
+                    );
                     curl_setopt($curl, CURLOPT_POST, true);
                     curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
                     curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);

--- a/src/Connections/IO.php
+++ b/src/Connections/IO.php
@@ -7,6 +7,9 @@ use BlueFission\Behavioral\Behaviors\Meta;
 use BlueFission\Behavioral\IDispatcher;
 use BlueFission\Async\Promise;
 use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Data\File;
+use BlueFission\Data\FileSystem;
 
 /**
  * IO utility class for performing common input/output operations
@@ -26,17 +29,21 @@ class IO
     {
         // Fast-path: when a concrete input file is provided, avoid the
         // behavioral/stdio stack and just copy/read the file directly.
-        if (is_string($input) && is_file($input)) {
-            $data = @file_get_contents($input);
+        $source = Str::is($input) ? Str::make($input) : null;
+        $file = new File();
 
-            if (isset($config['output']) && is_string($config['output'])) {
-                @file_put_contents($config['output'], $data);
+        if ($source && $source->isNotEmpty() && $file->exists($source())) {
+            $data = FileSystem::fileContents($source());
+            $options = Arr::make($config);
+
+            if ($options->hasKey('output') && Str::is($options['output'])) {
+                @file_put_contents($options['output'], $data);
             }
 
             return self::applyFilters($data);
         }
 
-        $stdio = new Stdio(array_merge(['target' => $input], $config));
+        $stdio = new Stdio(Arr::make(['target' => $input])->merge($config)->toArray());
         $stdio
             ->when(new Event(Event::CONNECTED), fn ($b) => self::messages("Connected to stdio", $b))
             ->when(new Event(Event::COMPLETE), fn ($b) => self::messages("Communication complete", $b))
@@ -63,7 +70,7 @@ class IO
      */
     public static function fetch(string $url, array $config = []): mixed
     {
-        $curl = new Curl(array_merge(['target' => $url, 'timeout' => 5, 'connect_timeout' => 3], $config));
+        $curl = new Curl(Arr::make(['target' => $url, 'timeout' => 5, 'connect_timeout' => 3])->merge($config)->toArray());
         $curl
             ->when(new Event(Event::CONNECTED), fn ($b) => self::messages("Connected to remote", $b))
             ->when(new Event(Event::COMPLETE), fn ($b) => self::messages("Read complete", $b))
@@ -82,7 +89,7 @@ class IO
      */
     public static function stream(string $url, array $config = []): mixed
     {
-        $stream = new Stream(array_merge(['target' => $url, 'timeout' => 5], $config));
+        $stream = new Stream(Arr::make(['target' => $url, 'timeout' => 5])->merge($config)->toArray());
         $stream
             ->when(new Event(Event::CONNECTED), fn ($b) => self::messages("Connected to stream", $b))
             ->when(new Event(Event::COMPLETE), fn ($b) => self::messages("Read complete", $b))
@@ -101,7 +108,7 @@ class IO
      */
     public static function sock(string $url, array $config = []): mixed
     {
-        $socket = new Socket(array_merge(['target' => $url, 'timeout' => 5], $config));
+        $socket = new Socket(Arr::make(['target' => $url, 'timeout' => 5])->merge($config)->toArray());
         $socket
             ->when(new Event(Event::CONNECTED), fn ($b) => self::messages("Connected to socket", $b))
             ->when(new Event(Event::COMPLETE), fn ($b) => self::messages("Read complete", $b))
@@ -150,7 +157,7 @@ class IO
         if (self::$_messages === null) {
             self::$_messages = (new Arr())->constraint(function (&$val) {
                 if (Arr::size($val) > 100) {
-                    array_shift($val);
+                    $val = Arr::make($val)->slice(1)->toArray();
                 }
             });
         }

--- a/src/Connections/Socket.php
+++ b/src/Connections/Socket.php
@@ -4,6 +4,7 @@ namespace BlueFission\Connections;
 
 use BlueFission\Val;
 use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\IObj;
 use BlueFission\Net\HTTP;
 use BlueFission\Behavioral\IConfigurable;
@@ -141,47 +142,56 @@ class Socket extends Connection implements IConfigurable
         $status = '';
 
         if ($socket) {
-            $method = $this->config('method');
+            $method = Str::make($this->config('method'))->upper()->val();
 
             $data = HTTP::query($this->_data);
             $this->_result = '';
 
-            if (Val::is($data)) {
+            if (Str::isNotEmpty($data)) {
                 $this->perform([Action::SEND, State::SENDING], new Meta(when: Action::PROCESS, data: $data));
             }
 
-            $method = strtoupper($method);
-            $request = '';
-
-            $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : 'PHP/'.phpversion();
+            $request = Str::make();
 
             if ($method == 'GET') {
-                $request .= '/' . $this->_url . '?';
-                $request .= $data;
-                $request .= "\r\n";
-                $request .= "User-Agent: Dev-Elation\r\n";
-                $request .= "Connection: Close\r\n";
-                $request .= "Content-Length: 0\r\n";
-
-                $cmd = "GET $request HTTP/1.0\r\nHost: ".$this->_host."\r\n\r\n";
+                $request
+                    ->append('/')
+                    ->append($this->_url)
+                    ->append('?')
+                    ->append($data)
+                    ->append("\r\n")
+                    ->append("User-Agent: Dev-Elation\r\n")
+                    ->append("Connection: Close\r\n")
+                    ->append("Content-Length: 0\r\n");
             } elseif ($method == 'POST') {
-
-                $request .= '/' . $this->_url;
-                $request .= "\r\n";
-                $request .= "User-Agent: Dev-Elation\r\n";
-                $request .= "Content-Type: application/x-www-form-urlencoded\r\n";
-                $request .= "Content-Length: ".strlen($data)."\r\n";
-                $request .= $data;
+                $request
+                    ->append('/')
+                    ->append($this->_url)
+                    ->append("\r\n")
+                    ->append("User-Agent: Dev-Elation\r\n")
+                    ->append("Content-Type: application/x-www-form-urlencoded\r\n")
+                    ->append("Content-Length: ")
+                    ->append(Str::size($data))
+                    ->append("\r\n")
+                    ->append($data);
             } else {
                 $status = self::STATUS_FAILED;
                 $this->status($status);
                 return false;
             }
 
-            $cmd = "$method $request HTTP/1.1\r\nHost: ".$this->_host."\r\n";
+            $cmd = Str::make($method)
+                ->append(' ')
+                ->append($request())
+                ->append(' HTTP/1.1')
+                ->append("\r\nHost: ")
+                ->append($this->_host)
+                ->append("\r\n")
+                ->val();
 
             $this->perform([State::RECEIVING, State::PROCESSING, State::BUSY]);
             fputs($socket, $cmd);
+            $response = Str::make();
 
             while (!feof($socket)) {
                 $chunk = fgets($socket, 1024);
@@ -198,8 +208,9 @@ class Socket extends Connection implements IConfigurable
 
                 $this->dispatch(Event::RECEIVED, new Meta(when: Action::RECEIVE, data: $chunk));
 
-                $this->_result .= $chunk;
+                $response->append($chunk);
             }
+            $this->_result = $response->val();
             $this->halt([State::BUSY, State::RECEIVING, State::PROCESSING]);
 
             $status = $this->_result ? self::STATUS_SUCCESS : self::STATUS_FAILED;

--- a/src/Connections/Stdio.php
+++ b/src/Connections/Stdio.php
@@ -142,10 +142,11 @@ class Stdio extends Connection implements IConfigurable
     {
         $this->close();
 
-        $this->_connection;
+        $target = $this->config('target');
+        $output = $this->config('output');
         $this->_connection = [
-            'in' => $this->config('target') ? fopen($this->config('target'), 'r') : (defined('STDIN') ? STDIN : fopen('php://input', 'r')),
-            'out' => $this->config('output') ? fopen($this->config('output'), 'w') : (defined('STDOUT') ? STDOUT : fopen('php://output', 'w'))
+            'in' => Str::isNotEmpty($target) ? fopen($target, 'r') : (defined('STDIN') ? STDIN : fopen('php://input', 'r')),
+            'out' => Str::isNotEmpty($output) ? fopen($output, 'w') : (defined('STDOUT') ? STDOUT : fopen('php://output', 'w'))
         ];
 
         $status = $this->_connection['in'] && $this->_connection['out'] ? self::STATUS_CONNECTED : self::STATUS_NOTCONNECTED;
@@ -181,7 +182,7 @@ class Stdio extends Connection implements IConfigurable
 
         $numChangedStreams = @stream_select($readStreams, $writeStreams, $exceptStreams, $timeout);
 
-        $this->_result = '';
+        $result = Str::make();
 
         if ($numChangedStreams === false) {
             // Error occurred during stream_select
@@ -193,7 +194,7 @@ class Stdio extends Connection implements IConfigurable
             $data = fgets($this->_connection['in']);
 
             if ($data !== false) {
-                $this->_result .= $data;
+                $result->append($data);
                 $this->dispatch(Event::RECEIVED, new Meta(data: $data)); // Emit success with data
                 $captured = true;
             } else {
@@ -202,6 +203,7 @@ class Stdio extends Connection implements IConfigurable
                 $this->perform(Event::ERROR, new Meta(when: Action::PROCESS, info: $error));
             }
         }
+        $this->_result = $result->val();
 
         // $this->halt(State::BUSY);
     }
@@ -233,10 +235,10 @@ class Stdio extends Connection implements IConfigurable
      */
     protected function _close(): void
     {
-        if (isset($this->_connection['in']) && is_resource($this->_connection['in'])) {
+        if (Arr::is($this->_connection) && Arr::hasKey($this->_connection, 'in') && is_resource($this->_connection['in'])) {
             fclose($this->_connection['in']);
         }
-        if (isset($this->_connection['out']) && is_resource($this->_connection['out'])) {
+        if (Arr::is($this->_connection) && Arr::hasKey($this->_connection, 'out') && is_resource($this->_connection['out'])) {
             fclose($this->_connection['out']);
         }
         $this->perform(Event::DISCONNECTED); // Signal that the stream has been unloaded

--- a/src/Connections/Stream.php
+++ b/src/Connections/Stream.php
@@ -64,7 +64,7 @@ class Stream extends Connection implements IConfigurable
 
         $target = $this->config('target') ?? HTTP::domain();
         $method = $this->config('method');
-        $header = $this->config('header');
+        $header = Str::make($this->config('header') ?? '');
         $wrapper = $this->config('wrapper');
         $timeout = (float)$this->config('timeout');
         $protocolVersion = (float)$this->config('protocol_version');
@@ -76,8 +76,8 @@ class Stream extends Connection implements IConfigurable
             return;
         }
 
-        if (!Str::has(Str::lower($header), 'connection: close')) {
-            $header .= "Connection: close\r\n";
+        if (!$header->copy()->lower()->has('connection: close')) {
+            $header->append("Connection: close\r\n");
         }
 
         // Check if target URL exists
@@ -86,7 +86,7 @@ class Stream extends Connection implements IConfigurable
             // Create a stream context with the options provided in the config
             $options = [
                 $wrapper => [
-                    'header'	=>	$header,
+                    'header'	=>	$header->val(),
                     'method'	=>	$method,
                     'timeout'   =>  $timeout,
                     'protocol_version' => $protocolVersion,
@@ -146,13 +146,14 @@ class Stream extends Connection implements IConfigurable
                 if (Arr::isAssoc($query)) {
                     $this->assign($query);
                 } elseif (Str::is($query)) {
-                    $data = urlencode($query);
+                    $data = Str::make(urlencode($query))->val();
                 }
             }
 
             $data = $data ?? HTTP::query($this->_data);
+            $payload = Str::make($data);
 
-            if (!Val::isEmpty($data) || Arr::size($data) > 0) {
+            if ($payload->isNotEmpty()) {
                 $this->perform([Action::SEND, State::SENDING], new Meta(when: Action::PROCESS, data: $data));
             }
 
@@ -166,6 +167,7 @@ class Stream extends Connection implements IConfigurable
             if ($this->_handle) {
                 stream_set_timeout($this->_handle, $timeout);
                 $this->perform([Action::RECEIVE, State::RECEIVING, State::PROCESSING, State::BUSY]);
+                $response = Str::make();
                 while (!feof($this->_handle)) {
                     $chunk = fread($this->_handle, 8192);
                     $meta = stream_get_meta_data($this->_handle);
@@ -177,8 +179,9 @@ class Stream extends Connection implements IConfigurable
 
                     $this->dispatch(Event::RECEIVED, new Meta(when: Action::RECEIVE, data: $chunk));
 
-                    $this->_result .= $chunk;
+                    $response->append($chunk);
                 }
+                $this->_result = $response->val();
                 $this->halt([State::BUSY, State::RECEIVING, State::PROCESSING]);
             } else {
                 $this->perform(Event::ERROR, new Meta(when: Action::RECEIVE, info: "Failed to open stream"));

--- a/src/System/Machine.php
+++ b/src/System/Machine.php
@@ -132,7 +132,7 @@ class Machine {
             $response = (string)$this->_system->response();
 
             //extract the numerical value from the response
-            $cpuUsage = Str::replacePattern("/[^0-9]/", "", $response);
+            $cpuUsage = Str::replacePattern($response, "/[^0-9]/", "");
 
             if ($cpuUsage === null || $cpuUsage === '') {
                 return 0.0;

--- a/tests/Connections/CurlHelperTest.php
+++ b/tests/Connections/CurlHelperTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BlueFission\Tests\Connections;
+
+use BlueFission\Connections\Curl;
+use PHPUnit\Framework\TestCase;
+
+class CurlHelperProbe extends Curl
+{
+    public function headers($headers): array
+    {
+        return $this->normalizeHeaders($headers);
+    }
+
+    public function jsonHeaders(array $headers, string $payload): array
+    {
+        return $this->jsonPayloadHeaders($headers, $payload);
+    }
+}
+
+class CurlHelperTest extends TestCase
+{
+    public function testNormalizeHeadersCastsAssociativeValues(): void
+    {
+        $curl = new CurlHelperProbe();
+
+        $headers = $curl->headers([
+            'Accept' => ['application/json', 'text/plain'],
+            'X-Test' => 'one',
+        ]);
+
+        $this->assertSame([
+            'Accept: application/json, text/plain',
+            'X-Test: one',
+        ], $headers);
+    }
+
+    public function testJsonPayloadHeadersPreserveExistingCaseInsensitiveHeaders(): void
+    {
+        $curl = new CurlHelperProbe();
+
+        $headers = $curl->jsonHeaders([
+            'content-type: application/vnd.api+json',
+            'ACCEPT: application/json',
+            'Content-Length: 12',
+        ], 'hello');
+
+        $this->assertSame([
+            'content-type: application/vnd.api+json',
+            'ACCEPT: application/json',
+            'Content-Length: 12',
+        ], $headers);
+    }
+
+    public function testJsonPayloadHeadersFillMissingDefaults(): void
+    {
+        $curl = new CurlHelperProbe();
+
+        $headers = $curl->jsonHeaders(['X-Test: one'], 'hello');
+
+        $this->assertContains('Content-Type: application/json', $headers);
+        $this->assertContains('Accept: application/json', $headers);
+        $this->assertContains('Content-Length: 5', $headers);
+    }
+}


### PR DESCRIPTION
## Intent summary

Refine the connection utilities so request setup, header normalization, streamed response assembly, and direct file input handling use DevElation primitives and data helpers through the method lifecycle.

This also carries the current `Machine::getCPUUsage()` helper-call fix so the branch validates cleanly from the current base.

## User stories / acceptance criteria

- As a maintainer, I can read connection setup code and see request/header/list/string state managed by DevElation helpers instead of loose native operations.
- As a consumer, existing Curl, IO, Socket, Stream, and Stdio behavior remains compatible.
- As a contributor, Curl header normalization has direct unit coverage without requiring network access.
- As a maintainer, the full test suite passes from this branch.

## Key files changed

- `src/Connections/Curl.php`
- `src/Connections/IO.php`
- `src/Connections/Socket.php`
- `src/Connections/Stdio.php`
- `src/Connections/Stream.php`
- `src/System/Machine.php`
- `tests/Connections/CurlHelperTest.php`

## How to test

```bash
php -l src/Connections/IO.php
php -l src/Connections/Curl.php
php -l src/Connections/Socket.php
php -l src/Connections/Stream.php
php -l src/Connections/Stdio.php
php -l src/System/Machine.php
php -l tests/Connections/CurlHelperTest.php
vendor/bin/phpunit --do-not-cache-result tests/Connections/CurlHelperTest.php
vendor/bin/phpunit --do-not-cache-result tests/Connections/IOTest.php tests/Connections/StreamTest.php tests/Connections/StdioTest.php
vendor/bin/phpunit --do-not-cache-result tests/Connections
vendor/bin/phpunit --do-not-cache-result tests/System/MachineTest.php
composer validate --strict
git diff --check
vendor/bin/phpunit --do-not-cache-result --no-progress
```

## QA checklist

- [x] Connection file lint checks pass.
- [x] Focused Curl helper tests pass.
- [x] Connections suite passes with expected optional skips.
- [x] Machine CPU usage regression test passes.
- [x] Composer validation passes.
- [x] Whitespace check passes.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm the connection helper style is consistent with the current first-class primitive direction.
- Confirm carrying the one-line Machine validation fix in this slice is acceptable while adjacent branches are under review.
