### PR TITLE
Fix Date predicate and MySQL empty-table id guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@
 /.codex/
 /AGENTS.md
 /AGENTS.behavior.md
+/AGENTS.standards.md
 /harness.json

--- a/src/Data/Storage/MySQL.php
+++ b/src/Data/Storage/MySQL.php
@@ -116,6 +116,11 @@ class MySQL extends Storage implements IData
     {
         $tables = $this->tables();
         $keys = [];
+
+        if (Arr::isEmpty($tables)) {
+            return null;
+        }
+
         $table = $tables[0];
 
         foreach ($this->fields() as $field => $column) {

--- a/src/Date.php
+++ b/src/Date.php
@@ -7,6 +7,7 @@ use BlueFission\Num;
 use BlueFission\Arr;
 use BlueFission\Behavioral\Behaviors\Event;
 use DateTime;
+use DateTimeInterface;
 
 class Date extends Val implements IVal
 {
@@ -203,7 +204,42 @@ class Date extends Val implements IVal
      */
     public function _is(): bool
     {
-        return ($this->isValidTimestamp($this->timestamp()));
+        return $this->_datetime instanceof DateTimeInterface
+            && self::isValidTimestamp($this->timestamp());
+    }
+
+    /**
+     * Checks if a value is a DateTime, parseable date string, or valid unix timestamp.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public static function is($value = null): bool
+    {
+        self::remember($value);
+
+        if ($value instanceof DateTimeInterface) {
+            return true;
+        }
+
+        if (self::isValidTimestamp($value)) {
+            return true;
+        }
+
+        if (!is_string($value) || trim($value) === '') {
+            return false;
+        }
+
+        if (strtotime($value) !== false) {
+            return true;
+        }
+
+        try {
+            new DateTime($value);
+            return true;
+        } catch (\Throwable $exception) {
+            return false;
+        }
     }
 
     /**
@@ -212,7 +248,7 @@ class Date extends Val implements IVal
      * @param  int  $timestamp the proposed unix timestamp
      * @return bool 		 true if the value is a valid unix timestamp
      */
-    private function isValidTimestamp($timestamp): bool
+    private static function isValidTimestamp($timestamp): bool
     {
         return is_numeric($timestamp)
             && ($timestamp <= PHP_INT_MAX)

--- a/src/Date.php
+++ b/src/Date.php
@@ -7,7 +7,6 @@ use BlueFission\Num;
 use BlueFission\Arr;
 use BlueFission\Behavioral\Behaviors\Event;
 use DateTime;
-use DateTimeInterface;
 
 class Date extends Val implements IVal
 {
@@ -204,42 +203,8 @@ class Date extends Val implements IVal
      */
     public function _is(): bool
     {
-        return $this->_datetime instanceof DateTimeInterface
+        return $this->_datetime instanceof DateTime
             && self::isValidTimestamp($this->timestamp());
-    }
-
-    /**
-     * Checks if a value is a DateTime, parseable date string, or valid unix timestamp.
-     *
-     * @param mixed $value
-     * @return bool
-     */
-    public static function is($value = null): bool
-    {
-        self::remember($value);
-
-        if ($value instanceof DateTimeInterface) {
-            return true;
-        }
-
-        if (self::isValidTimestamp($value)) {
-            return true;
-        }
-
-        if (!is_string($value) || trim($value) === '') {
-            return false;
-        }
-
-        if (strtotime($value) !== false) {
-            return true;
-        }
-
-        try {
-            new DateTime($value);
-            return true;
-        } catch (\Throwable $exception) {
-            return false;
-        }
     }
 
     /**

--- a/src/Val.php
+++ b/src/Val.php
@@ -214,17 +214,6 @@ class Val implements IVal, IDispatcher {
 	}
 
 	/**
-	 * Records the last value inspected by a static predicate.
-	 *
-	 * @param mixed $value
-	 * @return void
-	 */
-	protected static function remember($value): void
-	{
-		self::$_last = $value;
-	}
-
-	/**
 	 * Use the last instance of the class
 	 * @return IVal
 	 */
@@ -935,8 +924,16 @@ class Val implements IVal, IDispatcher {
 			$value = array_shift( $args );
 
 			self::$_last = $value;
-			
-			$object = new $class( $value, false, false );
+
+			try {
+				$object = new $class( $value, false, false );
+			} catch ( \Throwable $exception ) {
+				if ( $method === 'is' ) {
+					return false;
+				}
+
+				throw $exception;
+			}
 			$output = call_user_func_array([$object, self::PRIVATE_PREFIX.$method], $args);
 			unset($object);
 			if ($output instanceof IVal) {

--- a/src/Val.php
+++ b/src/Val.php
@@ -214,6 +214,17 @@ class Val implements IVal, IDispatcher {
 	}
 
 	/**
+	 * Records the last value inspected by a static predicate.
+	 *
+	 * @param mixed $value
+	 * @return void
+	 */
+	protected static function remember($value): void
+	{
+		self::$_last = $value;
+	}
+
+	/**
 	 * Use the last instance of the class
 	 * @return IVal
 	 */

--- a/tests/Data/Storage/MySQLTest.php
+++ b/tests/Data/Storage/MySQLTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BlueFission\Tests\Data\Storage;
+
+use BlueFission\Data\Storage\MySQL;
+use PHPUnit\Framework\TestCase;
+
+class MySQLTest extends TestCase
+{
+    public function testIdReturnsNullWhenTableListIsEmpty(): void
+    {
+        $storage = new MySQL();
+
+        set_error_handler(function ($severity, $message, $file, $line) {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $this->assertNull($storage->id());
+        } finally {
+            restore_error_handler();
+        }
+    }
+}

--- a/tests/DateTest.php
+++ b/tests/DateTest.php
@@ -267,6 +267,18 @@ class DateTest extends ValTest {
 		$this->assertTrue( $trueResult );
 		$this->assertFalse( $falseResult );
 	}
+
+	public function testIsReturnsFalseForArbitraryString()
+	{
+		$this->assertFalse(Date::is('2022_08_03_000000_scaffold_framework_tables.php'));
+	}
+
+	public function testIsReturnsTrueForSupportedDateValues()
+	{
+		$this->assertTrue(Date::is('2012-12-12'));
+		$this->assertTrue(Date::is((string)strtotime('2012-12-12')));
+		$this->assertTrue(Date::is(new \DateTime('2012-12-12')));
+	}
 	
 	public function testRecognizesNullAsEmptyStatically()
 	{

--- a/tests/PrimitiveConventionTest.php
+++ b/tests/PrimitiveConventionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BlueFission\Tests;
+
+use BlueFission\Arr;
+use BlueFission\Date;
+use BlueFission\Flag;
+use BlueFission\Func;
+use BlueFission\Num;
+use BlueFission\Ref;
+use BlueFission\Str;
+use BlueFission\Val;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+class PrimitiveConventionTest extends TestCase
+{
+    public function testStaticMethodsDoNotShadowPseudoPrimitiveMethods(): void
+    {
+        $classes = [
+            Val::class,
+            Arr::class,
+            Date::class,
+            Flag::class,
+            Func::class,
+            Num::class,
+            Ref::class,
+            Str::class,
+        ];
+        $collisions = [];
+
+        foreach ($classes as $class) {
+            $reflection = new ReflectionClass($class);
+            $staticMethods = [];
+            $pseudoMethods = [];
+
+            foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                $name = $method->getName();
+
+                if ($method->isStatic()) {
+                    $staticMethods[strtolower($name)] = $name;
+                } elseif (str_starts_with($name, '_') && !str_starts_with($name, '__')) {
+                    $pseudoMethods[strtolower(substr($name, 1))] = $name;
+                }
+            }
+
+            foreach (array_intersect_key($staticMethods, $pseudoMethods) as $name => $staticMethod) {
+                $collisions[] = sprintf(
+                    '%s::%s() shadows %s()',
+                    $class,
+                    $staticMethod,
+                    $pseudoMethods[$name]
+                );
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $collisions,
+            "Pseudo-primitive operations must use underscored instance methods and Val::__callStatic().\n"
+                . implode("\n", $collisions)
+        );
+    }
+}


### PR DESCRIPTION
## Intent summary

Fix the fresh Opus/MorPro consumer blockers captured in #222 and #223, and include the requested `.gitignore` hygiene for local standards files.

## User stories / acceptance criteria

- As a storage consumer, arbitrary migration-like filenames passed through `Date::is()` return `false` instead of throwing.
- As a DevElation primitive user, supported Date values still validate and preserve `Date::grab()` / `Date::use()` static predicate behavior.
- As a MySQL storage consumer, calling `MySQL::id()` before table metadata exists returns `null` without reading an empty table list.
- As a maintainer, `AGENTS.standards.md` remains local-only and ignored.

## Key files changed

- `.gitignore`
- `src/Date.php`
- `src/Val.php`
- `src/Data/Storage/MySQL.php`
- `tests/DateTest.php`
- `tests/Data/Storage/MySQLTest.php`

## How to test

- `php -l src\Date.php`
- `php -l src\Val.php`
- `php -l src\Data\Storage\MySQL.php`
- `php -l tests\DateTest.php`
- `php -l tests\Data\Storage\MySQLTest.php`
- `vendor\bin\phpunit.bat --do-not-cache-result tests\DateTest.php`
- `vendor\bin\phpunit.bat --do-not-cache-result tests\Data\Storage\MySQLTest.php`
- `vendor\bin\phpunit.bat --do-not-cache-result tests\Data tests\DateTest.php`
- Split full-suite PHPUnit by test area due local harness timeout on the all-in-one run.
- `composer validate --strict`
- `composer audit`
- `git diff --check`

## QA checklist

- [x] Date predicate regression covered for migration filename strings.
- [x] Date predicate still accepts parseable strings, timestamps, and DateTime values.
- [x] Static primitive `grab()` / `use()` behavior remains covered by existing Date tests.
- [x] MySQL empty table-list guard covered without requiring a live database.
- [x] Composer validation and audit completed.

## Approval conditions

Approve once CI is green and the fixes are acceptable for Opus to re-run its database delta path.

Fixes #222.
Fixes #223.
