### PR TITLE
Resolve constructorless application services

### DIFF
--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -1204,9 +1204,12 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 	 */
 	public function getDynamicInstance(string $class )
 	{
-		$constructor = new \ReflectionMethod($class, '__construct');
+		$reflection = new \ReflectionClass($class);
+		$constructor = $reflection->getConstructor();
 
-		$dependencies = [];
+		if ( Val::isNull($constructor) ) {
+			return $reflection->newInstance();
+		}
 
 		$arguments = $this->boundArguments($class);
 
@@ -1214,9 +1217,7 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 
 		$values = Arr::make($dependencies)->values()->val();
 
-		$instance = new $class(...$values);
-	
-		return $instance;
+		return $reflection->newInstanceArgs($values);
 	}
 
 	/**
@@ -1359,11 +1360,9 @@ class Application extends Obj implements IConfigurable, IDispatcher, IBehavioral
 			if ( $varTypes->has($dependencyClass) ) {
 				$dependencies[$dependencyName] = $arguments[$dependencyName] ?? ( $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null );
 			} elseif ( $dependencyClass ) {
-				$values = Arr::make($this->handleDependencies(new \ReflectionMethod($dependencyClass.'::__construct')))->values()->val();
-
-				$dependencies[$dependencyName] = 
-					$arguments[$dependencyName] ?? 
-					new $dependencyClass(...$values);
+				$dependencies[$dependencyName] =
+					$arguments[$dependencyName] ??
+					$this->getDynamicInstance($dependencyClass);
 			}
 		}
 

--- a/tests/Services/ApplicationTest.php
+++ b/tests/Services/ApplicationTest.php
@@ -51,6 +51,33 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($first, $second);
     }
 
+    public function testResolvesClassWithoutExplicitConstructor()
+    {
+        $instance = $this->object->resolve(ConstructorlessApplicationService::class);
+
+        $this->assertInstanceOf(ConstructorlessApplicationService::class, $instance);
+    }
+
+    public function testResolvesConstructorlessNestedDependency()
+    {
+        $instance = $this->object->resolve(ApplicationServiceWithDependency::class);
+
+        $this->assertInstanceOf(ApplicationServiceWithDependency::class, $instance);
+        $this->assertInstanceOf(ConstructorlessApplicationDependency::class, $instance->dependency);
+    }
+
+    public function testResolvesClassWithBoundScalarConstructorArgument()
+    {
+        $this->object->bindArgs(
+            ['name' => 'configured'],
+            ApplicationServiceWithBoundArgument::class
+        );
+
+        $instance = $this->object->resolve(ApplicationServiceWithBoundArgument::class);
+
+        $this->assertSame('configured', $instance->name);
+    }
+
     public function testApplicationInstanceReturnsFirstRegisteredInstance()
     {
         $first = Application::instance();
@@ -365,5 +392,27 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         }
 
         rmdir($directory);
+    }
+}
+
+class ConstructorlessApplicationService
+{
+}
+
+class ConstructorlessApplicationDependency
+{
+}
+
+class ApplicationServiceWithDependency
+{
+    public function __construct(public ConstructorlessApplicationDependency $dependency)
+    {
+    }
+}
+
+class ApplicationServiceWithBoundArgument
+{
+    public function __construct(public string $name)
+    {
     }
 }


### PR DESCRIPTION
## Intent summary

Resolve services and controllers without explicit constructors while preserving Application dependency injection and named constructor bindings.

## User stories / acceptance criteria

- Constructorless services and controllers resolve without `ReflectionException`.
- Constructorless nested dependencies resolve recursively.
- Classes with constructor dependencies retain dependency injection behavior.
- Named scalar constructor arguments retain the existing binding contract.
- Resolution remains PHP 8.2 compatible and uses DevElation primitive conventions.

## Key files changed

- `src/Services/Application.php`
- `tests/Services/ApplicationTest.php`

## How to test

- `php -l src/Services/Application.php`
- `php -l tests/Services/ApplicationTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Services/ApplicationTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Services`
- `composer validate --strict`
- `git diff --check`

## QA checklist

- [x] Direct constructorless resolution is covered.
- [x] Nested constructorless dependency resolution is covered.
- [x] Existing named scalar constructor bindings are covered.
- [x] Full Services suite passes.
- [x] Composer metadata validates strictly.

## Approval conditions

Approve once CI is green and downstream service/controller resolution behavior is acceptable.

Fixes #226.
