### PR TITLE
Harden Authenticator lockout timing

### DIFF
--- a/src/Services/Authenticator.php
+++ b/src/Services/Authenticator.php
@@ -11,6 +11,8 @@
 namespace BlueFission\Services;
 
 use BlueFission\Arr;
+use BlueFission\Date;
+use BlueFission\Num;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Behavioral\Configurable;
@@ -34,7 +36,7 @@ class Authenticator extends Service
         'id_field' => 'user_id',
         'username_field' => 'username',
         'password_field' => 'password',
-        'lockout_interval' => 10,
+        'lockout_interval' => 600, // Seconds before the attempt counter resets.
         'duration' => 3600,
         'max_attempts' => 10,
     ];
@@ -208,12 +210,11 @@ class Authenticator extends Service
         $last = Arr::make(Arr::toArray($attempts->data()));
 
 
-        if ($last->hasKey('last_attempt') && strtotime($last['last_attempt']) > strtotime($this->config('lockout_interval'))) {
-            $attemptCount = (int)($last['attempts'] ?? 0) + 1;
-        } else {
-            $attemptCount = 0;
-        }
-        $attempts->field('last_attempt', date('Y-m-d G:i:s', strtotime('now')));
+        $attemptCount = $this->isWithinLockoutWindow($last)
+            ? (int)Num::make($last['attempts'] ?? 0)->add(1)->val()
+            : 0;
+
+        $attempts->field('last_attempt', Date::now()->formatTimestamp('Y-m-d H:i:s'));
         $attempts->field('attempts', $attemptCount);
         $attempts->write();
 
@@ -239,7 +240,7 @@ class Authenticator extends Service
         $last = Arr::make(Arr::toArray($attempts->data()));
 
 
-        if ($last->hasKey('last_attempt') && strtotime($last['last_attempt']) > strtotime($this->config('lockout_interval'))) {
+        if ($this->isWithinLockoutWindow($last)) {
             if ($last->hasKey('attempts') && $last['attempts'] >= $this->config('max_attempts')) {
                 return true;
             }
@@ -260,9 +261,35 @@ class Authenticator extends Service
         $attempts->read();
         $last = Arr::make(Arr::toArray($attempts->data()));
 
-        if ($last->hasKey('last_attempt') && strtotime($last['last_attempt']) > strtotime($this->config('lockout_interval'))) {
+        if ($this->isWithinLockoutWindow($last)) {
             $attempts->delete();
         }
+    }
+
+    private function isWithinLockoutWindow(Arr $attempt): bool
+    {
+        if (!$attempt->hasKey('last_attempt')) {
+            return false;
+        }
+
+        $lastAttempt = $attempt['last_attempt'];
+        if (Val::isNull($lastAttempt) || !Date::is($lastAttempt)) {
+            return false;
+        }
+
+        $interval = $this->config('lockout_interval');
+        if (!Num::is($interval)) {
+            return false;
+        }
+
+        $intervalSeconds = (int)Num::make($interval)->abs()->val();
+        $windowStart = (int)Num::make(Date::now()->timestamp())
+            ->sub($intervalSeconds)
+            ->val();
+        $lastAttemptTimestamp = Date::timestamp($lastAttempt);
+
+        return Val::isNotNull($lastAttemptTimestamp)
+            && $lastAttemptTimestamp >= $windowStart;
     }
 
     private function loginAttemptsStorage(): Storage

--- a/tests/Services/AuthenticatorTest.php
+++ b/tests/Services/AuthenticatorTest.php
@@ -96,4 +96,129 @@ class AuthenticatorTest extends TestCase
 
         $this->assertTrue($method->invoke($authenticator, '127.0.0.1'));
     }
+
+    public function testFreshLoginAttemptDoesNotEmitTimestampWarnings()
+    {
+        $fields = [];
+        $authenticator = $this->authenticatorWithAttemptData([
+            'last_attempt' => null,
+            'attempts' => 0,
+        ], $fields);
+        $hadRemoteAddress = array_key_exists('REMOTE_ADDR', $_SERVER);
+        $remoteAddress = $_SERVER['REMOTE_ADDR'] ?? null;
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+        set_error_handler(function ($severity, $message, $file, $line) {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $this->assertTrue($this->invokeAuthenticatorMethod(
+                $authenticator,
+                'confirmIPAddress',
+                ['127.0.0.1']
+            ));
+            $this->assertFalse($this->invokeAuthenticatorMethod(
+                $authenticator,
+                'blockIPAddress'
+            ));
+            $this->assertNull($this->invokeAuthenticatorMethod(
+                $authenticator,
+                'clearIPAddress'
+            ));
+        } finally {
+            restore_error_handler();
+
+            if ($hadRemoteAddress) {
+                $_SERVER['REMOTE_ADDR'] = $remoteAddress;
+            } else {
+                unset($_SERVER['REMOTE_ADDR']);
+            }
+        }
+
+        $this->assertSame(600, $authenticator->config('lockout_interval'));
+        $this->assertSame(0, $fields['attempts']);
+        $this->assertNotEmpty($fields['last_attempt']);
+    }
+
+    public function testLoginAttemptWithinWindowIncrementsCount()
+    {
+        $fields = [];
+        $authenticator = $this->authenticatorWithAttemptData([
+            'last_attempt' => date('Y-m-d H:i:s', time() - 60),
+            'attempts' => 4,
+        ], $fields);
+
+        $this->assertTrue($this->invokeAuthenticatorMethod(
+            $authenticator,
+            'confirmIPAddress',
+            ['127.0.0.1']
+        ));
+        $this->assertSame(5, $fields['attempts']);
+    }
+
+    public function testExpiredLoginAttemptResetsCount()
+    {
+        $fields = [];
+        $authenticator = $this->authenticatorWithAttemptData([
+            'last_attempt' => date('Y-m-d H:i:s', time() - 601),
+            'attempts' => 9,
+        ], $fields);
+
+        $this->assertTrue($this->invokeAuthenticatorMethod(
+            $authenticator,
+            'confirmIPAddress',
+            ['127.0.0.1']
+        ));
+        $this->assertSame(0, $fields['attempts']);
+    }
+
+    public function testMaximumLoginAttemptsAreRejected()
+    {
+        $fields = [];
+        $authenticator = $this->authenticatorWithAttemptData([
+            'last_attempt' => date('Y-m-d H:i:s', time() - 60),
+            'attempts' => 9,
+        ], $fields);
+
+        $this->assertFalse($this->invokeAuthenticatorMethod(
+            $authenticator,
+            'confirmIPAddress',
+            ['127.0.0.1']
+        ));
+        $this->assertSame(10, $fields['attempts']);
+    }
+
+    private function authenticatorWithAttemptData(array $data, array &$fields): Authenticator
+    {
+        $session = new Cookie();
+        $datasource = $this->createMock(Storage::class);
+        $attempts = $this->createMock(Storage::class);
+
+        $attempts->method('config')->willReturnSelf();
+        $attempts->method('activate')->willReturnSelf();
+        $attempts->method('read')->willReturnSelf();
+        $attempts->method('data')->willReturn($data);
+        $attempts->method('write')->willReturnSelf();
+        $attempts->method('field')->willReturnCallback(
+            function ($field, $value = null) use (&$fields, $attempts) {
+                $fields[$field] = $value;
+
+                return $attempts;
+            }
+        );
+
+        return new Authenticator($session, $datasource, null, $attempts);
+    }
+
+    private function invokeAuthenticatorMethod(
+        Authenticator $authenticator,
+        string $method,
+        array $arguments = []
+    ): mixed {
+        $reflection = new \ReflectionMethod($authenticator, $method);
+        $reflection->setAccessible(true);
+
+        return $reflection->invokeArgs($authenticator, $arguments);
+    }
 }


### PR DESCRIPTION
## Intent summary

Make Authenticator login-attempt lockout timing explicit, warning-free on PHP 8.2, and consistent across confirmation, blocking, and clearing paths.

## User stories / acceptance criteria

- Fresh records with a missing or null `last_attempt` do not emit warnings or corrupt responses.
- `lockout_interval` is an explicit seconds-based duration with a ten-minute default.
- Attempts inside the active window increment the existing counter.
- Expired attempt windows reset the counter.
- Reaching `max_attempts` rejects authentication consistently.
- `confirmIPAddress()`, `blockIPAddress()`, and `clearIPAddress()` share one duration predicate.

## Key files changed

- `src/Services/Authenticator.php`
- `tests/Services/AuthenticatorTest.php`

## How to test

- `php -l src/Services/Authenticator.php`
- `php -l tests/Services/AuthenticatorTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Services/AuthenticatorTest.php`
- `vendor/bin/phpunit --do-not-cache-result tests/Services`
- `vendor/bin/phpunit --do-not-cache-result tests/DateTest.php tests/NumTest.php tests/ValTest.php`
- `composer validate --strict`
- `git diff --check`

## QA checklist

- [x] Null timestamps are warning-free across all three lockout operations.
- [x] Within-window, expired-window, and maximum-attempt cases are covered.
- [x] Production lockout timing uses `Date`, `Num`, and `Val` primitives.
- [x] Native `strtotime()` and `date()` calls were removed from Authenticator.
- [x] Services and supporting primitive suites pass.

## Approval conditions

Approve once CI is green and the explicit 600-second default is acceptable for downstream authentication consumers.

Fixes #225.
