### PR TITLE
Refine service auth helper lifecycles

### DIFF
--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -10,6 +10,8 @@
 
 namespace BlueFission\Services;
 
+use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Behavioral\Behaviors\Behavior;
 use BlueFission\Behavioral\Configurable;
@@ -106,12 +108,12 @@ class Authenticator extends Service
         // $users = $this->config('users');
         // $users->
 
-        if (isset($_SERVER['REMOTE_ADDR']) && !$this->confirmIPAddress($_SERVER['REMOTE_ADDR'])) {
+        if (Arr::hasKey($_SERVER, 'REMOTE_ADDR') && !$this->confirmIPAddress($_SERVER['REMOTE_ADDR'])) {
             $this->_status[] = 'Too many failures';
             return false;
         }
 
-        if ("" == $username || "" == $password) {
+        if (Str::make((string)$username)->isEmpty() || Str::make((string)$password)->isEmpty()) {
             $this->_status[] = "Username and password required";
             return false;
         }
@@ -123,9 +125,11 @@ class Authenticator extends Service
             return false;
         }
 
-        $savedpass = $userinfo[$this->config('password_field')];
+        $userinfo = Arr::make(Arr::toArray($userinfo));
+        $passwordField = $this->config('password_field');
+        $savedpass = $userinfo->hasKey($passwordField) ? $userinfo[$passwordField] : null;
 
-        if (empty($savedpass) || !$this->verifyPassword($password, $savedpass)) {
+        if (Val::isEmpty($savedpass) || !$this->verifyPassword($password, $savedpass)) {
             $this->_status[] = "Username or password incorrect";
             return false;
         }
@@ -195,19 +199,19 @@ class Authenticator extends Service
         $last = [];
         $attempts->field('ip_address', $value);
         $attempts->read();
-        $last = $attempts->data();
+        $last = Arr::make(Arr::toArray($attempts->data()));
 
 
-        if (isset($last['last_attempt']) && strtotime($last['last_attempt']) > strtotime($this->config('lockout_interval'))) {
-            $last['attempts']++;
+        if ($last->hasKey('last_attempt') && strtotime($last['last_attempt']) > strtotime($this->config('lockout_interval'))) {
+            $attemptCount = (int)($last['attempts'] ?? 0) + 1;
         } else {
-            $last['attempts'] = 0;
+            $attemptCount = 0;
         }
         $attempts->field('last_attempt', date('Y-m-d G:i:s', strtotime('now')));
-        $attempts->field('attempts', $last['attempts']);
+        $attempts->field('attempts', $attemptCount);
         $attempts->write();
 
-        if (isset($last['attempts']) && $last['attempts'] >= $this->config('max_attempts')) {
+        if ($attemptCount >= $this->config('max_attempts')) {
             return false;
         }
         return true;
@@ -229,11 +233,11 @@ class Authenticator extends Service
         $last = [];
         $attempts->field('ip_address', $_SERVER['REMOTE_ADDR']);
         $attempts->read();
-        $last = $attempts->data();
+        $last = Arr::make(Arr::toArray($attempts->data()));
 
 
-        if (isset($last['last_attempt']) && strtotime($last['last_attempt']) > strtotime($this->config('lockout_interval'))) {
-            if (isset($last['attempts']) && $last['attempts'] >= $this->config('max_attempts')) {
+        if ($last->hasKey('last_attempt') && strtotime($last['last_attempt']) > strtotime($this->config('lockout_interval'))) {
+            if ($last->hasKey('attempts') && $last['attempts'] >= $this->config('max_attempts')) {
                 return true;
             }
         }
@@ -253,9 +257,9 @@ class Authenticator extends Service
         $last = [];
         $attempts->field('ip_address', $_SERVER['REMOTE_ADDR']);
         $attempts->read();
-        $last = $attempts->data();
+        $last = Arr::make(Arr::toArray($attempts->data()));
 
-        if (isset($last['last_attempt']) && strtotime($last['last_attempt']) > strtotime($this->config('lockout_interval'))) {
+        if ($last->hasKey('last_attempt') && strtotime($last['last_attempt']) > strtotime($this->config('lockout_interval'))) {
             $db->delete('dash_login_attempts', 'ip_address', $_SERVER['REMOTE_ADDR']);
         }
     }
@@ -293,7 +297,7 @@ class Authenticator extends Service
         $user->read();
         $dbCheck = $user->data();
 
-        if (!empty($dbCheck)) {
+        if (Val::isNotEmpty($dbCheck)) {
             return $dbCheck;
         } else {
             return false;
@@ -310,8 +314,9 @@ class Authenticator extends Service
         // $data = $this->_session->data();
         // die(var_dump($_SESSION));
 
-        if (isset($_COOKIE[$this->config('session')])) {
-            if ($this->setAuthCookie(stripslashes($_COOKIE[$this->config('session')]))) {
+        $sessionKey = $this->config('session');
+        if (Arr::hasKey($_COOKIE, $sessionKey)) {
+            if ($this->setAuthCookie(stripslashes($_COOKIE[$sessionKey]))) {
                 return true;
             } else {
                 $this->_status[] = "Could not save session";

--- a/src/Services/Credentials.php
+++ b/src/Services/Credentials.php
@@ -5,6 +5,7 @@ namespace BlueFission\Services;
 use BlueFission\Behavioral\Configurable;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Obj;
+use BlueFission\Val;
 
 class Credentials extends Obj
 {
@@ -46,9 +47,9 @@ class Credentials extends Obj
     {
         $valid = false;
 
-        if (!$this->field('username')) {
+        if (Val::isEmpty($this->field('username'))) {
             $this->status(self::FAILED_USERNAME_EMPTY);
-        } elseif (!$this->field('password')) {
+        } elseif (Val::isEmpty($this->field('password'))) {
             $this->status(self::FAILED_PASSWORD_EMPTY);
         } else {
             $valid = true;


### PR DESCRIPTION
## Intent summary

Continue issue #154 by tightening service authentication helpers around existing DevElation primitives for request, credential, and storage-state checks.

## User stories / acceptance criteria

- As a maintainer, Authenticator uses `Arr::hasKey` for request/cookie/data key checks instead of raw `isset`.
- As a maintainer, Authenticator uses `Str` and `Val` for empty credential and saved-password decisions.
- As a maintainer, Credentials validation uses `Val::isEmpty` for username/password lifecycle checks.
- Existing authentication and credentials tests continue to pass.

## Key files changed

- `src/Services/Authenticator.php`
- `src/Services/Credentials.php`

## How to test

- `php -l src\Services\Authenticator.php`
- `php -l src\Services\Credentials.php`
- `vendor\bin\phpunit.bat --do-not-cache-result tests\Services\AuthenticatorTest.php tests\Services\CredentialsTest.php`
- `vendor\bin\phpunit.bat --do-not-cache-result tests\Services`
- `composer validate --strict`
- `git diff --check`
- `vendor\bin\phpunit.bat --do-not-cache-result --no-progress`

## QA checklist

- [x] Focused auth/credentials tests pass.
- [x] Full Services suite passes.
- [x] Composer metadata validates strictly.
- [x] Whitespace check passes.
- [x] Full PHPUnit suite passes.

## Approval conditions

- Confirm the helper usage improves service lifecycle consistency without broadening authentication/session design.
- Confirm no downstream-specific compatibility framing is introduced.
