### PR TITLE
Tighten data tail lifecycles

### DIFF
--- a/src/Data/Datasource/Datasource.php
+++ b/src/Data/Datasource/Datasource.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Data\Datasource;
 
 use BlueFission\Num;
+use BlueFission\Arr;
 use BlueFission\IObj;
 use BlueFission\Data\Data;
 use BlueFission\Data\IData;
@@ -39,8 +40,9 @@ class Datasource extends Data implements IData
      */
     public function __construct($config = null)
     {
-        parent::__construct($config = null);
-        $_index = -1;
+        parent::__construct($config);
+        $this->_index = -1;
+        $this->_collection = [];
     }
 
     /**
@@ -84,8 +86,12 @@ class Datasource extends Data implements IData
      *
      * @return string
      */
-    public function contents()
+    public function contents($data = null): mixed
     {
+        if ($data !== null) {
+            return $this->assign($data);
+        }
+
         return serialize($this->_data);
     }
 
@@ -112,7 +118,7 @@ class Datasource extends Data implements IData
     private function inbounds($index = null)
     {
         $index = Num::isValid($index) ? $index : $this->_index;
-        return ($index <= count($this->_collection) && $index >= 0);
+        return ($index <= Arr::count($this->_collection) && $index >= 0);
     }
 
     /**

--- a/src/Data/Log.php
+++ b/src/Data/Log.php
@@ -3,6 +3,8 @@
 namespace BlueFission\Data;
 
 use BlueFission\Arr;
+use BlueFission\Date;
+use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\IObj;
 use BlueFission\Data\FileSystem;
@@ -63,7 +65,7 @@ class Log extends Data implements iData
     public function __construct($config = null)
     {
         parent::__construct();
-        if (is_array($config)) {
+        if (Arr::is($config)) {
             $this->config($config);
         }
 
@@ -94,7 +96,7 @@ class Log extends Data implements iData
      */
     public function push($message): IObj
     {
-        $time = date('Y-m-d G:i:s');
+        $time = Date::now()->formatTimestamp('Y-m-d G:i:s');
         $this->field($time, $message);
         if ($this->config('instant')) {
             $this->write();
@@ -220,11 +222,15 @@ class Log extends Data implements iData
             ->filter(fn ($line) => Val::isNotEmpty($line))
             ->val();
 
-        $output = '';
+        $output = Str::make();
         foreach ($message as $time => $line) {
-            $output .= "{$time} - {$line}\n";
+            $output
+                ->append($time)
+                ->append(' - ')
+                ->append($line)
+                ->append("\n");
         }
-        return $output;
+        return $output->val();
     }
 
     /**

--- a/src/System/Machine.php
+++ b/src/System/Machine.php
@@ -132,7 +132,7 @@ class Machine {
             $response = (string)$this->_system->response();
 
             //extract the numerical value from the response
-            $cpuUsage = Str::replacePattern("/[^0-9]/", "", $response);
+            $cpuUsage = Str::replacePattern($response, "/[^0-9]/", "");
 
             if ($cpuUsage === null || $cpuUsage === '') {
                 return 0.0;

--- a/tests/Data/DatasourceTest.php
+++ b/tests/Data/DatasourceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BlueFission\Tests\Data;
+
+use BlueFission\Data\Datasource\Datasource;
+use PHPUnit\Framework\TestCase;
+
+class ConfiguredDatasourceProbe extends Datasource
+{
+    protected $_config = [
+        'name' => '',
+    ];
+}
+
+class DatasourceTest extends TestCase
+{
+    public function testConstructorKeepsConfigAndInitializesIndex(): void
+    {
+        $source = new ConfiguredDatasourceProbe(['name' => 'records']);
+
+        $this->assertSame('records', $source->config('name'));
+        $this->assertSame(-1, $source->index());
+    }
+}


### PR DESCRIPTION
## Intent summary

Tighten the remaining lightweight Data lifecycle surface by preserving Datasource constructor config, initializing Datasource state predictably, matching the parent `contents()` signature, and moving Log timestamp/message construction into DevElation helpers.

This also carries the current `Machine::getCPUUsage()` helper-call fix so the branch validates cleanly from the current base.

## User stories / acceptance criteria

- As a maintainer, Datasource construction should preserve declared config values and initialize its cursor/collection state.
- As a contributor, Datasource should load without signature mismatches against `Data::contents()`.
- As a maintainer, Log should use DevElation helpers for config checks, timestamps, and message string construction.
- As a contributor, focused Data coverage should protect the repaired Datasource constructor path.

## Key files changed

- `src/Data/Datasource/Datasource.php`
- `src/Data/Log.php`
- `src/System/Machine.php`
- `tests/Data/DatasourceTest.php`

## How to test

```bash
php -l src/Data/Datasource/Datasource.php
php -l src/Data/Log.php
php -l src/System/Machine.php
php -l tests/Data/DatasourceTest.php
vendor/bin/phpunit --do-not-cache-result tests/Data/DatasourceTest.php tests/Data/LogTest.php tests/Collections
vendor/bin/phpunit --do-not-cache-result tests/Data tests/System/MachineTest.php
composer validate --strict
git diff --check
vendor/bin/phpunit --do-not-cache-result --no-progress
```

## QA checklist

- [x] Touched source and test files lint cleanly.
- [x] Focused Datasource, Log, and Collection-adjacent tests pass.
- [x] Full Data suite passes with expected optional skips.
- [x] Machine CPU usage regression test passes.
- [x] Composer validation passes.
- [x] Whitespace check passes.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm Datasource should keep declared config values through construction.
- Confirm Log helper usage matches the current first-class primitive direction.
- Confirm carrying the one-line Machine validation fix in this slice is acceptable while adjacent branches are under review.
