### PR TITLE
Polish CLI args parsing helpers

### DIFF
--- a/src/Cli/Args.php
+++ b/src/Cli/Args.php
@@ -97,7 +97,7 @@ class Args extends Obj
         while ($index < $count) {
             $arg = $argv[$index];
             if ($arg === '--') {
-                $positionals->merge(array_slice($argv, $index + 1));
+                $positionals->merge(Arr::make($argv)->slice($index + 1)->val());
                 break;
             }
 
@@ -217,15 +217,16 @@ class Args extends Obj
         $raw = $arg;
 
         $eqPos = Str::pos($arg, '=');
+        $argument = Str::make($arg);
         if ($eqPos !== false) {
-            $name = substr($arg, 2, $eqPos - 2);
-            $value = substr($arg, $eqPos + 1);
+            $name = $argument->sub(2, $eqPos - 2);
+            $value = $argument->sub($eqPos + 1);
         } else {
-            $name = substr($arg, 2);
+            $name = $argument->sub(2);
         }
 
         if (Str::pos($name, 'no-') === 0) {
-            $candidate = substr($name, 3);
+            $candidate = Str::make($name)->sub(3);
             if (isset($map['long'][$candidate])) {
                 return [$map['long'][$candidate]->name(), false];
             }
@@ -253,7 +254,7 @@ class Args extends Obj
 
     protected function parseShortOption(string $arg, array $argv, int &$index, array $map): ?array
     {
-        $chunk = substr($arg, 1);
+        $chunk = Str::make($arg)->sub(1);
         $results = [];
         $letters = Str::make($chunk)->splitBy('//', -1, PREG_SPLIT_NO_EMPTY)->val();
 
@@ -303,7 +304,7 @@ class Args extends Obj
             return $results;
         }
 
-        $value = implode('', $letters);
+        $value = Arr::make($letters)->join('')->val();
         if ($value === '' && $this->requiresValue($definition)) {
             $next = $argv[$index + 1] ?? null;
             if ($next !== null && Str::pos($next, '-') !== 0) {

--- a/src/System/Machine.php
+++ b/src/System/Machine.php
@@ -132,7 +132,7 @@ class Machine {
             $response = (string)$this->_system->response();
 
             //extract the numerical value from the response
-            $cpuUsage = Str::replacePattern("/[^0-9]/", "", $response);
+            $cpuUsage = Str::replacePattern($response, "/[^0-9]/", "");
 
             if ($cpuUsage === null || $cpuUsage === '') {
                 return 0.0;


### PR DESCRIPTION
## Intent summary

Polish the remaining CLI Args parser tail so option slicing, positional remainder handling, and compact short-option value joining use DevElation `Str` and `Arr` helpers.

This also carries the current `Machine::getCPUUsage()` helper-call fix so the branch validates cleanly from the current base.

## User stories / acceptance criteria

- As a maintainer, CLI argument parsing should use the same first-class helper patterns as the rest of the CLI layer.
- As a consumer, long options, negated boolean options, short option clusters, and `--` positional passthrough behavior remain compatible.
- As a contributor, the full CLI suite and full project suite pass from this branch.

## Key files changed

- `src/Cli/Args.php`
- `src/System/Machine.php`

## How to test

```bash
php -l src/Cli/Args.php
php -l src/System/Machine.php
vendor/bin/phpunit --do-not-cache-result tests/Cli/ArgsTest.php tests/System/MachineTest.php
vendor/bin/phpunit --do-not-cache-result tests/Cli
composer validate --strict
git diff --check
vendor/bin/phpunit --do-not-cache-result --no-progress
```

## QA checklist

- [x] Touched files lint cleanly.
- [x] Focused CLI Args and Machine tests pass.
- [x] Full CLI suite passes.
- [x] Composer validation passes.
- [x] Whitespace check passes.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm CLI Args parser behavior remains compatible.
- Confirm this small parser tail cleanup matches the current first-class primitive direction.
- Confirm carrying the one-line Machine validation fix in this slice is acceptable while adjacent branches are under review.
