### PR TITLE
Add branding and Packagist docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+<p align="center">
+  <img src="docs/assets/develation-circle-logo.png" alt="DevElation logo" width="144">
+</p>
+
 # DevElation: A PHP Library for Graceful Development
+
+[![Packagist Version](https://img.shields.io/packagist/v/bluefission/develation.svg)](https://packagist.org/packages/bluefission/develation)
+[![Packagist Downloads](https://img.shields.io/packagist/dt/bluefission/develation.svg)](https://packagist.org/packages/bluefission/develation)
+[![License](https://img.shields.io/packagist/l/bluefission/develation.svg)](https://packagist.org/packages/bluefission/develation)
 
 Welcome to the central documentation of **DevElation**, a comprehensive PHP library designed to simplify the development of large and complex projects. This library addresses the intricacies of modern PHP development with a suite of tools that cater to a wide range of functionalities, from basic data type handling to advanced system management and beyond. It is a property of Blue Fission Technology and is currently available under the MIT license.
 
@@ -302,6 +310,8 @@ Install DevElation with Composer:
 composer require bluefission/develation
 ```
 
+The canonical package source is [bluefission/develation on Packagist](https://packagist.org/packages/bluefission/develation). Packagist resolves the package to the canonical GitHub source repository and is the recommended install path for applications and libraries.
+
 Composer autoload registers DevElation classes and the global helper function
 file. After requiring `vendor/autoload.php`, helpers such as `arr()`, `str()`,
 `obj()`, `collect()`, `datetime()`, `filesystem()`, `doc()`, and `directory()`
@@ -315,7 +325,7 @@ satisfy its dependency constraints:
 composer require cboden/ratchet
 ```
 
-The canonical source repository is `BlueFissionTech/develation` on GitHub.
+The canonical source repository is [`BlueFissionTech/develation`](https://github.com/BlueFissionTech/develation) on GitHub.
 
 ```bash
 git clone https://github.com/BlueFissionTech/develation.git

--- a/docs/index.html
+++ b/docs/index.html
@@ -267,6 +267,7 @@
         <span>DevElation</span>
       </a>
       <div class="links">
+        <a href="https://packagist.org/packages/bluefission/develation">Packagist</a>
         <a href="https://github.com/BlueFissionTech/develation">GitHub</a>
         <a href="https://github.com/BlueFissionTech/develation/wiki">Wiki</a>
         <a href="https://github.com/BlueFissionTech/develation/releases/tag/v1.3.39">v1.3.39</a>
@@ -280,7 +281,8 @@
         <h1>DevElation</h1>
         <p>Blue Fission's PHP foundation for primitive value objects, resources, behaviors, storage, services, connections, parsing, CLI, HTML, and lifecycle utilities.</p>
         <div class="actions">
-          <a class="button" href="https://github.com/BlueFissionTech/develation">View Source</a>
+          <a class="button" href="https://packagist.org/packages/bluefission/develation">Install From Packagist</a>
+          <a class="button secondary" href="https://github.com/BlueFissionTech/develation">View Source</a>
           <a class="button secondary" href="https://github.com/BlueFissionTech/develation/wiki">Read The Wiki</a>
         </div>
         <code class="install">composer require bluefission/develation</code>


### PR DESCRIPTION
## Intent summary
Add DevElation branding and make the official Packagist install/source path explicit across the public docs surface.

## User stories / acceptance criteria
- As a package user, I can see the DevElation logo immediately in the README.
- As a Composer user, I can find the Packagist package and install command from README and GitHub Pages.
- As a reviewer, I can confirm this PR is documentation-only.

## Key files changed
- README.md
- docs/index.html

## How to test
- git diff --check
- Review README rendering for the logo and Packagist badges.
- Review docs/index.html for the Packagist nav/action link.

## QA checklist
- [x] README references tracked logo asset
- [x] Packagist package link added
- [x] Pages landing page points to Packagist
- [x] No code/runtime changes

## Approval conditions
- Confirm logo rendering is acceptable in GitHub README.
- Confirm Packagist wording matches the intended official source language.