### PR TITLE
Refine utils security helper lifecycles

### DIFF
--- a/src/Security/Hash.php
+++ b/src/Security/Hash.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Security;
 
 use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
 use BlueFission\Flag;
 use BlueFission\IVal;
 use BlueFission\Net\HTTP;
@@ -186,7 +187,7 @@ class Hash extends Obj
         $this->clearErrors();
         $this->perform(new Action(Action::PROCESS), new Meta(data: ['algo' => $algo, 'file' => $path]));
 
-        if (!is_file($path)) {
+        if (!FileSystem::fileExists($path)) {
             $this->addError('file', 'file_not_found');
             $this->perform(Event::FAILURE, new Meta(data: $this->errors()));
             Dev::do('_after', [$this]);

--- a/src/Utils/Mem.php
+++ b/src/Utils/Mem.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Utils;
 
+use BlueFission\Arr;
 use BlueFission\Data\Storage\Storage;
 use BlueFission\Behavioral\Behavioral;
 use BlueFission\Behavioral\Behaviors\State;
@@ -53,7 +54,7 @@ class Mem
 
     public static function unregister($id)
     {
-        if (isset(self::$pool[$id])) {
+        if (Arr::hasKey(self::$pool, $id)) {
             unset(self::$pool[$id]);
             unset(self::$audit[$id]);
         }
@@ -66,7 +67,7 @@ class Mem
 
     public static function get($id)
     {
-        if (isset(self::$pool[$id]) && self::$pool[$id] !== self::SLEEPING) {
+        if (Arr::hasKey(self::$pool, $id) && self::$pool[$id] !== self::SLEEPING) {
             self::$audit[$id]['used'] = true;
             return self::$pool[$id];
         }
@@ -110,7 +111,7 @@ class Mem
 
     public static function wakeup($id)
     {
-        if (isset(self::$pool[$id]) && self::$pool[$id] === self::SLEEPING) {
+        if (Arr::hasKey(self::$pool, $id) && self::$pool[$id] === self::SLEEPING) {
             // Assume stored data is serialized
             self::$pool[$id] = self::retrieve($id);
             Dev::do(null, [self::$pool[$id]]);
@@ -120,7 +121,7 @@ class Mem
 
     public static function sleep($id)
     {
-        if (isset(self::$pool[$id]) && self::$pool[$id] !== self::SLEEPING) {
+        if (Arr::hasKey(self::$pool, $id) && self::$pool[$id] !== self::SLEEPING) {
             Dev::do(null, [self::$pool[$id]]);
 
             if (self::$storage) {

--- a/src/Utils/Util.php
+++ b/src/Utils/Util.php
@@ -7,6 +7,7 @@ use BlueFission\Val;
 use BlueFission\Net\Email;
 use BlueFission\Net\HTTP;
 use BlueFission\Data\Storage\Disk;
+use BlueFission\Data\FileSystem;
 use BlueFission\Security\Hash;
 
 class Util {
@@ -57,7 +58,7 @@ class Util {
     static function globals($var, $value = null)
     {
         if (Val::isNull($value) )
-            return isset( $GLOBALS[$var] ) ? $GLOBALS[$var] : null;
+            return Arr::hasKey($GLOBALS, $var) ? $GLOBALS[$var] : null;
             
         $GLOBALS[$var] = $value;
             
@@ -70,7 +71,7 @@ class Util {
     static function getStoragePath() {
         // Use an environment variable or fallback to a default path
         $storagePath = getenv('STORAGE_PATH') ?: __DIR__ . '/storage/data';
-        if (!is_dir($storagePath)) {
+        if (!FileSystem::directoryExists($storagePath)) {
             mkdir($storagePath, 0777, true);
         }
         return $storagePath;
@@ -81,9 +82,9 @@ class Util {
         try {
             $userHome = self::getUserHomeDir();
             $sessionIdFile = $userHome . DIRECTORY_SEPARATOR . '.cli_session_id';
-            if (file_exists($sessionIdFile)) {
+            if (FileSystem::fileExists($sessionIdFile)) {
                 // Retrieve existing session ID
-                $sessionId = file_get_contents($sessionIdFile);
+                $sessionId = FileSystem::fileContents($sessionIdFile);
             } else {
                 // Generate a new session ID
                 $sessionId = bin2hex(random_bytes(16)); // Generate a random session ID
@@ -153,7 +154,8 @@ class Util {
 
             if ($value === null) {
                 // Return the value if $value is null
-                return isset($storedData[$name]) ? $storedData[$name] : null;
+                $storedData = Arr::make($storedData);
+                return $storedData->hasKey($name) ? $storedData[$name] : null;
             }
 
             $storedData[$name] = $value;


### PR DESCRIPTION
## Intent summary

Continue issue #154 by tightening Security and Utils internals around existing DevElation helpers for file checks and keyed state access.

## User stories / acceptance criteria

- As a maintainer, checksum file validation uses the package `FileSystem` helper rather than a raw file primitive.
- As a maintainer, CLI storage/session helper code uses `FileSystem` read/existence helpers where practical.
- As a maintainer, memory pool and global/stored-data lookups use `Arr::hasKey` for consistent key-existence semantics.
- Existing hashing, utility, loader, and memory behavior remains compatible.

## Key files changed

- `src/Security/Hash.php`
- `src/Utils/Util.php`
- `src/Utils/Mem.php`

## How to test

- `php -l src\Security\Hash.php`
- `php -l src\Utils\Util.php`
- `php -l src\Utils\Mem.php`
- `vendor\bin\phpunit.bat --do-not-cache-result tests\Security\HashTest.php tests\Utils\UtilTest.php tests\Utils\MemTest.php tests\Utils\LoaderTest.php`
- `composer validate --strict`
- `git diff --check`
- `vendor\bin\phpunit.bat --do-not-cache-result --no-progress`

## QA checklist

- [x] Focused Security/Utils tests pass.
- [x] Composer metadata validates strictly.
- [x] Whitespace check passes.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm the helper usage improves lifecycle consistency without broadening utility/storage scope.
- Confirm no downstream-specific compatibility framing is introduced.
