### PR TITLE
Publish examples gallery and Codespaces setup

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,19 @@
+# DevElation Codespaces
+
+This dev container prepares a PHP 8.2 environment for running DevElation examples.
+
+Useful commands:
+
+```bash
+composer test
+php examples/helpers/workflow.php
+php examples/http/api_packet.php
+php examples/cli/report.php --limit 3 --delay 0 --title "Codespaces Demo"
+php examples/game/gangs.php script
+php -S 0.0.0.0:8080
+```
+
+After starting the PHP server, open the forwarded port and browse to:
+
+- `/examples/todo/index.php`
+- `/examples/comments/index.php`

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "DevElation Examples",
+  "image": "mcr.microsoft.com/devcontainers/php:1-8.2-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/composer:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bmewburn.vscode-intelephense-client",
+        "xdebug.php-debug"
+      ]
+    }
+  },
+  "postCreateCommand": "composer install",
+  "postAttachCommand": "php -v && composer --version",
+  "forwardPorts": [
+    8080
+  ],
+  "portsAttributes": {
+    "8080": {
+      "label": "PHP example server",
+      "onAutoForward": "notify"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Guidance for running PHPUnit tests and enabling optional integration coverage.
 ### Examples
 Sample applications that demonstrate DevElation’s flexibility:
 
+- Browse the hosted examples gallery: [GitHub Pages examples](https://bluefissiontech.github.io/develation/examples/)
+- Run the examples online: [Open in GitHub Codespaces](https://codespaces.new/BlueFissionTech/develation)
 - Session-backed todo list using `Arr`, `Date`, `Session` storage, HTML helpers, and templates: `examples/todo/index.php`
 - Simple comment thread with voting using `Arr`, `Str`, `Session` storage, HTML helpers, and templates: `examples/comments/index.php`
 - CLI territory game using the behavioral engine (`Behaves`) and an `Arr`-backed log: `examples/game/gangs.php`
@@ -184,6 +186,15 @@ Sample applications that demonstrate DevElation’s flexibility:
 - Helper workflow using global factory helpers plus primitive, file, HTTP, date, flag, and security objects: `examples/helpers/workflow.php`
 - HTTP/API packet builder using request normalization, headers, JSON, and status helpers: `examples/http/api_packet.php`
 - Additional walkthroughs live in `examples/README.md`
+
+Codespaces runs `composer install` automatically through `.devcontainer/devcontainer.json`. Once it opens, try:
+
+```bash
+php examples/helpers/workflow.php
+php examples/http/api_packet.php
+php examples/cli/report.php --limit 3 --delay 0 --title "Codespaces Demo"
+php examples/game/gangs.php script
+```
 
 ## Quick Start Examples
 

--- a/docs/examples/cli-report.html
+++ b/docs/examples/cli-report.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CLI Status Report Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header><nav class="shell"><a class="brand" href="index.html"><img src="../assets/develation-circle-logo.png" alt="">CLI Status Report</a><div class="links"><a href="index.html">Examples</a><a href="https://github.com/BlueFissionTech/develation/blob/master/examples/cli/report.php">Source</a><a href="https://codespaces.new/BlueFissionTech/develation">Codespaces</a></div></nav></header>
+  <main class="shell">
+    <h1>CLI Status Report</h1>
+    <p>This example models argument parsing, colorized output, terminal tables, progress bars, and status output through DevElation CLI helpers.</p>
+    <h2>Run It</h2>
+    <pre><code>composer install
+php examples/cli/report.php --limit 3 --delay 0 --title "Pages Demo"</code></pre>
+    <h2>Expected Output</h2>
+    <pre><code>Pages Demo
++--------+--------+
+| Item   | Status |
++--------+--------+
+| Item 1 |  ready |
+| Item 2 |  ready |
+| Item 3 |  ready |
++--------+--------+
+total: 3 | mode: demo | date: 2026-07-12
+[#############---------------------------]  33% (1/3)
+[##########################--------------]  67% (2/3)
+[########################################] 100% (3/3)</code></pre>
+    <p class="note">The real terminal output rewrites the progress line in place; the static transcript expands it into visible steps.</p>
+  </main>
+</body>
+</html>

--- a/docs/examples/comments.html
+++ b/docs/examples/comments.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Comment Thread Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header><nav class="shell"><a class="brand" href="index.html"><img src="../assets/develation-circle-logo.png" alt="">Comment Thread</a><div class="links"><a href="index.html">Examples</a><a href="https://github.com/BlueFissionTech/develation/tree/master/examples/comments">Source</a><a href="https://codespaces.new/BlueFissionTech/develation">Codespaces</a></div></nav></header>
+  <main class="shell">
+    <h1>Comment Thread</h1>
+    <p>The comments example is a compact thread and voting flow. It models session storage, `Arr` updates, `Str::pluralize()`, Vibe template composition, and HTML table rendering.</p>
+    <h2>Run It In Codespaces Or Locally</h2>
+    <pre><code>composer install
+php -S 0.0.0.0:8080</code></pre>
+    <p>Open `/examples/comments/index.php` on the forwarded or local server.</p>
+    <h2>What To Study</h2>
+    <p>Compare this with the todo example. Both use session-backed state and templates, but the comment thread has nested-ish display data, voting commands, and count labels.</p>
+  </main>
+</body>
+</html>

--- a/docs/examples/game-gangs.html
+++ b/docs/examples/game-gangs.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Territory Game Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header><nav class="shell"><a class="brand" href="index.html"><img src="../assets/develation-circle-logo.png" alt="">Territory Game</a><div class="links"><a href="index.html">Examples</a><a href="https://github.com/BlueFissionTech/develation/blob/master/examples/game/gangs.php">Source</a><a href="https://codespaces.new/BlueFissionTech/develation">Codespaces</a></div></nav></header>
+  <main class="shell">
+    <h1>Territory Game</h1>
+    <p>This scripted CLI example shows `Behavioral\Behaves`, behavioral state transitions, and an `Arr`-backed narration log in a small turn-driven game.</p>
+    <h2>Run It</h2>
+    <pre><code>composer install
+php examples/game/gangs.php script</code></pre>
+    <h2>Expected Output</h2>
+    <pre><code>Scripted DevElation Gangs run.
+
+Territory:
+  You   : 1
+  Rival : 1
+&gt; attack
+You make a move on rival territory.
+The move fails and you lose ground.
+Rival is waiting for a move.
+You have lost all territory. Game over.
+
+Recap of NPC actions:
+Actions logged: 1
+- Rival is waiting for a move.</code></pre>
+    <p class="note">Run without `script` for the interactive terminal game.</p>
+  </main>
+</body>
+</html>

--- a/docs/examples/helper-workflow.html
+++ b/docs/examples/helper-workflow.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Helper Workflow Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header><nav class="shell"><a class="brand" href="index.html"><img src="../assets/develation-circle-logo.png" alt="">Helper Workflow</a><div class="links"><a href="index.html">Examples</a><a href="https://github.com/BlueFissionTech/develation/blob/master/examples/helpers/workflow.php">Source</a><a href="https://codespaces.new/BlueFissionTech/develation">Codespaces</a></div></nav></header>
+  <main class="shell">
+    <h1>Helper Workflow</h1>
+    <p>This is the broadest CLI model for the helper surface. It uses `arr()`, `collect()`, `str()`, `num()`, `flag()`, `datetime()`, `filesystem()`, `doc()`, HTTP helpers, and `Hash` without needing a web server.</p>
+    <h2>Run It</h2>
+    <pre><code>composer install
+php examples/helpers/workflow.php</code></pre>
+    <h2>Expected Output</h2>
+    <pre><code>{
+  "title": "=== DevElation helper workflow ===",
+  "processed_on": "2026-07-12T00:00:00+00:00",
+  "source_file_exists": true,
+  "source_file_reachable": true,
+  "fixture_entries": ["names.txt"],
+  "name_count": 3,
+  "names_latest_first": ["Katherine Johnson", "Grace Hopper", "Ada Lovelace"],
+  "status_line": "HTTP/1.1 200 OK",
+  "encoded_path_segment": "Example%20Report.md",
+  "url_host": "example.test",
+  "content_id": "example:...",
+  "angles": [
+    {"degrees": 0, "radians": 0, "sin": 0, "cos": 1},
+    {"degrees": 45, "radians": 0.785398, "sin": 0.707107, "cos": 0.707107}
+  ]
+}</code></pre>
+    <p class="note">The timestamp and content ID are generated at runtime, so exact values will differ.</p>
+  </main>
+</body>
+</html>

--- a/docs/examples/http-api-packet.html
+++ b/docs/examples/http-api-packet.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>HTTP API Packet Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header><nav class="shell"><a class="brand" href="index.html"><img src="../assets/develation-circle-logo.png" alt="">HTTP/API Packet</a><div class="links"><a href="index.html">Examples</a><a href="https://github.com/BlueFissionTech/develation/blob/master/examples/http/api_packet.php">Source</a><a href="https://codespaces.new/BlueFissionTech/develation">Codespaces</a></div></nav></header>
+  <main class="shell">
+    <h1>HTTP/API Packet</h1>
+    <p>This CLI example builds a deterministic request/response packet without calling an external service. It models `Obj` request data, `HTTP` helpers, headers, JSON, dates, flags, strings, and deterministic content IDs.</p>
+    <h2>Run It</h2>
+    <pre><code>composer install
+php examples/http/api_packet.php</code></pre>
+    <h2>Expected Output</h2>
+    <pre><code>{
+  "request": {
+    "method": "GET",
+    "url": "https://api.example.test/v1/Example%20Report.md?limit=3&amp;include=summary&amp;active=true",
+    "scheme": "https",
+    "host": "api.example.test",
+    "path_segment": "Example%20Report.md"
+  },
+  "headers": [
+    "Accept: application/json",
+    "X-Request-Date: 2026-07-12",
+    "X-Request-Id: api_..."
+  ],
+  "expected_response": {
+    "status": "HTTP/1.1 202 Accepted",
+    "body": {"accepted": true, "message": "queued"}
+  },
+  "content_id": "api-example:..."
+}</code></pre>
+  </main>
+</body>
+</html>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DevElation Examples</title>
+  <meta name="description" content="Browse DevElation examples, CLI transcripts, and Codespaces commands.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <nav class="shell" aria-label="Primary">
+      <a class="brand" href="../index.html">
+        <img src="../assets/develation-circle-logo.png" alt="DevElation logo">
+        <span>DevElation Examples</span>
+      </a>
+      <div class="links">
+        <a href="../index.html">Home</a>
+        <a href="https://github.com/BlueFissionTech/develation">Source</a>
+        <a href="https://codespaces.new/BlueFissionTech/develation">Codespaces</a>
+      </div>
+    </nav>
+  </header>
+
+  <main class="shell">
+    <section class="hero">
+      <h1>Examples That Model The Library</h1>
+      <p>These examples are small reference apps and scripts for learning DevElation primitives, storage, services, templates, CLI helpers, HTTP utilities, and behavior patterns. Static pages show commands and expected output; Codespaces runs the examples in a prepared PHP environment.</p>
+      <div class="actions">
+        <a class="button" href="https://codespaces.new/BlueFissionTech/develation">Open In Codespaces</a>
+        <a class="button secondary" href="https://github.com/BlueFissionTech/develation/tree/master/examples">View Source Examples</a>
+      </div>
+    </section>
+
+    <section class="grid" aria-label="Example gallery">
+      <article class="card">
+        <h3>Todo List</h3>
+        <p>Session-backed web flow using `Arr`, `Date`, Vibe templates, and storage lifecycle calls.</p>
+        <div class="meta"><span class="pill">web</span><span class="pill">storage</span><span class="pill">templates</span></div>
+        <a href="todo.html">Open tutorial</a>
+      </article>
+      <article class="card">
+        <h3>Comment Thread</h3>
+        <p>Voting and threaded rendering with session storage, `Arr`, `Str::pluralize()`, and Vibe templates.</p>
+        <div class="meta"><span class="pill">web</span><span class="pill">session</span><span class="pill">html</span></div>
+        <a href="comments.html">Open tutorial</a>
+      </article>
+      <article class="card">
+        <h3>Helper Workflow</h3>
+        <p>Non-interactive CLI script covering factory helpers, primitives, files, HTTP helpers, dates, flags, and hashes.</p>
+        <div class="meta"><span class="pill">cli</span><span class="pill">helpers</span><span class="pill">json</span></div>
+        <a href="helper-workflow.html">Open tutorial</a>
+      </article>
+      <article class="card">
+        <h3>CLI Status Report</h3>
+        <p>Argument parsing, terminal tables, progress output, status bars, and prompt-ready CLI composition.</p>
+        <div class="meta"><span class="pill">cli</span><span class="pill">console</span><span class="pill">args</span></div>
+        <a href="cli-report.html">Open tutorial</a>
+      </article>
+      <article class="card">
+        <h3>HTTP/API Packet</h3>
+        <p>Deterministic API packet construction with `Obj`, `HTTP`, `Arr`, `Flag`, `Date`, `Str`, and `Hash`.</p>
+        <div class="meta"><span class="pill">cli</span><span class="pill">http</span><span class="pill">security</span></div>
+        <a href="http-api-packet.html">Open tutorial</a>
+      </article>
+      <article class="card">
+        <h3>Territory Game</h3>
+        <p>Scripted CLI game showing `Behaves`, behavioral state transitions, and an `Arr`-backed narration log.</p>
+        <div class="meta"><span class="pill">cli</span><span class="pill">behavior</span><span class="pill">scripted</span></div>
+        <a href="game-gangs.html">Open tutorial</a>
+      </article>
+    </section>
+  </main>
+
+  <footer>
+    <div class="shell">Run the examples locally or in Codespaces with `composer install` first.</div>
+  </footer>
+</body>
+</html>

--- a/docs/examples/style.css
+++ b/docs/examples/style.css
@@ -1,0 +1,189 @@
+:root {
+  color-scheme: light;
+  --ink: #102033;
+  --muted: #526477;
+  --line: #d8e3ec;
+  --blue: #176aa2;
+  --paper: #ffffff;
+  --wash: #f4f8fb;
+  --code: #0f2638;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background: var(--paper);
+  line-height: 1.55;
+}
+
+a {
+  color: var(--blue);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.shell {
+  width: min(1120px, calc(100% - 40px));
+  margin: 0 auto;
+}
+
+header {
+  border-bottom: 1px solid var(--line);
+  background: white;
+}
+
+nav {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.brand img {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+}
+
+.links {
+  display: flex;
+  gap: 18px;
+  font-size: 14px;
+}
+
+main {
+  padding: 48px 0 72px;
+}
+
+.hero {
+  max-width: 820px;
+  margin-bottom: 36px;
+}
+
+h1 {
+  margin: 0 0 14px;
+  font-size: 48px;
+  line-height: 1;
+}
+
+h2 {
+  margin: 34px 0 12px;
+  font-size: 26px;
+}
+
+h3 {
+  margin: 0 0 8px;
+}
+
+p {
+  color: var(--muted);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  border: 1px solid var(--line);
+  background: var(--line);
+}
+
+.card {
+  min-height: 210px;
+  padding: 22px;
+  background: white;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 14px 0;
+}
+
+.pill {
+  display: inline-block;
+  padding: 3px 8px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--blue);
+  background: var(--blue);
+  color: white;
+  font-weight: 650;
+}
+
+.button.secondary {
+  color: var(--blue);
+  background: white;
+}
+
+pre {
+  overflow-x: auto;
+  padding: 16px;
+  background: var(--code);
+  color: white;
+  line-height: 1.45;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.note {
+  padding: 16px;
+  border-left: 4px solid var(--blue);
+  background: var(--wash);
+  color: var(--muted);
+}
+
+footer {
+  padding: 28px 0;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 14px;
+}
+
+@media (max-width: 860px) {
+  .links {
+    display: none;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 38px;
+  }
+}

--- a/docs/examples/todo.html
+++ b/docs/examples/todo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Todo List Example</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header><nav class="shell"><a class="brand" href="index.html"><img src="../assets/develation-circle-logo.png" alt="">Todo List</a><div class="links"><a href="index.html">Examples</a><a href="https://github.com/BlueFissionTech/develation/tree/master/examples/todo">Source</a><a href="https://codespaces.new/BlueFissionTech/develation">Codespaces</a></div></nav></header>
+  <main class="shell">
+    <h1>Todo List</h1>
+    <p>The todo example is a small session-backed web flow. It models `Data\Storage\Session`, `Arr` mutation, `Date` parsing/formatting, controller-style request handling, and Vibe template rendering.</p>
+    <h2>Run It In Codespaces Or Locally</h2>
+    <pre><code>composer install
+php -S 0.0.0.0:8080</code></pre>
+    <p>Open `/examples/todo/index.php` on the forwarded or local server.</p>
+    <h2>What To Study</h2>
+    <p>Follow the storage lifecycle: activate, read, normalize input, mutate an `Arr`, assign the updated value, write, then render template data.</p>
+  </main>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -268,6 +268,7 @@
       </a>
       <div class="links">
         <a href="https://packagist.org/packages/bluefission/develation">Packagist</a>
+        <a href="examples/index.html">Examples</a>
         <a href="https://github.com/BlueFissionTech/develation">GitHub</a>
         <a href="https://github.com/BlueFissionTech/develation/wiki">Wiki</a>
         <a href="https://github.com/BlueFissionTech/develation/releases/tag/v1.3.39">v1.3.39</a>
@@ -283,6 +284,7 @@
         <div class="actions">
           <a class="button" href="https://packagist.org/packages/bluefission/develation">Install From Packagist</a>
           <a class="button secondary" href="https://github.com/BlueFissionTech/develation">View Source</a>
+          <a class="button secondary" href="examples/index.html">Browse Examples</a>
           <a class="button secondary" href="https://github.com/BlueFissionTech/develation/wiki">Read The Wiki</a>
         </div>
         <code class="install">composer require bluefission/develation</code>
@@ -310,6 +312,10 @@
           <article class="tile">
             <h3>Data And Services</h3>
             <p>Storage, queues, schema, graph, request/response, mapping, clients, connections, and system utilities with substitutable contracts.</p>
+          </article>
+          <article class="tile">
+            <h3>Hosted Examples</h3>
+            <p>Static GitHub Pages tutorials and Codespaces commands demonstrate CLI scripts, web examples, helper workflows, and HTTP packet construction.</p>
           </article>
         </div>
       </div>

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,11 @@ The examples favor DevElation primitives, data objects, storage objects, HTML he
 
 Run `composer install` first. The examples share `examples/support.php`, which loads Composer, keeps local runtime files under `.localappdata/examples`, and provides tiny helpers for input normalization, safe HTML output, IDs, and logging.
 
+Online entry points:
+
+- Browse the hosted examples gallery: <https://bluefissiontech.github.io/develation/examples/>
+- Run the examples in a prepared environment: <https://codespaces.new/BlueFissionTech/develation>
+
 ### 1. Todo List – `examples/todo/index.php`
 
 - **Purpose**: Minimal todo app showing how to track tasks with owners and due dates.


### PR DESCRIPTION
Closes #216

## Intent summary
Add the primary GitHub Pages examples gallery and the secondary Codespaces execution path for DevElation examples.

## User stories / acceptance criteria
- As a new user, I can browse DevElation examples online without cloning the repo.
- As a CLI user, I can see commands and representative output before running examples locally.
- As a contributor, I can open a prepared Codespaces environment and run the examples after Composer setup.

## Key files changed
- .devcontainer/devcontainer.json
- .devcontainer/README.md
- docs/examples/*
- docs/index.html
- README.md
- xamples/README.md

## How to test
- Get-Content .devcontainer/devcontainer.json | ConvertFrom-Json | Out-Null
- g -n 'D:\\|C:\\Users|artifacts|wiki-tutorial-work|sk_test|abc123' docs README.md examples/README.md .devcontainer
- git diff --check
- endor/bin/phpunit.bat --do-not-cache-result tests/Examples/ExamplesSmokeTest.php

## QA checklist
- [x] GitHub Pages examples gallery added under docs/examples/
- [x] Main Pages landing page links to the examples gallery
- [x] README and examples catalog link to Pages and Codespaces
- [x] Codespaces devcontainer added for PHP 8.2 and Composer
- [x] CLI examples have representative static transcripts
- [x] No runtime library behavior changes

## Approval conditions
- Confirm the gallery structure is the desired public presentation for examples.
- Confirm Codespaces should remain the default online execution path for CLI examples.