### PR TITLE
Refine system process helper lifecycles

### DIFF
--- a/src/System/CommandLocator.php
+++ b/src/System/CommandLocator.php
@@ -4,6 +4,7 @@ namespace BlueFission\System;
 
 use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
+use BlueFission\Flag;
 use BlueFission\Str;
 use BlueFission\DevElation as Dev;
 
@@ -21,50 +22,53 @@ class CommandLocator
             'use_shell' => true,
             'cache' => true,
         ], $options);
+        $options = Arr::make($options);
 
         $command = Str::trim((string)$command);
         if ($command === '') {
             return null;
         }
 
-        if (!empty($options['cache']) && Arr::hasKey(self::$_cache, $command)) {
+        if (self::optionEnabled($options, 'cache', true) && Arr::hasKey(self::$_cache, $command)) {
             return self::$_cache[$command];
         }
 
         if (self::isAbsolutePath($command)) {
             $resolved = self::resolvePath($command);
-            return self::remember($command, $resolved, $options);
+            return self::remember($command, $resolved, $options->val());
         }
 
         $paths = Arr::toArray($options['paths'] ?? []);
         $envPath = $options['env_path'] ?? null;
-        if (!Str::is($envPath) || Str::trim((string)$envPath) === '') {
+        if (!Str::is($envPath) || Str::make((string)$envPath)->trim()->isEmpty()) {
             $envPath = getenv('PATH') ?: '';
         }
 
-        $searchPaths = Arr::merge($paths, Str::make((string)$envPath)->split(PATH_SEPARATOR)->val());
+        $searchPaths = Arr::make($paths)
+            ->merge(Str::make((string)$envPath)->split(PATH_SEPARATOR))
+            ->val();
         $extensions = self::extensions();
         $hasExtension = self::hasExtension($command);
 
         foreach ($searchPaths as $path) {
-            $path = Str::trim((string)$path);
-            if ($path === '') {
+            $path = Str::make((string)$path)->trim();
+            if ($path->isEmpty()) {
                 continue;
             }
 
-            $candidateBase = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $command;
+            $candidateBase = $path->trim(DIRECTORY_SEPARATOR)->append(DIRECTORY_SEPARATOR)->append($command)->val();
             $result = self::matchExecutable($candidateBase, $extensions, $hasExtension);
             if ($result) {
-                return self::remember($command, $result, $options);
+                return self::remember($command, $result, $options->val());
             }
         }
 
-        if (!empty($options['use_shell'])) {
+        if (self::optionEnabled($options, 'use_shell', true)) {
             $result = self::shellLocate($command);
-            return self::remember($command, $result, $options);
+            return self::remember($command, $result, $options->val());
         }
 
-        return self::remember($command, null, $options);
+        return self::remember($command, null, $options->val());
     }
 
     public static function isWindows(): bool
@@ -75,7 +79,7 @@ class CommandLocator
     protected static function remember(string $command, ?string $value, array $options): ?string
     {
         $value = Dev::apply('_out', $value);
-        if (!empty($options['cache'])) {
+        if (self::optionEnabled(Arr::make($options), 'cache', true)) {
             self::$_cache[$command] = $value;
         }
 
@@ -103,7 +107,7 @@ class CommandLocator
         }
 
         if (self::isWindows()) {
-            if (preg_match('/^[A-Za-z]:\\\\/', $command)) {
+            if (Str::matchPattern($command, '/^[A-Za-z]:\\\\/')) {
                 return true;
             }
 
@@ -121,20 +125,20 @@ class CommandLocator
 
         $pathext = getenv('PATHEXT') ?: '.EXE;.BAT;.CMD;.COM';
         $extensions = Str::make($pathext)->split(';')->val();
-        $normalized = [];
+        $normalized = Arr::make();
 
         foreach ($extensions as $ext) {
-            $ext = Str::trim((string)$ext);
-            if ($ext === '') {
+            $ext = Str::make((string)$ext)->trim();
+            if ($ext->isEmpty()) {
                 continue;
             }
-            if (Str::sub($ext, 0, 1) !== '.') {
-                $ext = '.' . $ext;
+            if (!$ext->startsWith('.')) {
+                $ext->prepend('.');
             }
-            $normalized[] = $ext;
+            $normalized[] = $ext->val();
         }
 
-        return $normalized;
+        return $normalized->val();
     }
 
     protected static function hasExtension(string $command): bool
@@ -145,7 +149,7 @@ class CommandLocator
 
     protected static function matchExecutable(string $candidateBase, array $extensions, bool $hasExtension): ?string
     {
-        if ($hasExtension || count($extensions) === 0) {
+        if ($hasExtension || Arr::count($extensions) === 0) {
             return self::resolvePath($candidateBase);
         }
 
@@ -172,7 +176,7 @@ class CommandLocator
             }
         }
 
-        if (!$output) {
+        if (Str::isEmpty($output)) {
             return null;
         }
 
@@ -189,5 +193,14 @@ class CommandLocator
         }
 
         return null;
+    }
+
+    protected static function optionEnabled(Arr $options, string $key, bool $default = false): bool
+    {
+        if (!$options->hasKey($key)) {
+            return $default;
+        }
+
+        return Flag::parseBool($options[$key], $default);
     }
 }

--- a/src/System/CommandLocator.php
+++ b/src/System/CommandLocator.php
@@ -56,7 +56,7 @@ class CommandLocator
                 continue;
             }
 
-            $candidateBase = $path->trim(DIRECTORY_SEPARATOR)->append(DIRECTORY_SEPARATOR)->append($command)->val();
+            $candidateBase = rtrim($path->val(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $command;
             $result = self::matchExecutable($candidateBase, $extensions, $hasExtension);
             if ($result) {
                 return self::remember($command, $result, $options->val());

--- a/src/System/Process.php
+++ b/src/System/Process.php
@@ -9,6 +9,7 @@ use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\State;
 use BlueFission\Behavioral\Behaviors\Action;
 use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\Connections\Stdio;
 use BlueFission\Data\FileSystem;
 use BlueFission\Flag;
 use BlueFission\Str;
@@ -205,7 +206,7 @@ class Process implements IDispatcher
         if ($this->_windowsSafeMode && $this->_stdoutFile && FileSystem::fileExists($this->_stdoutFile)) {
             $this->_output = (string)FileSystem::fileContents($this->_stdoutFile);
         } else {
-            $this->_output = Arr::hasKey($this->_pipes, 1) ? stream_get_contents($this->_pipes[1]) : '';
+            $this->_output = Arr::hasKey($this->_pipes, 1) ? Stdio::readInput($this->_pipes[1]) : '';
         }
         $this->trigger(Event::READ);
 

--- a/src/System/Process.php
+++ b/src/System/Process.php
@@ -2,12 +2,16 @@
 
 namespace BlueFission\System;
 
+use BlueFission\Arr;
 use BlueFission\Behavioral\Dispatches;
 use BlueFission\Behavioral\IDispatcher;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Behavioral\Behaviors\State;
 use BlueFission\Behavioral\Behaviors\Action;
 use BlueFission\Behavioral\Behaviors\Meta;
+use BlueFission\Data\FileSystem;
+use BlueFission\Flag;
+use BlueFission\Str;
 
 /**
  * Class Process is a wrapper class for the PHP proc_open function
@@ -126,13 +130,14 @@ class Process implements IDispatcher
     public function __construct($command, $cwd = null, $env = null, $descriptorspec = null, $options = [])
     {
         $this->__dConstruct();
+        $options = Arr::make($options);
         $this->_command = $command;
         $this->_cwd = $cwd ?? getcwd();
         $this->_env = $env;
         $this->_descriptorspec = $descriptorspec ?? $this->_spec;
-        $this->_options = $options;
+        $this->_options = $options->val();
         $windowsSafe = $options['windows_safe'] ?? $options['windowsSafe'] ?? false;
-        $this->_windowsSafeMode = $this->isWindows() && (bool)$windowsSafe;
+        $this->_windowsSafeMode = $this->isWindows() && Flag::parseBool($windowsSafe, false);
 
         $this->trigger(Event::LOAD);
     }
@@ -167,10 +172,10 @@ class Process implements IDispatcher
         if (is_resource($this->_process)) {
             $this->trigger(Event::STARTED);
             // Make the streams non-blocking
-            if (isset($this->_pipes[1]) && is_resource($this->_pipes[1])) {
+            if (Arr::hasKey($this->_pipes, 1) && is_resource($this->_pipes[1])) {
                 stream_set_blocking($this->_pipes[1], false);
             }
-            if (isset($this->_pipes[2]) && is_resource($this->_pipes[2])) {
+            if (Arr::hasKey($this->_pipes, 2) && is_resource($this->_pipes[2])) {
                 stream_set_blocking($this->_pipes[2], false);
             }
             $this->trigger(Event::CONNECTED);
@@ -197,10 +202,10 @@ class Process implements IDispatcher
     {
         $this->trigger(Action::READ);
         $this->trigger(State::READING);
-        if ($this->_windowsSafeMode && $this->_stdoutFile && file_exists($this->_stdoutFile)) {
-            $this->_output = (string)file_get_contents($this->_stdoutFile);
+        if ($this->_windowsSafeMode && $this->_stdoutFile && FileSystem::fileExists($this->_stdoutFile)) {
+            $this->_output = (string)FileSystem::fileContents($this->_stdoutFile);
         } else {
-            $this->_output = isset($this->_pipes[1]) ? stream_get_contents($this->_pipes[1]) : '';
+            $this->_output = Arr::hasKey($this->_pipes, 1) ? stream_get_contents($this->_pipes[1]) : '';
         }
         $this->trigger(Event::READ);
 
@@ -218,10 +223,10 @@ class Process implements IDispatcher
         if ($this->_status) {
             return $this->_status['running'];
         } else {
-            if ($this->_windowsSafeMode && $this->_stderrFile && file_exists($this->_stderrFile)) {
-                return (string)file_get_contents($this->_stderrFile);
+            if ($this->_windowsSafeMode && $this->_stderrFile && FileSystem::fileExists($this->_stderrFile)) {
+                return (string)FileSystem::fileContents($this->_stderrFile);
             }
-            return fread($this->_pipes[2], 2096);
+            return Arr::hasKey($this->_pipes, 2) ? fread($this->_pipes[2], 2096) : '';
         }
     }
 
@@ -268,7 +273,7 @@ class Process implements IDispatcher
      */
     protected function isWindows(): bool
     {
-        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+        return Str::make(PHP_OS)->upper()->startsWith('WIN');
     }
 
     /**
@@ -289,10 +294,10 @@ class Process implements IDispatcher
      */
     protected function cleanupWindowsSafeCapture(): void
     {
-        if ($this->_stdoutFile && file_exists($this->_stdoutFile)) {
+        if ($this->_stdoutFile && FileSystem::fileExists($this->_stdoutFile)) {
             @unlink($this->_stdoutFile);
         }
-        if ($this->_stderrFile && file_exists($this->_stderrFile)) {
+        if ($this->_stderrFile && FileSystem::fileExists($this->_stderrFile)) {
             @unlink($this->_stderrFile);
         }
 

--- a/tests/System/CommandLocatorTest.php
+++ b/tests/System/CommandLocatorTest.php
@@ -33,4 +33,30 @@ class CommandLocatorTest extends TestCase
             'use_shell' => false,
         ]));
     }
+
+    public function testFindPreservesAbsoluteSearchPathRoots()
+    {
+        $directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('command-locator-dir-', true);
+        $command = 'bf-command-locator.test';
+        $file = $directory . DIRECTORY_SEPARATOR . $command;
+
+        mkdir($directory);
+        file_put_contents($file, 'test');
+
+        try {
+            $this->assertSame(realpath($file), CommandLocator::find($command, [
+                'paths' => [$directory],
+                'env_path' => '',
+                'cache' => false,
+                'use_shell' => false,
+            ]));
+        } finally {
+            if (FileSystem::fileExists($file)) {
+                unlink($file);
+            }
+            if (is_dir($directory)) {
+                rmdir($directory);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Intent summary

Continue issue #154 by bringing the System process helpers into the first-class DevElation lifecycle pattern without changing their public behavior.

## User stories / acceptance criteria

- As a maintainer, I can read `CommandLocator` option, path, and shell lookup handling through DevElation primitives and filters.
- As a maintainer, I can read `Process` option, keyed pipe, OS, and file capture handling through local helper APIs where those helpers add consistency.
- Existing process start/output/status behavior remains compatible.
- Native PHP process/resource calls remain native where wrapping them would obscure the platform contract.

## Key files changed

- `src/System/CommandLocator.php`
- `src/System/Process.php`

## How to test

- `php -l src\System\CommandLocator.php`
- `php -l src\System\Process.php`
- `vendor\bin\phpunit.bat --do-not-cache-result tests\System\CommandLocatorTest.php tests\System\ProcessTest.php tests\System\SystemTest.php tests\System\MachineTest.php`
- `composer validate --strict`
- `git diff --check`
- `vendor\bin\phpunit.bat --do-not-cache-result --no-progress`

## QA checklist

- [x] Focused System tests pass.
- [x] Composer metadata validates strictly.
- [x] Whitespace check passes.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm the helper usage improves lifecycle consistency without making process/resource semantics harder to follow.
- Confirm no downstream-specific compatibility framing is introduced.
